### PR TITLE
add regenerate_rates method

### DIFF
--- a/lib/EasyPost/Shipment.php
+++ b/lib/EasyPost/Shipment.php
@@ -64,6 +64,23 @@ class Shipment extends EasypostResource
     }
 
     /**
+     * re-rate for a shipment
+     *
+     * @param mixed $params
+     * @return $this
+     * @throws \EasyPost\Error
+     */
+    public function regenerate_rates($params = null)
+    {
+        $requestor = new Requestor($this->_apiKey);
+        $url = $this->instanceUrl() . '/rerate';
+        list($response, $apiKey) = $requestor->request('post', $url, $params);
+        $this->refreshFrom($response, $apiKey, true);
+
+        return $this;
+    }
+
+    /**
      * buy a shipment
      *
      * @param mixed $params


### PR DESCRIPTION
Starting soon in the future,get_rates() will always be read-only (as you would expect from a GET), and re-rating will be triggered through the new regenerate_rates() function. This adds the new function. No change has occurred to get_rates() yet.