### PR TITLE
fix: corrects support email in error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## CHANGELOG
+
+### NEXT RELEASE
+
+* Corrects references of `contact@easypost.com` to `support@easypost.com`
+
 ### 3.6.0 2021-06-10
 
 * Adds `SmartRate` functionality to the `Shipments` object (available by calling `get_smartrates()` on a shipment)

--- a/lib/EasyPost/Requestor.php
+++ b/lib/EasyPost/Requestor.php
@@ -279,20 +279,20 @@ class Requestor
     public function handleCurlError($errorNum, $message)
     {
         $apiBase = EasyPost::$apiBase;
-        $contactEmail = 'support@easypost.com';
+        $supportEmail = 'support@easypost.com';
 
         switch ($errorNum) {
             case CURLE_COULDNT_CONNECT:
             case CURLE_COULDNT_RESOLVE_HOST:
             case CURLE_OPERATION_TIMEOUTED:
-                $msg = "Could not connect to EasyPost ({$apiBase}). Please check your internet connection and try again.  If this problem persists please let us know at {$contactEmail}.";
+                $msg = "Could not connect to EasyPost ({$apiBase}). Please check your internet connection and try again.  If this problem persists please let us know at {$supportEmail}.";
                 break;
             case CURLE_SSL_CACERT:
             case CURLE_SSL_PEER_CERTIFICATE:
-                $msg = "Could not verify EasyPost's SSL certificate. Please make sure that your network is not intercepting certificates.  (Try going to {$apiBase} in your browser.)  If this problem persists, let us know at {$contactEmail}.";
+                $msg = "Could not verify EasyPost's SSL certificate. Please make sure that your network is not intercepting certificates.  (Try going to {$apiBase} in your browser.)  If this problem persists, let us know at {$supportEmail}.";
                 break;
             default:
-                $msg = "Unexpected error communicating with EasyPost. If this problem persists please let us know at {$contactEmail}.";
+                $msg = "Unexpected error communicating with EasyPost. If this problem persists please let us know at {$supportEmail}.";
         }
 
         $msg .= "\nNetwork error [errno {$errorNum}]: {$message})";

--- a/lib/EasyPost/Requestor.php
+++ b/lib/EasyPost/Requestor.php
@@ -279,18 +279,20 @@ class Requestor
     public function handleCurlError($errorNum, $message)
     {
         $apiBase = EasyPost::$apiBase;
+        $contactEmail = 'support@easypost.com';
+
         switch ($errorNum) {
             case CURLE_COULDNT_CONNECT:
             case CURLE_COULDNT_RESOLVE_HOST:
             case CURLE_OPERATION_TIMEOUTED:
-                $msg = "Could not connect to EasyPost ({$apiBase}). Please check your internet connection and try again.  If this problem persists please let us know at contact@easypost.com.";
+                $msg = "Could not connect to EasyPost ({$apiBase}). Please check your internet connection and try again.  If this problem persists please let us know at {$contactEmail}.";
                 break;
             case CURLE_SSL_CACERT:
             case CURLE_SSL_PEER_CERTIFICATE:
-                $msg = "Could not verify EasyPost's SSL certificate. Please make sure that your network is not intercepting certificates.  (Try going to {$apiBase} in your browser.)  If this problem persists, let us know at contact@easypost.com.";
+                $msg = "Could not verify EasyPost's SSL certificate. Please make sure that your network is not intercepting certificates.  (Try going to {$apiBase} in your browser.)  If this problem persists, let us know at {$contactEmail}.";
                 break;
             default:
-                $msg = "Unexpected error communicating with EasyPost. If this problem persists please let us know at contact@easypost.com.";
+                $msg = "Unexpected error communicating with EasyPost. If this problem persists please let us know at {$contactEmail}.";
         }
 
         $msg .= "\nNetwork error [errno {$errorNum}]: {$message})";


### PR DESCRIPTION
We haven't used the `contact@easypost.com` email for some time for support inquiries, correct it to `support@easypost.com`.