### PR TITLE
increase php version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "ext-curl": "*",
         "ext-json": "*",
-        "php": ">=5.3.0"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
v5.3 and v5.4 are EOL. v5.5 is the current minimum supported version.

i understand you may have some concerns bumping it all the way to 5.5,
but if you’re not comfortable with that please at least go to 5.4

5.3 has been EOL for over a year and has many known security issues.

bumping this is a good idea not only for security, but also gives the
package the ability to start taking advantage of newer features