### PR TITLE
feat: adds smartrate functionality

### DIFF
--- a/lib/EasyPost/Shipment.php
+++ b/lib/EasyPost/Shipment.php
@@ -81,6 +81,21 @@ class Shipment extends EasypostResource
     }
 
     /**
+     * get smartrates for a shipment
+     *
+     * @return $this
+     * @throws \EasyPost\Error
+     */
+    public function get_smartrates()
+    {
+        $requestor = new Requestor($this->_apiKey);
+        $url = $this->instanceUrl() . '/smartrate';
+        list($response, $apiKey) = $requestor->request('get', $url);
+
+        return $response;
+    }
+
+    /**
      * buy a shipment
      *
      * @param mixed $params

--- a/lib/EasyPost/Shipment.php
+++ b/lib/EasyPost/Shipment.php
@@ -92,7 +92,7 @@ class Shipment extends EasypostResource
         $url = $this->instanceUrl() . '/smartrate';
         list($response, $apiKey) = $requestor->request('get', $url);
 
-        return $response;
+        return $response['result'];
     }
 
     /**

--- a/lib/EasyPost/Shipment.php
+++ b/lib/EasyPost/Shipment.php
@@ -83,7 +83,7 @@ class Shipment extends EasypostResource
     /**
      * get smartrates for a shipment
      *
-     * @return $response
+     * @return array
      * @throws \EasyPost\Error
      */
     public function get_smartrates()

--- a/lib/EasyPost/Shipment.php
+++ b/lib/EasyPost/Shipment.php
@@ -92,7 +92,7 @@ class Shipment extends EasypostResource
         $url = $this->instanceUrl() . '/smartrate';
         list($response, $apiKey) = $requestor->request('get', $url);
 
-        return $response['result'];
+        return isset($response['result']) ? $response['result'] : [];
     }
 
     /**

--- a/lib/EasyPost/Shipment.php
+++ b/lib/EasyPost/Shipment.php
@@ -83,7 +83,7 @@ class Shipment extends EasypostResource
     /**
      * get smartrates for a shipment
      *
-     * @return $this
+     * @return $response
      * @throws \EasyPost\Error
      */
     public function get_smartrates()

--- a/test/EasyPost/Test/ShipmentTest.php
+++ b/test/EasyPost/Test/ShipmentTest.php
@@ -98,14 +98,14 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
         $this->assertNotNull($shipment->rates);
 
         $smartrates = $shipment->get_smartrates();
-        $this->assertEquals($shipment->rates[0]['id'], $smartrates['result'][0]['id']);
+        $this->assertEquals($shipment->rates[0]['id'], $smartrates[0]['id']);
         # TODO: Once we've added `php-vcr`, assert that the following values actually match an integer
-        $this->assertNotNull($smartrates['result'][0]['time_in_transit']['percentile_50']);
-        $this->assertNotNull($smartrates['result'][0]['time_in_transit']['percentile_75']);
-        $this->assertNotNull($smartrates['result'][0]['time_in_transit']['percentile_85']);
-        $this->assertNotNull($smartrates['result'][0]['time_in_transit']['percentile_90']);
-        $this->assertNotNull($smartrates['result'][0]['time_in_transit']['percentile_95']);
-        $this->assertNotNull($smartrates['result'][0]['time_in_transit']['percentile_97']);
-        $this->assertNotNull($smartrates['result'][0]['time_in_transit']['percentile_99']);
+        $this->assertNotNull($smartrates[0]['time_in_transit']['percentile_50']);
+        $this->assertNotNull($smartrates[0]['time_in_transit']['percentile_75']);
+        $this->assertNotNull($smartrates[0]['time_in_transit']['percentile_85']);
+        $this->assertNotNull($smartrates[0]['time_in_transit']['percentile_90']);
+        $this->assertNotNull($smartrates[0]['time_in_transit']['percentile_95']);
+        $this->assertNotNull($smartrates[0]['time_in_transit']['percentile_97']);
+        $this->assertNotNull($smartrates[0]['time_in_transit']['percentile_99']);
     }
 }

--- a/test/EasyPost/Test/ShipmentTest.php
+++ b/test/EasyPost/Test/ShipmentTest.php
@@ -69,7 +69,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving smartrates for a shipment
-     * 
+     *
      * @return void
      */
     public function testSmartrate()

--- a/test/EasyPost/Test/ShipmentTest.php
+++ b/test/EasyPost/Test/ShipmentTest.php
@@ -65,4 +65,47 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
         return $retrieved_shipment;
     }
+
+
+    /**
+     * Test retrieving smartrates for a shipment
+     * 
+     * @return void
+     */
+    public function testSmartrate()
+    {
+        $shipment = Shipment::create(
+            array(
+                "to_address"    => array(
+                    "street1" => "388 Townsend St",
+                    "street2" => "Apt 20",
+                    "city"    => "San Francisco",
+                    "state"   => "CA",
+                    "zip"     => "94107"),
+                "from_address"  => array(
+                    "street1" => "388 Townsend St",
+                    "street2" => "Apt 20",
+                    "city"    => "San Francisco",
+                    "state"   => "CA",
+                    "zip"     => "94107"),
+                "parcel"    => array(
+                    "length"     => "10",
+                    "width"     => "8",
+                    "height"    => "4",
+                    "weight"    => "15")
+            )
+        );
+        $this->assertNotNull($shipment->rates);
+
+        $smartrates = $shipment->get_smartrates();
+        $this->assertEquals($shipment->rates[0]['id'], $smartrates['result'][0]['id']);
+        # TODO: Once we've added `php-vcr`, assert that the following values actually match an integer
+        $this->assertNotNull($smartrates['result'][0]['time_in_transit']['percentile_50']);
+        $this->assertNotNull($smartrates['result'][0]['time_in_transit']['percentile_75']);
+        $this->assertNotNull($smartrates['result'][0]['time_in_transit']['percentile_85']);
+        $this->assertNotNull($smartrates['result'][0]['time_in_transit']['percentile_90']);
+        $this->assertNotNull($smartrates['result'][0]['time_in_transit']['percentile_95']);
+        $this->assertNotNull($smartrates['result'][0]['time_in_transit']['percentile_97']);
+        $this->assertNotNull($smartrates['result'][0]['time_in_transit']['percentile_99']);
+    }
 }


### PR DESCRIPTION
Adds the new `/smartrate` endpoint/method on the `Shipment` object.

Simply call `get_smartrates` on the shipment object and you'll be returned a list of smartrates like so:

```json
[
        {
            "carrier": "USPS",
            "carrier_account_id": "ca_123...",
            "created_at": "2021-05-04T21:15:59Z",
            "currency": "USD",
            "delivery_date": null,
            "delivery_date_guaranteed": true,
            "delivery_days": null,
            "est_delivery_days": null,
            "id": "rate_123...",
            "list_currency": null,
            "list_rate": null,
            "mode": "test",
            "object": "Rate",
            "rate": 0.01,
            "retail_currency": null,
            "retail_rate": null,
            "service": "First",
            "shipment_id": "shp_123",
            "time_in_transit": {
                "percentile_50": 2,
                "percentile_75": 3,
                "percentile_85": 4,
                "percentile_90": 4,
                "percentile_95": 4,
                "percentile_97": 4,
                "percentile_99": 4
            },
            "updated_at": "2021-05-04T21:15:59Z"
        },
    ]
```

A full code example would look like this:

```php
$shipment = \EasyPost\Shipment::retrieve('shp_123...');
$smartrates = $shipment->get_smartrates();
echo $smartrates;
```