### PR TITLE
Fixed create report feature and added unit test

### DIFF
--- a/lib/EasyPost/Report.php
+++ b/lib/EasyPost/Report.php
@@ -53,16 +53,10 @@ class Report extends EasypostResource
      */
     public static function create($params = null, $apiKey = null)
     {
-        if (!isset($params['report']) || !is_array($params['report'])) {
-            $clone = $params;
-            unset($params);
-            $params['report'] = $clone;
-        }
-
-        if (!isset($params['report']['type'])) {
+        if (!isset($params['type'])) {
             throw new Error('Undetermined Report Type');
         } else {
-            $type = $params['report']['type'];
+            $type = $params['type'];
 
             self::_validate('create', $params, $apiKey);
             $requestor = new Requestor($apiKey);

--- a/lib/EasyPost/Util.php
+++ b/lib/EasyPost/Util.php
@@ -109,6 +109,7 @@ abstract class Util
             'shprep'    => '\EasyPost\Report',
             'plrep'     => '\EasyPost\Report',
             'trkrep'    => '\EasyPost\Report',
+            'refrep'    => '\EasyPost\Report',
             'hook'      => '\EasyPost\Webhook'
         );
 

--- a/test/EasyPost/Test/ReportTest.php
+++ b/test/EasyPost/Test/ReportTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace EasyPost\Test;
+
+use EasyPost\Report;
+use EasyPost\EasyPost;
+
+EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+
+class TestReport extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Report the creation of a Payment Log report
+     *
+     * @return void
+     */
+    public function testCreatePaymentLogReport()
+    {
+        // Set a random date to use
+        $year = sprintf('%04d', rand(0001,2020));
+        $month = sprintf('%02d', rand(01,12));
+
+        // Build params and run assertions
+        $params = array(
+            "start_date" => "$year-$month-01",
+            "end_date" => "$year-$month-31",
+            "type" => "payment_log"
+        );
+        $payment_log_report = Report::create($params);
+        $this->assertInstanceOf('\EasyPost\Report', $payment_log_report);
+        $this->assertIsString($payment_log_report->id);
+        $this->assertStringMatchesFormat("plrep_%s", $payment_log_report->id);
+
+        return $payment_log_report;
+    }
+
+    /**
+     * Report the creation of a Refund report
+     *
+     * @return void
+     */
+    public function testCreateRefundReport()
+    {
+        // Set a random date to use
+        $year = sprintf('%04d', rand(0001,2020));
+        $month = sprintf('%02d', rand(01,12));
+
+        // Build params and run assertions
+        $params = array(
+            "start_date" => "$year-$month-01",
+            "end_date" => "$year-$month-31",
+            "type" => "refund"
+        );
+        $refund_report = Report::create($params);
+        $this->assertInstanceOf('\EasyPost\Report', $refund_report);
+        $this->assertIsString($refund_report->id);
+        $this->assertStringMatchesFormat("refrep_%s", $refund_report->id);
+
+        return $refund_report;
+    }
+
+    /**
+     * Report the creation of a Shipment report
+     *
+     * @return void
+     */
+    public function testCreateShipmentReport()
+    {
+        // Set a random date to use
+        $year = sprintf('%04d', rand(0001,2020));
+        $month = sprintf('%02d', rand(01,12));
+
+        // Build params and run assertions
+        $params = array(
+            "start_date" => "$year-$month-01",
+            "end_date" => "$year-$month-31",
+            "type" => "shipment"
+        );
+        $shipment_report = Report::create($params);
+        $this->assertInstanceOf('\EasyPost\Report', $shipment_report);
+        $this->assertIsString($shipment_report->id);
+        $this->assertStringMatchesFormat("shprep_%s", $shipment_report->id);
+
+        return $shipment_report;
+    }
+
+    /**
+     * Report the creation of a Tracker report
+     *
+     * @return void
+     */
+    public function testCreateTrackerReport()
+    {
+        // Set a random date to use
+        $year = sprintf('%04d', rand(0001,2020));
+        $month = sprintf('%02d', rand(01,12));
+
+        // Build params and run assertions
+        $params = array(
+            "start_date" => "$year-$month-01",
+            "end_date" => "$year-$month-31",
+            "type" => "tracker"
+        );
+        $tracker_report = Report::create($params);
+        $this->assertInstanceOf('\EasyPost\Report', $tracker_report);
+        $this->assertIsString($tracker_report->id);
+        $this->assertStringMatchesFormat("trkrep_%s", $tracker_report->id);
+
+        return $tracker_report;
+    }
+
+    /**
+     * Report the retrieval of a Payment Log report
+     *
+     * @param Report $report
+     * @return void
+     * @depends testCreatePaymentLogReport
+     */
+    public function testRetrievePaymentLogReport($payment_log_report)
+    {
+        $retrieved_payment_log_report = Report::retrieve($payment_log_report->id);
+
+        $this->assertInstanceOf('\EasyPost\Report', $retrieved_payment_log_report);
+        $this->assertEquals($retrieved_payment_log_report->id, $payment_log_report->id);
+        $this->assertEquals($retrieved_payment_log_report->start_date, $payment_log_report->start_date);
+        $this->assertEquals($retrieved_payment_log_report->end_date, $payment_log_report->end_date);
+
+        return $retrieved_payment_log_report;
+    }
+
+    /**
+     * Report the retrieval of a Refund report
+     *
+     * @param Report $report
+     * @return void
+     * @depends testCreateRefundReport
+     */
+    public function testRetrieveRefundReport($refund_report)
+    {
+        $retrieved_refund_report = Report::retrieve($refund_report->id);
+
+        $this->assertInstanceOf('\EasyPost\Report', $retrieved_refund_report);
+        $this->assertEquals($retrieved_refund_report->id, $refund_report->id);
+        $this->assertEquals($retrieved_refund_report->start_date, $refund_report->start_date);
+        $this->assertEquals($retrieved_refund_report->end_date, $refund_report->end_date);
+
+        return $retrieved_refund_report;
+    }
+
+    /**
+     * Report the retrieval of a Shipment report
+     *
+     * @param Report $report
+     * @return void
+     * @depends testCreateShipmentReport
+     */
+    public function testRetrieveShipmentReport($shipment_report)
+    {
+        $retrieved_shipment_report = Report::retrieve($shipment_report->id);
+
+        $this->assertInstanceOf('\EasyPost\Report', $retrieved_shipment_report);
+        $this->assertEquals($retrieved_shipment_report->id, $shipment_report->id);
+        $this->assertEquals($retrieved_shipment_report->start_date, $shipment_report->start_date);
+        $this->assertEquals($retrieved_shipment_report->end_date, $shipment_report->end_date);
+
+        return $retrieved_shipment_report;
+    }
+
+    /**
+     * Report the retrieval of a Tracker report
+     *
+     * @param Report $report
+     * @return void
+     * @depends testCreateTrackerReport
+     */
+    public function testRetrieveTrackerReport($tracker_report)
+    {
+        $retrieved_tracker_report = Report::retrieve($tracker_report->id);
+
+        $this->assertInstanceOf('\EasyPost\Report', $retrieved_tracker_report);
+        $this->assertEquals($retrieved_tracker_report->id, $tracker_report->id);
+        $this->assertEquals($retrieved_tracker_report->start_date, $tracker_report->start_date);
+        $this->assertEquals($retrieved_tracker_report->end_date, $tracker_report->end_date);
+
+        return $retrieved_tracker_report;
+    }
+}


### PR DESCRIPTION
Similar to our Python client library, the reports response is being double wrapped when it shouldn't. I've corrected that issue here and written a unit test.

For whatever reason, I cannot get the unit test of `assertInstanceOf` to pass for the `Refund` report... the problem is alluding me as the code is the exact same across all four reports. I'll need some help fixing that unit test before this will pass.