### PR TITLE
Bumped version to 3.4.5 with README clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Up-to-date documentation can be found at: https://www.easypost.com/docs.
 
 1. Update the `VERSION` file
 1. Update the `CHANGELOG` file
+1. Update the `VERSION` constant in the `EasyPost.php` file
 1. Update the version in the `composer.json` file
 1. Create a git tag with the new version
 


### PR DESCRIPTION
After looking into how we release PHP more, I noticed one other place where the version must be altered when releasing which is in the `EasyPost.php` file. This VERSION constant is used inside the headers so we know what CL version each request uses. 

The last few versions haven't had this constant bumped, mainly because it wasn't documented. I added a single clarifying step to the README so we'll remember moving forward.