### PR TITLE
Correctly insert the parameters of unsaved values into a save request

### DIFF
--- a/lib/EasyPost/Resource.php
+++ b/lib/EasyPost/Resource.php
@@ -102,7 +102,7 @@ abstract class Resource extends Object
         if (count($this->_unsavedValues)) {
             $requestor = new Requestor($this->_apiKey);
             $params = array();
-            foreach ($this->_unsavedValues as $k) {
+            foreach (array_keys($this->_unsavedValues) as $k) {
                 $params[$k] = $this->$k;
             }
             $url = $this->instanceUrl();


### PR DESCRIPTION
Formerly, values were being attempting to be assigned using the value of each array item, instead of the key of that item.
