### PR TITLE
Add optional CURL timeouts setting

### DIFF
--- a/lib/EasyPost/EasyPost.php
+++ b/lib/EasyPost/EasyPost.php
@@ -20,6 +20,24 @@ abstract class EasyPost
     public static $apiVersion = "2";
 
     /**
+     * Time in milliseconds to wait for a connection
+     *
+     * Zero or null means no timeout.
+     *
+     * @var int|null
+     */
+    public static $connectTimeout;
+
+    /**
+     * Time in milliseconds to wait for a response
+     *
+     * Zero or null means no timeout.
+     *
+     * @var int|null
+     */
+    public static $responseTimeout;
+
+    /**
      * @var string
      */
     const VERSION = '3.4.0';
@@ -82,5 +100,53 @@ abstract class EasyPost
     public static function setApiVersion($apiVersion)
     {
         self::$apiVersion = $apiVersion;
+    }
+
+    /**
+     * Set time in milliseconds to wait for a connection
+     *
+     * Zero or null means no timeout.
+     *
+     * @return int|null
+     */
+    public static function getConnectTimeout()
+    {
+        return self::$connectTimeout;
+    }
+
+    /**
+     * Get time in milliseconds to wait for a connection
+     *
+     * Zero or null means no timeout.
+     *
+     * @param int|null $connectTimeout
+     */
+    public static function setConnectTimeout($connectTimeout)
+    {
+        self::$connectTimeout = $connectTimeout;
+    }
+
+    /**
+     * Get time in milliseconds to wait for a response
+     *
+     * Zero or null means no timeout.
+     *
+     * @return int|null
+     */
+    public static function getResponseTimeout()
+    {
+        return self::$responseTimeout;
+    }
+
+    /**
+     * Get time in milliseconds to wait for a response
+     *
+     * Zero or null means no timeout.
+     *
+     * @param int|null $responseTimeout
+     */
+    public static function setResponseTimeout($responseTimeout)
+    {
+        self::$responseTimeout = $responseTimeout;
     }
 }

--- a/lib/EasyPost/Requestor.php
+++ b/lib/EasyPost/Requestor.php
@@ -212,6 +212,14 @@ class Requestor
         $curlOptions[CURLOPT_RETURNTRANSFER] = true;
         $curlOptions[CURLOPT_HTTPHEADER] = $headers;
 
+        if ($timeout = EasyPost::getConnectTimeout()) {
+            $curlOptions[CURLOPT_CONNECTTIMEOUT_MS] = $timeout;
+        }
+
+        if ($timeout = EasyPost::getResponseTimeout()) {
+            $curlOptions[CURLOPT_TIMEOUT_MS] = $timeout;
+        }
+
         curl_setopt_array($curl, $curlOptions);
         $httpBody = curl_exec($curl);
 


### PR DESCRIPTION
This PR addresses Issue https://github.com/EasyPost/easypost-php/issues/54

This is a backwards-compatible change that adds the `EasyPost::setConnectTimeout()` and  `EasyPost::setResponseTimeout()` methods to allowing setting the number of milliseconds to wait for a connection and response, respectively,

These are needed because the default curl behavior is to wait indefinitely, which can cause services to stall under load.

**Usage**
If `connectTimeout` is set to `1000` it will wait up to one (1) second to connect to EasyPost. If this is set to zero (0) or null, then the default PHP curl behavior is maintained. Thus there is no BC break, because the defaults for these settings are both null.

Likewise, if `responseTimeout` is set to `5000` it will wait up to five (5) seconds, after the connection is established, to get a complete response from EasyPost. If this is set to zero (0) or null, then the default PHP curl behavior is maintained.

The two timeouts are kept separate because we should be able to expect a connection within a fairly short timeframe, but may need to wait longer for a response.