### PR TITLE
Fixes the bug not allowing for carrier deletion

### DIFF
--- a/lib/EasyPost/EasyPostObject.php
+++ b/lib/EasyPost/EasyPostObject.php
@@ -84,6 +84,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
         $i = 0;
         $current = $this;
         $param = array($k => $v);
+
         while (true && $i < 99) {
             if (!is_null($current->_parent)) {
                 $param = array($current->_name => $param);
@@ -121,7 +122,8 @@ class EasyPostObject implements \ArrayAccess, \Iterator
 
             $i = 0;
             $current = $this;
-            $param = array($k => $v);
+            $param = array($k => null);
+
             while (true && $i < 99) {
                 if (!is_null($current->_parent)) {
                     $param = array($current->_name => $param);


### PR DESCRIPTION
Carriers cannot be deleted currently. This fixes the error found in #61 

Closes #61 
Closes #64 (difference here is no changes made to CHANGELOG as we'll do a release PR after)