### PR TITLE
Bugfix for the "undefined variable" exception

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+=== 3.4.2 2019-04-01
+
+* Fixed the bug described in #61
+
 === 3.4.1 2018-04-13
 
 * Added ability to set connection and response timeouts for all EasyPost actions (thanks mattjanssen!)

--- a/lib/EasyPost/EasyPostObject.php
+++ b/lib/EasyPost/EasyPostObject.php
@@ -120,7 +120,8 @@ class EasyPostObject implements \ArrayAccess, \Iterator
 
             $i = 0;
             $current = $this;
-            $param = array($k => $v);
+            $param = array($k => null);
+
             while(true && $i < 99) {
                 if(!is_null($current->_parent)) {
                     $param = array($current->_name => $param);


### PR DESCRIPTION
This PR removes the undefined variable `$v` which seems to cause the problem described in #61.