### PR TITLE
feat: adds VCR support to tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: set up php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.0
       - name: install composer
         run: composer self-update
       - name: install dependencies
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        phpversion: [7.2, 7.3, 7.4, 8.0]
+        phpversion: [7.3, 7.4, 8.0]
     steps:
       - uses: actions/checkout@v2
       - name: set up php
@@ -45,4 +45,4 @@ jobs:
       - name: install dependencies
         run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
       - name: test with phpunit on ${{ matrix.phpversion }}
-        run: composer test
+        run: API_KEY=123 composer test

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,4 @@ Icon
 easypost-php
 vendor
 bin
-.phpunit.result.cache
-.php_cs.cache
+*.cache

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ EasyPost is a simple shipping API. You can sign up for an account at https://eas
 
 ## Installation
 
-***NOTE:** Although this library may work with PHP 5.3^, it is only tested against PHP 7.2^ and we highly recommended to use PHP 7.2^. Additionally, This library relies on the [mbstring](http://php.net/manual/en/book.mbstring.php) extension. Ensure you have it [installed](http://www.php.net/manual/en/mbstring.installation.php) correctly before using the library.*
+***NOTE:** Although this library may work with PHP 5.3^, it is only tested against PHP 7.3^ and we highly recommended to use PHP 7.3^. Additionally, This library relies on the [mbstring](http://php.net/manual/en/book.mbstring.php) extension. Ensure you have it [installed](http://www.php.net/manual/en/mbstring.installation.php) correctly before using the library.*
 
 ### Install Client Library
 
@@ -103,7 +103,7 @@ Up-to-date documentation can be found at: https://www.easypost.com/docs.
 
 ## Testing & Development
 
-***NOTE: Unit tests only work with PHP 7.2^.***
+***NOTE: Unit tests only work with PHP >=7.2 and <8.0.***
 
 Ensure dependencies are installed, then run any of the following:
 
@@ -115,5 +115,5 @@ composer lint
 composer fix
 
 # Run tests
-composer test
+API_KEY=123... composer test
 ```

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Up-to-date documentation can be found at: https://www.easypost.com/docs.
 
 ## Testing & Development
 
-***NOTE: Unit tests only work with PHP >=7.2 and <8.0.***
+***NOTE: Unit tests only work with PHP >=7.3 and <8.0.***
 
 Ensure dependencies are installed, then run any of the following:
 

--- a/composer.json
+++ b/composer.json
@@ -1,43 +1,45 @@
 {
-    "name": "easypost/easypost-php",
-    "description": "EasyPost Shipping API Client Library for PHP",
-    "keywords": [
-        "shipping",
-        "api",
-        "easypost"
-    ],
-    "homepage": "https://github.com/EasyPost/easypost-php",
-    "type": "library",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "EasyPost Developers",
-            "email": "oss@easypost.com",
-            "homepage": "https://www.easypost.com"
-        }
-    ],
-    "require": {
-        "ext-curl": "*",
-        "ext-json": "*",
-        "php": ">=5.3.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^8",
-        "phpunit/php-token-stream": "3.*",
-        "squizlabs/php_codesniffer": "^3.0"
-    },
-    "scripts": {
-        "fix": "./bin/phpcbf",
-        "lint": "./bin/phpcs",
-        "test": "./bin/phpunit"
-    },
-    "config": {
-        "bin-dir": "bin"
-    },
-    "autoload": {
-        "psr-0": {
-            "EasyPost": "lib/"
-        }
-    },
-    "version": "3.6.0"
+  "name": "easypost/easypost-php",
+  "description": "EasyPost Shipping API Client Library for PHP",
+  "keywords": [
+    "shipping",
+    "api",
+    "easypost"
+  ],
+  "homepage": "https://github.com/EasyPost/easypost-php",
+  "type": "library",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "EasyPost Developers",
+      "email": "oss@easypost.com",
+      "homepage": "https://www.easypost.com"
+    }
+  ],
+  "require": {
+    "ext-curl": "*",
+    "ext-json": "*",
+    "php": ">=5.3.0"
+  },
+  "require-dev": {
+    "allejo/php-vcr-sanitizer": "^1.0.9",
+    "php-vcr/php-vcr": "^1.5",
+    "phpunit/php-token-stream": "3.*",
+    "phpunit/phpunit": "^9",
+    "squizlabs/php_codesniffer": "^3.0"
+  },
+  "scripts": {
+    "fix": "./bin/phpcbf",
+    "lint": "./bin/phpcs",
+    "test": "./bin/phpunit"
+  },
+  "config": {
+    "bin-dir": "bin"
+  },
+  "autoload": {
+    "psr-0": {
+      "EasyPost": "lib/"
+    }
+  },
+  "version": "3.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,143 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2386a19a3240dbb8d18276945a94581b",
+    "content-hash": "2f5a73dd0f71be867c39ebeddcbee396",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "allejo/php-vcr-sanitizer",
+            "version": "v1.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/allejo/php-vcr-sanitizer.git",
+                "reference": "a4969718307201f122b952a9c9aab12da74bfbec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/allejo/php-vcr-sanitizer/zipball/a4969718307201f122b952a9c9aab12da74bfbec",
+                "reference": "a4969718307201f122b952a9c9aab12da74bfbec",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "php-vcr/php-vcr": "^1.4",
+                "symfony/event-dispatcher": "^2.4|^3.0|^4.0|^5.0"
+            },
+            "require-dev": {
+                "donatj/mock-webserver": "^2.1",
+                "ext-curl": "*",
+                "mikey179/vfsstream": "^1.6",
+                "php-curl-class/php-curl-class": "^8.0",
+                "phpunit/phpunit": "^4.8|^5.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "allejo\\VCR\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Vladimir Jimenez",
+                    "email": "me@allejo.io"
+                }
+            ],
+            "description": "Bring privacy to php-vcr by excluding API keys, passwords, and credentials from your recordings",
+            "support": {
+                "issues": "https://github.com/allejo/php-vcr-sanitizer/issues",
+                "source": "https://github.com/allejo/php-vcr-sanitizer/tree/v1.0.9"
+            },
+            "funding": [
+                {
+                    "url": "https://www.buymeacoffee.com/allejo",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/allejo",
+                    "type": "github"
+                },
+                {
+                    "url": "https://ko-fi.com/allejo",
+                    "type": "ko_fi"
+                },
+                {
+                    "url": "https://www.patreon.com/allejo",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2021-05-23T00:14:47+00:00"
+        },
+        {
+            "name": "beberlei/assert",
+            "version": "v3.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beberlei/assert.git",
+                "reference": "5e721d7e937ca3ba2cdec1e1adf195f9e5188372"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/5e721d7e937ca3ba2cdec1e1adf195f9e5188372",
+                "reference": "5e721d7e937ca3ba2cdec1e1adf195f9e5188372",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "php": "^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "*",
+                "phpstan/phpstan": "*",
+                "phpunit/phpunit": ">=6.0.0",
+                "yoast/phpunit-polyfills": "^0.1.0"
+            },
+            "suggest": {
+                "ext-intl": "Needed to allow Assertion::count(), Assertion::isCountable(), Assertion::minCount(), and Assertion::maxCount() to operate on ResourceBundles"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Assert\\": "lib/Assert"
+                },
+                "files": [
+                    "lib/Assert/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Collaborator"
+                }
+            ],
+            "description": "Thin assertion library for input validation in business models.",
+            "keywords": [
+                "assert",
+                "assertion",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/beberlei/assert/issues",
+                "source": "https://github.com/beberlei/assert/tree/v3.3.1"
+            },
+            "time": "2021-04-18T20:11:03+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.4.0",
@@ -135,17 +269,73 @@
             "time": "2020-11-13T09:40:50+00:00"
         },
         {
-            "name": "phar-io/manifest",
-            "version": "2.0.1",
+            "name": "nikic/php-parser",
+            "version": "v4.12.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phar-io/manifest.git",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6608f01670c3cc5079e18c1dab1104e002579143",
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.12.0"
+            },
+            "time": "2021-07-21T10:44:31+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
@@ -190,9 +380,9 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/master"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
             },
-            "time": "2020-06-27T14:33:11+00:00"
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
@@ -244,6 +434,59 @@
                 "source": "https://github.com/phar-io/version/tree/3.1.0"
             },
             "time": "2021-02-23T14:00:09+00:00"
+        },
+        {
+            "name": "php-vcr/php-vcr",
+            "version": "1.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-vcr/php-vcr.git",
+                "reference": "989fdcad482d830890757b8165127ed0183de41b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-vcr/php-vcr/zipball/989fdcad482d830890757b8165127ed0183de41b",
+                "reference": "989fdcad482d830890757b8165127ed0183de41b",
+                "shasum": ""
+            },
+            "require": {
+                "beberlei/assert": "^3.2.5",
+                "ext-curl": "*",
+                "php": ">=7.2",
+                "symfony/event-dispatcher": "^2.4|^3.0|^4.0|^5.0",
+                "symfony/yaml": "~2.1|^3.0|^4.0|^5.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "mikey179/vfsstream": "^1.6",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-beberlei-assert": "^0.12.0",
+                "phpunit/phpunit": "^8.4.0",
+                "sebastian/version": "^1.0.3|^2.0",
+                "thecodingmachine/phpstan-strict-rules": "^0.12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "VCR\\": "src/VCR/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Adrian Philipp",
+                    "email": "mail@adrian-philipp.com"
+                }
+            ],
+            "description": "Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests.",
+            "support": {
+                "issues": "https://github.com/php-vcr/php-vcr/issues",
+                "source": "https://github.com/php-vcr/php-vcr/tree/1.5.2"
+            },
+            "time": "2021-03-20T10:01:20+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -472,40 +715,44 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "7.0.14",
+            "version": "9.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "bb7c9a210c72e4709cdde67f8b7362f672f2225c"
+                "reference": "f6293e1b30a2354e8428e004689671b83871edde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/bb7c9a210c72e4709cdde67f8b7362f672f2225c",
-                "reference": "bb7c9a210c72e4709cdde67f8b7362f672f2225c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f6293e1b30a2354e8428e004689671b83871edde",
+                "reference": "f6293e1b30a2354e8428e004689671b83871edde",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=7.2",
-                "phpunit/php-file-iterator": "^2.0.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.1.1 || ^4.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^4.2.2",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1.3"
+                "nikic/php-parser": "^4.10.2",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0.3",
+                "sebastian/version": "^3.0.1",
+                "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.2.2"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-xdebug": "^2.7.2"
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.0-dev"
+                    "dev-master": "9.2-dev"
                 }
             },
             "autoload": {
@@ -533,7 +780,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/7.0.14"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.6"
             },
             "funding": [
                 {
@@ -541,32 +788,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-12-02T13:39:03+00:00"
+            "time": "2021-03-28T07:26:59+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.3",
+            "version": "3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357"
+                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/4b49fb70f067272b659ef0174ff9ca40fdaa6357",
-                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -593,7 +840,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.5"
             },
             "funding": [
                 {
@@ -601,26 +848,97 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:25:21+00:00"
+            "time": "2020-09-28T05:57:25+00:00"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -644,34 +962,40 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
             },
-            "time": "2015-06-21T13:50:34+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.3",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662"
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/2454ae1765516d20c4ffe103d85a58a9a3bd5662",
-                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -697,7 +1021,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/2.1.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
             },
             "funding": [
                 {
@@ -705,20 +1029,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:20:02+00:00"
+            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2"
+                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/472b687829041c24b25f475e14c2f38a09edf1c2",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9c1da83261628cb24b6a6df371b6e312b3954768",
+                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768",
                 "shasum": ""
             },
             "require": {
@@ -756,7 +1080,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
-                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.2"
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.3"
             },
             "funding": [
                 {
@@ -765,20 +1089,20 @@
                 }
             ],
             "abandoned": true,
-            "time": "2020-11-30T08:38:46+00:00"
+            "time": "2021-07-26T12:15:06+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.15",
+            "version": "9.5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "038d4196d8e8cb405cd5e82cedfe413ad6eef9ef"
+                "reference": "ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/038d4196d8e8cb405cd5e82cedfe413ad6eef9ef",
-                "reference": "038d4196d8e8cb405cd5e82cedfe413ad6eef9ef",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b",
+                "reference": "ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b",
                 "shasum": ""
             },
             "require": {
@@ -789,32 +1113,35 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.0",
-                "phar-io/manifest": "^2.0.1",
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
-                "php": ">=7.2",
-                "phpspec/prophecy": "^1.10.3",
-                "phpunit/php-code-coverage": "^7.0.12",
-                "phpunit/php-file-iterator": "^2.0.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.1.2",
-                "sebastian/comparator": "^3.0.2",
-                "sebastian/diff": "^3.0.2",
-                "sebastian/environment": "^4.2.3",
-                "sebastian/exporter": "^3.1.2",
-                "sebastian/global-state": "^3.0.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^2.0.1",
-                "sebastian/type": "^1.1.3",
-                "sebastian/version": "^2.0.1"
+                "php": ">=7.3",
+                "phpspec/prophecy": "^1.12.1",
+                "phpunit/php-code-coverage": "^9.2.3",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.5",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.3",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^2.3.4",
+                "sebastian/version": "^3.0.2"
             },
             "require-dev": {
-                "ext-pdo": "*"
+                "ext-pdo": "*",
+                "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
                 "ext-soap": "*",
-                "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0.0"
+                "ext-xdebug": "*"
             },
             "bin": [
                 "phpunit"
@@ -822,12 +1149,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "8.5-dev"
+                    "dev-master": "9.5-dev"
                 }
             },
             "autoload": {
                 "classmap": [
                     "src/"
+                ],
+                "files": [
+                    "src/Framework/Assert/Functions.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -850,7 +1180,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.15"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.9"
             },
             "funding": [
                 {
@@ -862,32 +1192,194 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-03-17T07:27:54+00:00"
+            "time": "2021-08-31T06:47:40+00:00"
         },
         {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.2",
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
-                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "php": ">=7.2.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:08:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -909,7 +1401,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.2"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
             },
             "funding": [
                 {
@@ -917,34 +1409,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:15:22+00:00"
+            "time": "2020-09-28T05:30:19+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.3",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758"
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1071dfcef776a57013124ff35e1fc41ccd294758",
-                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1",
-                "sebastian/diff": "^3.0",
-                "sebastian/exporter": "^3.1"
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -983,7 +1475,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
             },
             "funding": [
                 {
@@ -991,33 +1483,90 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:04:30+00:00"
+            "time": "2020-10-26T15:49:45+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "3.0.3",
+            "name": "sebastian/complexity",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
-                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "nikic/php-parser": "^4.7",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^8.0",
-                "symfony/process": "^2 || ^3.3 || ^4"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:52:27+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1049,7 +1598,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
             },
             "funding": [
                 {
@@ -1057,27 +1606,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:59:04+00:00"
+            "time": "2020-10-26T13:10:38+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.4",
+            "version": "5.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0"
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
-                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/388b6ced16caa751030f6a69e588299fa09200ac",
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -1085,7 +1634,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "5.1-dev"
                 }
             },
             "autoload": {
@@ -1112,7 +1661,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/4.2.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
             },
             "funding": [
                 {
@@ -1120,34 +1669,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:53:42+00:00"
+            "time": "2020-09-28T05:52:38+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.3",
+            "version": "4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e"
+                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/6b853149eab67d4da22291d36f5b0631c0fd856e",
-                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1189,7 +1738,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.3"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
             },
             "funding": [
                 {
@@ -1197,30 +1746,30 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:47:53+00:00"
+            "time": "2020-09-28T05:24:23+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "3.0.1",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "474fb9edb7ab891665d3bfc6317f42a0a150454b"
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/474fb9edb7ab891665d3bfc6317f42a0a150454b",
-                "reference": "474fb9edb7ab891665d3bfc6317f42a0a150454b",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^8.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1228,7 +1777,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1253,7 +1802,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
             },
             "funding": [
                 {
@@ -1261,34 +1810,91 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:43:24+00:00"
+            "time": "2021-06-11T13:31:12+00:00"
         },
         {
-            "name": "sebastian/object-enumerator",
-            "version": "3.0.4",
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2"
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
-                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "nikic/php-parser": "^4.6",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:42:11+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1310,7 +1916,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/3.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
             },
             "funding": [
                 {
@@ -1318,32 +1924,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:40:27+00:00"
+            "time": "2020-10-26T13:12:34+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.2",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d"
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
-                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1365,7 +1971,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/1.1.2"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
             },
             "funding": [
                 {
@@ -1373,32 +1979,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:37:18+00:00"
+            "time": "2020-10-26T13:14:26+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.1",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb"
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/367dcba38d6e1977be014dc4b22f47a484dac7fb",
-                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1428,7 +2034,7 @@
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
             },
             "funding": [
                 {
@@ -1436,29 +2042,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:34:24+00:00"
+            "time": "2020-10-26T13:17:30+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "2.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3"
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/31d35ca87926450c44eae7e2611d45a7a65ea8b3",
-                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1480,7 +2089,7 @@
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
             },
             "funding": [
                 {
@@ -1488,32 +2097,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:30:19+00:00"
+            "abandoned": true,
+            "time": "2020-09-28T06:45:17+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "1.1.4",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4"
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/0150cfbc4495ed2df3872fb31b26781e4e077eb4",
-                "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.2"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.3-dev"
                 }
             },
             "autoload": {
@@ -1536,7 +2146,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/1.1.4"
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
             },
             "funding": [
                 {
@@ -1544,29 +2154,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:25:11+00:00"
+            "time": "2021-06-15T12:49:02+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "2.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=7.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1589,9 +2199,15 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/master"
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
             },
-            "time": "2016-10-03T07:35:21+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1648,6 +2264,237 @@
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
             "time": "2021-04-09T00:54:41+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-03-23T23:28:01+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v5.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "ce7b20d69c66a20939d8952b617506a44d102130"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/ce7b20d69c66a20939d8952b617506a44d102130",
+                "reference": "ce7b20d69c66a20939d8952b617506a44d102130",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/event-dispatcher-contracts": "^2",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<4.4"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "2.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/expression-language": "^4.4|^5.0",
+                "symfony/http-foundation": "^4.4|^5.0",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/stopwatch": "^4.4|^5.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.3.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-08-04T21:20:46+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "69fee1ad2332a7cbab3aca13591953da9cdb7a11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/69fee1ad2332a7cbab3aca13591953da9cdb7a11",
+                "reference": "69fee1ad2332a7cbab3aca13591953da9cdb7a11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/event-dispatcher": "^1"
+            },
+            "suggest": {
+                "symfony/event-dispatcher-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-03-23T23:28:01+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1729,17 +2576,175 @@
             "time": "2021-02-19T12:13:01+00:00"
         },
         {
-            "name": "theseer/tokenizer",
-            "version": "1.2.0",
+            "name": "symfony/polyfill-php80",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-28T13:41:28+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v5.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "4500fe63dc9c6ffc32d3b1cb0448c329f9c814b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/4500fe63dc9c6ffc32d3b1cb0448c329f9c814b7",
+                "reference": "4500fe63dc9c6ffc32d3b1cb0448c329f9c814b7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<4.4"
+            },
+            "require-dev": {
+                "symfony/console": "^4.4|^5.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v5.3.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-29T06:20:01+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
@@ -1768,7 +2773,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/master"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
             },
             "funding": [
                 {
@@ -1776,7 +2781,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-07-12T23:59:07+00:00"
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false" bootstrap="vendor/autoload.php" colors="true">
+<phpunit backupGlobals="false" bootstrap="test/bootstrap.php" cacheResultFile=".phpunit.cache/test-results" executionOrder="depends,defects" beStrictAboutCoversAnnotation="true" beStrictAboutOutputDuringTests="true" beStrictAboutTodoAnnotatedTests="true" failOnRisky="true" failOnWarning="true" verbose="true" colors="true">
     <testsuites>
         <testsuite name="EasyPost Test Suite">
             <directory suffix="Test.php">./test/EasyPost/</directory>

--- a/test/EasyPost/Test/AddressTest.php
+++ b/test/EasyPost/Test/AddressTest.php
@@ -53,7 +53,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
         $this->assertStringMatchesFormat('adr_%s', $address->id);
         $this->assertEquals($address->street1, '388 Townsend St');
 
-        // Return so the `retrieve` tests can reuse this object
+        // Return so the `retrieve` test can reuse this object
         return $address;
     }
 

--- a/test/EasyPost/Test/ParcelTest.php
+++ b/test/EasyPost/Test/ParcelTest.php
@@ -52,7 +52,7 @@ class ParcelTest extends \PHPUnit\Framework\TestCase
         $this->assertStringMatchesFormat('prcl_%s', $parcel->id);
         $this->assertEquals($parcel->weight, '15');
 
-        // Return so the `retrieve` tests can reuse this object
+        // Return so the `retrieve` test can reuse this object
         return $parcel;
     }
 

--- a/test/EasyPost/Test/ReportTest.php
+++ b/test/EasyPost/Test/ReportTest.php
@@ -50,7 +50,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         $this->assertIsString($payment_log_report->id);
         $this->assertStringMatchesFormat("plrep_%s", $payment_log_report->id);
 
-        // Return so the `retrieve` tests can reuse this object
+        // Return so the `retrieve` test can reuse this object
         return $payment_log_report;
     }
 
@@ -73,7 +73,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         $this->assertIsString($refund_report->id);
         $this->assertStringMatchesFormat("refrep_%s", $refund_report->id);
 
-        // Return so the `retrieve` tests can reuse this object
+        // Return so the `retrieve` test can reuse this object
         return $refund_report;
     }
 
@@ -96,7 +96,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         $this->assertIsString($shipment_report->id);
         $this->assertStringMatchesFormat("shprep_%s", $shipment_report->id);
 
-        // Return so the `retrieve` tests can reuse this object
+        // Return so the `retrieve` test can reuse this object
         return $shipment_report;
     }
 
@@ -119,7 +119,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         $this->assertIsString($shipment_invoice_report->id);
         $this->assertStringMatchesFormat("shpinvrep_%s", $shipment_invoice_report->id);
 
-        // Return so the `retrieve` tests can reuse this object
+        // Return so the `retrieve` test can reuse this object
         return $shipment_invoice_report;
     }
 
@@ -142,7 +142,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         $this->assertIsString($tracker_report->id);
         $this->assertStringMatchesFormat("trkrep_%s", $tracker_report->id);
 
-        // Return so the `retrieve` tests can reuse this object
+        // Return so the `retrieve` test can reuse this object
         return $tracker_report;
     }
 

--- a/test/EasyPost/Test/ReportTest.php
+++ b/test/EasyPost/Test/ReportTest.php
@@ -2,186 +2,242 @@
 
 namespace EasyPost\Test;
 
+use VCR\VCR;
 use EasyPost\Report;
 use EasyPost\EasyPost;
 
-EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+EasyPost::setApiKey(getenv('API_KEY'));
 
-class TestReport extends \PHPUnit\Framework\TestCase
+class ReportTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * Report the creation of a Payment Log report
+     * Set up VCR before running tests in this file
      *
      * @return void
      */
+    public static function setUpBeforeClass(): void
+    {
+        VCR::turnOn();
+    }
+
+    /**
+     * Spin down VCR after running tests
+     *
+     * @return void
+     */
+    public static function tearDownAfterClass(): void
+    {
+        VCR::eject();
+        VCR::turnOff();
+    }
+
+    /**
+     * Test the creation of a Payment Log report
+     *
+     * @return Report
+     */
     public function testCreatePaymentLogReport()
     {
-        // Set a random date to use
-        $year = sprintf('%04d', rand(0001, 2020));
-        $month = sprintf('%02d', rand(01, 12));
+        VCR::insertCassette('reports/createPaymentLogReport.yml');
 
-        // Build params and run assertions
-        $params = array(
-            "start_date" => "$year-$month-01",
-            "end_date" => "$year-$month-31",
+        $payment_log_report = Report::create(array(
+            "start_date" => "2021-01-01",
+            "end_date" => "2021-01-02",
             "type" => "payment_log"
-        );
-        $payment_log_report = Report::create($params);
+        ));
+
         $this->assertInstanceOf('\EasyPost\Report', $payment_log_report);
         $this->assertIsString($payment_log_report->id);
         $this->assertStringMatchesFormat("plrep_%s", $payment_log_report->id);
 
+        // Return so the `retrieve` tests can reuse this object
         return $payment_log_report;
     }
 
     /**
-     * Report the creation of a Refund report
+     * Test the creation of a Refund report
      *
-     * @return void
+     * @return Report
      */
     public function testCreateRefundReport()
     {
-        // Set a random date to use
-        $year = sprintf('%04d', rand(0001, 2020));
-        $month = sprintf('%02d', rand(01, 12));
+        VCR::insertCassette('reports/createRefundReport.yml');
 
-        // Build params and run assertions
-        $params = array(
-            "start_date" => "$year-$month-01",
-            "end_date" => "$year-$month-31",
+        $refund_report = Report::create(array(
+            "start_date" => "2021-01-01",
+            "end_date" => "2021-01-02",
             "type" => "refund"
-        );
-        $refund_report = Report::create($params);
+        ));
+
         $this->assertInstanceOf('\EasyPost\Report', $refund_report);
         $this->assertIsString($refund_report->id);
         $this->assertStringMatchesFormat("refrep_%s", $refund_report->id);
 
+        // Return so the `retrieve` tests can reuse this object
         return $refund_report;
     }
 
     /**
-     * Report the creation of a Shipment report
+     * Test the creation of a Shipment report
      *
-     * @return void
+     * @return Report
      */
     public function testCreateShipmentReport()
     {
-        // Set a random date to use
-        $year = sprintf('%04d', rand(0001, 2020));
-        $month = sprintf('%02d', rand(01, 12));
+        VCR::insertCassette('reports/createShipmentReport.yml');
 
-        // Build params and run assertions
-        $params = array(
-            "start_date" => "$year-$month-01",
-            "end_date" => "$year-$month-31",
+        $shipment_report = Report::create(array(
+            "start_date" => "2021-01-01",
+            "end_date" => "2021-01-02",
             "type" => "shipment"
-        );
-        $shipment_report = Report::create($params);
+        ));
+
         $this->assertInstanceOf('\EasyPost\Report', $shipment_report);
         $this->assertIsString($shipment_report->id);
         $this->assertStringMatchesFormat("shprep_%s", $shipment_report->id);
 
+        // Return so the `retrieve` tests can reuse this object
         return $shipment_report;
     }
 
     /**
-     * Report the creation of a Tracker report
+     * Test the creation of a Shipment Invoice report
      *
-     * @return void
+     * @return Report
+     */
+    public function testCreateShipmentInvoiceReport()
+    {
+        VCR::insertCassette('reports/createShipmentInvoiceReport.yml');
+
+        $shipment_invoice_report = Report::create(array(
+            "start_date" => "2021-01-01",
+            "end_date" => "2021-01-02",
+            "type" => "shipment_invoice"
+        ));
+
+        $this->assertInstanceOf('\EasyPost\Report', $shipment_invoice_report);
+        $this->assertIsString($shipment_invoice_report->id);
+        $this->assertStringMatchesFormat("shpinvrep_%s", $shipment_invoice_report->id);
+
+        // Return so the `retrieve` tests can reuse this object
+        return $shipment_invoice_report;
+    }
+
+    /**
+     * Test the creation of a Tracker report
+     *
+     * @return Report
      */
     public function testCreateTrackerReport()
     {
-        // Set a random date to use
-        $year = sprintf('%04d', rand(0001, 2020));
-        $month = sprintf('%02d', rand(01, 12));
+        VCR::insertCassette('reports/createTrackerReport.yml');
 
-        // Build params and run assertions
-        $params = array(
-            "start_date" => "$year-$month-01",
-            "end_date" => "$year-$month-31",
+        $tracker_report = Report::create(array(
+            "start_date" => "2021-01-01",
+            "end_date" => "2021-01-02",
             "type" => "tracker"
-        );
-        $tracker_report = Report::create($params);
+        ));
+
         $this->assertInstanceOf('\EasyPost\Report', $tracker_report);
         $this->assertIsString($tracker_report->id);
         $this->assertStringMatchesFormat("trkrep_%s", $tracker_report->id);
 
+        // Return so the `retrieve` tests can reuse this object
         return $tracker_report;
     }
 
     /**
-     * Report the retrieval of a Payment Log report
+     * Test the retrieval of a Payment Log report
      *
-     * @param Report $report
+     * @param Report $payment_log_report
      * @return void
      * @depends testCreatePaymentLogReport
      */
     public function testRetrievePaymentLogReport($payment_log_report)
     {
+        VCR::insertCassette('reports/retrievePaymentLogReport.yml');
+
         $retrieved_payment_log_report = Report::retrieve($payment_log_report->id);
 
         $this->assertInstanceOf('\EasyPost\Report', $retrieved_payment_log_report);
         $this->assertEquals($retrieved_payment_log_report->id, $payment_log_report->id);
         $this->assertEquals($retrieved_payment_log_report->start_date, $payment_log_report->start_date);
         $this->assertEquals($retrieved_payment_log_report->end_date, $payment_log_report->end_date);
-
-        return $retrieved_payment_log_report;
     }
 
     /**
-     * Report the retrieval of a Refund report
+     * Test the retrieval of a Refund report
      *
-     * @param Report $report
+     * @param Report $refund_report
      * @return void
      * @depends testCreateRefundReport
      */
     public function testRetrieveRefundReport($refund_report)
     {
+        VCR::insertCassette('reports/retrieveRefundReport.yml');
+
         $retrieved_refund_report = Report::retrieve($refund_report->id);
 
         $this->assertInstanceOf('\EasyPost\Report', $retrieved_refund_report);
         $this->assertEquals($retrieved_refund_report->id, $refund_report->id);
         $this->assertEquals($retrieved_refund_report->start_date, $refund_report->start_date);
         $this->assertEquals($retrieved_refund_report->end_date, $refund_report->end_date);
-
-        return $retrieved_refund_report;
     }
 
     /**
-     * Report the retrieval of a Shipment report
+     * Test the retrieval of a Shipment report
      *
-     * @param Report $report
+     * @param Report $shipment_report
      * @return void
      * @depends testCreateShipmentReport
      */
     public function testRetrieveShipmentReport($shipment_report)
     {
+        VCR::insertCassette('reports/retrieveShipmentReport.yml');
+
         $retrieved_shipment_report = Report::retrieve($shipment_report->id);
 
         $this->assertInstanceOf('\EasyPost\Report', $retrieved_shipment_report);
         $this->assertEquals($retrieved_shipment_report->id, $shipment_report->id);
         $this->assertEquals($retrieved_shipment_report->start_date, $shipment_report->start_date);
         $this->assertEquals($retrieved_shipment_report->end_date, $shipment_report->end_date);
-
-        return $retrieved_shipment_report;
     }
 
     /**
-     * Report the retrieval of a Tracker report
+     * Test the retrieval of a Shipment Invoice report
      *
-     * @param Report $report
+     * @param Report $shipment_invoice_report
+     * @return void
+     * @depends testCreateShipmentInvoiceReport
+     */
+    public function testRetrieveShipmentInvoiceReport($shipment_invoice_report)
+    {
+        VCR::insertCassette('reports/retrieveShipmentReport.yml');
+
+        $retrieved_shipment_invoice_report = Report::retrieve($shipment_invoice_report->id);
+
+        $this->assertInstanceOf('\EasyPost\Report', $retrieved_shipment_invoice_report);
+        $this->assertEquals($retrieved_shipment_invoice_report->id, $shipment_invoice_report->id);
+        $this->assertEquals($retrieved_shipment_invoice_report->start_date, $shipment_invoice_report->start_date);
+        $this->assertEquals($retrieved_shipment_invoice_report->end_date, $shipment_invoice_report->end_date);
+    }
+
+    /**
+     * Test the retrieval of a Tracker report
+     *
+     * @param Report $tracker_report
      * @return void
      * @depends testCreateTrackerReport
      */
     public function testRetrieveTrackerReport($tracker_report)
     {
+        VCR::insertCassette('reports/retrieveTrackerReport.yml');
+
         $retrieved_tracker_report = Report::retrieve($tracker_report->id);
 
         $this->assertInstanceOf('\EasyPost\Report', $retrieved_tracker_report);
         $this->assertEquals($retrieved_tracker_report->id, $tracker_report->id);
         $this->assertEquals($retrieved_tracker_report->start_date, $tracker_report->start_date);
         $this->assertEquals($retrieved_tracker_report->end_date, $tracker_report->end_date);
-
-        return $retrieved_tracker_report;
     }
 }

--- a/test/EasyPost/Test/ShipmentTest.php
+++ b/test/EasyPost/Test/ShipmentTest.php
@@ -68,7 +68,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
         $this->assertStringMatchesFormat('shp_%s', $shipment->id);
         $this->assertEquals($shipment->parcel->weight, '15');
 
-        // Return so the `retrieve` tests can reuse this object
+        // Return so the `retrieve` test can reuse this object
         return $shipment;
     }
 

--- a/test/EasyPost/Test/ShipmentTest.php
+++ b/test/EasyPost/Test/ShipmentTest.php
@@ -89,8 +89,28 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('\EasyPost\Shipment', $retrieved_shipment);
         $this->assertEquals($retrieved_shipment->id, $shipment->id);
         $this->assertEquals($retrieved_shipment, $shipment);
+
+        // Return so the `buy` test can reuse this object
+        return $shipment;
     }
 
+    /**
+     * Test buying a Shipment
+     *
+     * @param Shipment $shipment
+     * @return void
+     * @depends testRetrieve
+     */
+    public function testBuy(Shipment $shipment)
+    {
+        VCR::insertCassette('shipments/buy.yml');
+
+        $shipment->buy(array(
+            'id' => 'rate_94ad5814f2be4c9e97dc6256b8ec940a',
+        ));
+
+        $this->assertNotNull($shipment->postage_label);
+    }
 
     /**
      * Test retrieving smartrates for a shipment

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,4 +1,3 @@
-
 <?php
 
 use VCR\VCR;

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -16,6 +16,7 @@ VCRCleaner::enable(array(
     'request' => array(
         'ignoreHeaders' => array(
             'Authorization',
+            'X-Client-User-Agent',
         ),
     ),
 ));

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,0 +1,21 @@
+
+<?php
+
+use VCR\VCR;
+use allejo\VCR\VCRCleaner;
+
+if (!file_exists('test/cassettes')) {
+    mkdir('test/cassettes', 0777, true);
+}
+
+VCR::configure()->setCassettePath('test/cassettes')
+    ->setStorage('yaml')
+    ->setMode('once');
+
+VCRCleaner::enable(array(
+    'request' => array(
+        'ignoreHeaders' => array(
+            'Authorization',
+        ),
+    ),
+));

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -4,7 +4,7 @@ use VCR\VCR;
 use allejo\VCR\VCRCleaner;
 
 if (!file_exists('test/cassettes')) {
-    mkdir('test/cassettes', 0777, true);
+    mkdir('test/cassettes', 0755, true);
 }
 
 VCR::configure()->setCassettePath('test/cassettes')

--- a/test/cassettes/addresses/create.yml
+++ b/test/cassettes/addresses/create.yml
@@ -1,0 +1,78 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/addresses'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+        body: 'address%5Bstreet1%5D=388+Townsend+St&address%5Bstreet2%5D=Apt+20&address%5Bcity%5D=San+Francisco&address%5Bstate%5D=CA&address%5Bzip%5D=94107'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 917ccb3f61379629e786af7e009e7905
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            location: /api/v2/addresses/adr_ee8ef1e75fa842e68bb9688f2e78f9f0
+            content-type: 'application/json; charset=utf-8'
+            content-length: '429'
+            etag: 'W/"590bb5c4349e8e6b32b4e63c2dc70e7e"'
+            x-request-id: dd8933f3-e203-4549-97a7-9f836b7c1b63
+            x-runtime: '0.037233'
+            x-node: bigweb4nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq 543ba58655', 'extlb2nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"adr_ee8ef1e75fa842e68bb9688f2e78f9f0","object":"Address","created_at":"2021-09-07T16:41:13+00:00","updated_at":"2021-09-07T16:41:13+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/addresses'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 845
+            request_size: 665
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.255859
+            namelookup_time: 0.008096
+            connect_time: 0.074502
+            pretransfer_time: 0.15727
+            size_upload: !!float 141
+            size_download: !!float 429
+            speed_download: !!float 1676
+            speed_upload: !!float 551
+            download_content_length: !!float 429
+            upload_content_length: !!float 141
+            starttransfer_time: 0.255781
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.130
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50318
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 157215
+            connect_time_us: 74502
+            namelookup_time_us: 8096
+            pretransfer_time_us: 157270
+            redirect_time_us: 0
+            starttransfer_time_us: 255781
+            total_time_us: 255859

--- a/test/cassettes/addresses/create.yml
+++ b/test/cassettes/addresses/create.yml
@@ -5,7 +5,7 @@
         url: 'https://api.easypost.com/v2/addresses'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            X-Client-User-Agent: ''
             User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
             Authorization: ''
             EasyPost-Version: '2'

--- a/test/cassettes/addresses/retrieve.yml
+++ b/test/cassettes/addresses/retrieve.yml
@@ -5,7 +5,7 @@
         url: 'https://api.easypost.com/v2/addresses/adr_ee8ef1e75fa842e68bb9688f2e78f9f0'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            X-Client-User-Agent: ''
             User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
             Authorization: ''
             EasyPost-Version: '2'

--- a/test/cassettes/addresses/retrieve.yml
+++ b/test/cassettes/addresses/retrieve.yml
@@ -1,0 +1,76 @@
+
+-
+    request:
+        method: GET
+        url: 'https://api.easypost.com/v2/addresses/adr_ee8ef1e75fa842e68bb9688f2e78f9f0'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 917ccb4161379c70e786b49f00a093a4
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '429'
+            etag: 'W/"590bb5c4349e8e6b32b4e63c2dc70e7e"'
+            x-request-id: c2ed6931-75f9-4195-a611-d26340ce6ea5
+            x-runtime: '0.022779'
+            x-node: bigweb8nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq 543ba58655', 'extlb2nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"adr_ee8ef1e75fa842e68bb9688f2e78f9f0","object":"Address","created_at":"2021-09-07T16:41:13+00:00","updated_at":"2021-09-07T16:41:13+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/addresses/adr_ee8ef1e75fa842e68bb9688f2e78f9f0'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 774
+            request_size: 490
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.301913
+            namelookup_time: 0.047044
+            connect_time: 0.109122
+            pretransfer_time: 0.216986
+            size_upload: !!float 0
+            size_download: !!float 429
+            speed_download: !!float 1420
+            speed_upload: !!float 0
+            download_content_length: !!float 429
+            upload_content_length: !!float 0
+            starttransfer_time: 0.301812
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.130
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50481
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 216887
+            connect_time_us: 109122
+            namelookup_time_us: 47044
+            pretransfer_time_us: 216986
+            redirect_time_us: 0
+            starttransfer_time_us: 301812
+            total_time_us: 301913

--- a/test/cassettes/parcels/create.yml
+++ b/test/cassettes/parcels/create.yml
@@ -1,0 +1,78 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/parcels'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+        body: 'parcel%5Blength%5D=10&parcel%5Bwidth%5D=8&parcel%5Bheight%5D=4&parcel%5Bweight%5D=15'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 3774dfba613797cbe786b01b00a56f0d
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            location: /api/v2/parcels.prcl_7241cc3cb20f477aa22b72a3d84bf9ad
+            content-type: 'application/json; charset=utf-8'
+            content-length: '229'
+            etag: 'W/"54d2a86f8938779b86ccc7d0045116b0"'
+            x-request-id: 18b0591d-bf9d-4fc1-b3e3-06c623520f31
+            x-runtime: '0.027235'
+            x-node: bigweb2nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq 543ba58655', 'extlb1nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"prcl_7241cc3cb20f477aa22b72a3d84bf9ad","object":"Parcel","created_at":"2021-09-07T16:48:11Z","updated_at":"2021-09-07T16:48:11Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/parcels'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 844
+            request_size: 605
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.247968
+            namelookup_time: 0.011111
+            connect_time: 0.072226
+            pretransfer_time: 0.158324
+            size_upload: !!float 84
+            size_download: !!float 229
+            speed_download: !!float 923
+            speed_upload: !!float 338
+            download_content_length: !!float 229
+            upload_content_length: !!float 84
+            starttransfer_time: 0.247866
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50360
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 158249
+            connect_time_us: 72226
+            namelookup_time_us: 11111
+            pretransfer_time_us: 158324
+            redirect_time_us: 0
+            starttransfer_time_us: 247866
+            total_time_us: 247968

--- a/test/cassettes/parcels/create.yml
+++ b/test/cassettes/parcels/create.yml
@@ -5,7 +5,7 @@
         url: 'https://api.easypost.com/v2/parcels'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            X-Client-User-Agent: ''
             User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
             Authorization: ''
             EasyPost-Version: '2'

--- a/test/cassettes/parcels/retrieve.yml
+++ b/test/cassettes/parcels/retrieve.yml
@@ -5,7 +5,7 @@
         url: 'https://api.easypost.com/v2/parcels/prcl_7241cc3cb20f477aa22b72a3d84bf9ad'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            X-Client-User-Agent: ''
             User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
             Authorization: ''
             EasyPost-Version: '2'

--- a/test/cassettes/parcels/retrieve.yml
+++ b/test/cassettes/parcels/retrieve.yml
@@ -1,0 +1,76 @@
+
+-
+    request:
+        method: GET
+        url: 'https://api.easypost.com/v2/parcels/prcl_7241cc3cb20f477aa22b72a3d84bf9ad'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 3774dfbe61379c59e786b48200a707d7
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '229'
+            etag: 'W/"54d2a86f8938779b86ccc7d0045116b0"'
+            x-request-id: 16a57108-fdad-4794-8114-d62ef2ac762c
+            x-runtime: '0.022581'
+            x-node: bigweb6nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq 543ba58655', 'extlb1nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"prcl_7241cc3cb20f477aa22b72a3d84bf9ad","object":"Parcel","created_at":"2021-09-07T16:48:11Z","updated_at":"2021-09-07T16:48:11Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/parcels/prcl_7241cc3cb20f477aa22b72a3d84bf9ad'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 774
+            request_size: 489
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.253545
+            namelookup_time: 0.025458
+            connect_time: 0.086451
+            pretransfer_time: 0.168849
+            size_upload: !!float 0
+            size_download: !!float 229
+            speed_download: !!float 903
+            speed_upload: !!float 0
+            download_content_length: !!float 229
+            upload_content_length: !!float 0
+            starttransfer_time: 0.253468
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50475
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 168774
+            connect_time_us: 86451
+            namelookup_time_us: 25458
+            pretransfer_time_us: 168849
+            redirect_time_us: 0
+            starttransfer_time_us: 253468
+            total_time_us: 253545

--- a/test/cassettes/reports/createPaymentLogReport.yml
+++ b/test/cassettes/reports/createPaymentLogReport.yml
@@ -1,0 +1,77 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/reports/payment_log/'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+        body: 'start_date=2021-01-01&end_date=2021-01-02&type=payment_log'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 3774dfb861379a49e786b3fe00a63af3
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '259'
+            etag: 'W/"4bf8c4885141fa37247ccc0ff8caf4a6"'
+            x-request-id: e3350907-9b6e-4ade-82f1-adcedb12469c
+            x-runtime: '0.045816'
+            x-node: bigweb3nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq 543ba58655', 'extlb1nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"plrep_44432ab730e3410aad8cae818225226f","object":"PaymentLogReport","created_at":"2021-09-07T16:58:49Z","updated_at":"2021-09-07T16:58:49Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"new","url":null,"url_expires_at":null}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/reports/payment_log/'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 779
+            request_size: 592
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.254214
+            namelookup_time: 0.00168
+            connect_time: 0.064012
+            pretransfer_time: 0.137754
+            size_upload: !!float 58
+            size_download: !!float 259
+            speed_download: !!float 1018
+            speed_upload: !!float 228
+            download_content_length: !!float 259
+            upload_content_length: !!float 58
+            starttransfer_time: 0.254151
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50435
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 137653
+            connect_time_us: 64012
+            namelookup_time_us: 1680
+            pretransfer_time_us: 137754
+            redirect_time_us: 0
+            starttransfer_time_us: 254151
+            total_time_us: 254214

--- a/test/cassettes/reports/createPaymentLogReport.yml
+++ b/test/cassettes/reports/createPaymentLogReport.yml
@@ -5,7 +5,7 @@
         url: 'https://api.easypost.com/v2/reports/payment_log/'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            X-Client-User-Agent: ''
             User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
             Authorization: ''
             EasyPost-Version: '2'

--- a/test/cassettes/reports/createRefundReport.yml
+++ b/test/cassettes/reports/createRefundReport.yml
@@ -5,7 +5,7 @@
         url: 'https://api.easypost.com/v2/reports/refund/'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            X-Client-User-Agent: ''
             User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
             Authorization: ''
             EasyPost-Version: '2'

--- a/test/cassettes/reports/createRefundReport.yml
+++ b/test/cassettes/reports/createRefundReport.yml
@@ -1,0 +1,77 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/reports/refund/'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+        body: 'start_date=2021-01-01&end_date=2021-01-02&type=refund'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 3774dfbe61379a48e786b3fc00a63a88
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '256'
+            etag: 'W/"9a2fb1b03b03bd9b6d28de8c26fa214f"'
+            x-request-id: 3199f487-79f9-4f41-af08-b0ae106d97f0
+            x-runtime: '0.065057'
+            x-node: bigweb2nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq 543ba58655', 'extlb1nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"refrep_eaf0cb1246a847c0b83e4d6c859a0b85","object":"RefundReport","created_at":"2021-09-07T16:58:48Z","updated_at":"2021-09-07T16:58:48Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"new","url":null,"url_expires_at":null}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/reports/refund/'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 779
+            request_size: 582
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.268631
+            namelookup_time: 0.001788
+            connect_time: 0.06137
+            pretransfer_time: 0.141702
+            size_upload: !!float 53
+            size_download: !!float 256
+            speed_download: !!float 952
+            speed_upload: !!float 197
+            download_content_length: !!float 256
+            upload_content_length: !!float 53
+            starttransfer_time: 0.268596
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50433
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 141623
+            connect_time_us: 61370
+            namelookup_time_us: 1788
+            pretransfer_time_us: 141702
+            redirect_time_us: 0
+            starttransfer_time_us: 268596
+            total_time_us: 268631

--- a/test/cassettes/reports/createShipmentInvoiceReport.yml
+++ b/test/cassettes/reports/createShipmentInvoiceReport.yml
@@ -1,0 +1,77 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/reports/shipment_invoice/'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+        body: 'start_date=2021-01-01&end_date=2021-01-02&type=shipment_invoice'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 3774dfbc61379a49e786b3ff00a63b20
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '293'
+            etag: 'W/"cc0e002ffdfa7d851bd06202277c8ead"'
+            x-request-id: 19fd09b4-0dbd-4e32-9759-fd75c79619dd
+            x-runtime: '0.039551'
+            x-node: bigweb5nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq 543ba58655', 'extlb1nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"shpinvrep_810e174f49af44c1805ccc82d53816cb","object":"ShipmentInvoiceReport","created_at":"2021-09-07T16:58:49Z","updated_at":"2021-09-07T16:58:49Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/reports/shipment_invoice/'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 779
+            request_size: 602
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.232416
+            namelookup_time: 0.001906
+            connect_time: 0.06123
+            pretransfer_time: 0.13219
+            size_upload: !!float 63
+            size_download: !!float 293
+            speed_download: !!float 1260
+            speed_upload: !!float 271
+            download_content_length: !!float 293
+            upload_content_length: !!float 63
+            starttransfer_time: 0.232384
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50436
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 132125
+            connect_time_us: 61230
+            namelookup_time_us: 1906
+            pretransfer_time_us: 132190
+            redirect_time_us: 0
+            starttransfer_time_us: 232384
+            total_time_us: 232416

--- a/test/cassettes/reports/createShipmentInvoiceReport.yml
+++ b/test/cassettes/reports/createShipmentInvoiceReport.yml
@@ -5,7 +5,7 @@
         url: 'https://api.easypost.com/v2/reports/shipment_invoice/'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            X-Client-User-Agent: ''
             User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
             Authorization: ''
             EasyPost-Version: '2'

--- a/test/cassettes/reports/createShipmentReport.yml
+++ b/test/cassettes/reports/createShipmentReport.yml
@@ -5,7 +5,7 @@
         url: 'https://api.easypost.com/v2/reports/shipment/'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            X-Client-User-Agent: ''
             User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
             Authorization: ''
             EasyPost-Version: '2'

--- a/test/cassettes/reports/createShipmentReport.yml
+++ b/test/cassettes/reports/createShipmentReport.yml
@@ -1,0 +1,77 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/reports/shipment/'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+        body: 'start_date=2021-01-01&end_date=2021-01-02&type=shipment'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 3774dfbd61379a48e786b3fb00a63a73
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '283'
+            etag: 'W/"d85ad54c0e4ee0d6c9d4f6f7b4066b2d"'
+            x-request-id: 8439cc0f-3c76-4240-ad10-03eb3498e2c7
+            x-runtime: '0.044387'
+            x-node: bigweb6nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq 543ba58655', 'extlb1nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"shprep_1c2b5100501646c783fa7ed9179098ff","object":"ShipmentReport","created_at":"2021-09-07T16:58:48Z","updated_at":"2021-09-07T16:58:48Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/reports/shipment/'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 779
+            request_size: 586
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.275592
+            namelookup_time: 0.012444
+            connect_time: 0.079331
+            pretransfer_time: 0.167652
+            size_upload: !!float 55
+            size_download: !!float 283
+            speed_download: !!float 1026
+            speed_upload: !!float 199
+            download_content_length: !!float 283
+            upload_content_length: !!float 55
+            starttransfer_time: 0.275498
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50432
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 167439
+            connect_time_us: 79331
+            namelookup_time_us: 12444
+            pretransfer_time_us: 167652
+            redirect_time_us: 0
+            starttransfer_time_us: 275498
+            total_time_us: 275592

--- a/test/cassettes/reports/createTrackerReport.yml
+++ b/test/cassettes/reports/createTrackerReport.yml
@@ -1,0 +1,77 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/reports/tracker/'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+        body: 'start_date=2021-01-01&end_date=2021-01-02&type=tracker'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 3774dfb861379a49e786b3fd00a63abc
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '282'
+            etag: 'W/"54b1d381e58fa08a7280d3435549f6bf"'
+            x-request-id: f0580179-7bf8-4d8e-8956-d8ba3bf2c3f6
+            x-runtime: '0.048567'
+            x-node: bigweb8nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq 543ba58655', 'extlb1nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"trkrep_f3a8b8c133ff4ebaaf185272ccd32e5c","object":"TrackerReport","created_at":"2021-09-07T16:58:49Z","updated_at":"2021-09-07T16:58:49Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/reports/tracker/'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 779
+            request_size: 584
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.24534
+            namelookup_time: 0.00168
+            connect_time: 0.061869
+            pretransfer_time: 0.133431
+            size_upload: !!float 54
+            size_download: !!float 282
+            speed_download: !!float 1149
+            speed_upload: !!float 220
+            download_content_length: !!float 282
+            upload_content_length: !!float 54
+            starttransfer_time: 0.245298
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50434
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 133396
+            connect_time_us: 61869
+            namelookup_time_us: 1680
+            pretransfer_time_us: 133431
+            redirect_time_us: 0
+            starttransfer_time_us: 245298
+            total_time_us: 245340

--- a/test/cassettes/reports/createTrackerReport.yml
+++ b/test/cassettes/reports/createTrackerReport.yml
@@ -5,7 +5,7 @@
         url: 'https://api.easypost.com/v2/reports/tracker/'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            X-Client-User-Agent: ''
             User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
             Authorization: ''
             EasyPost-Version: '2'

--- a/test/cassettes/reports/retrievePaymentLogReport.yml
+++ b/test/cassettes/reports/retrievePaymentLogReport.yml
@@ -5,7 +5,7 @@
         url: 'https://api.easypost.com/v2/reports/plrep_44432ab730e3410aad8cae818225226f'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            X-Client-User-Agent: ''
             User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
             Authorization: ''
             EasyPost-Version: '2'

--- a/test/cassettes/reports/retrievePaymentLogReport.yml
+++ b/test/cassettes/reports/retrievePaymentLogReport.yml
@@ -1,0 +1,76 @@
+
+-
+    request:
+        method: GET
+        url: 'https://api.easypost.com/v2/reports/plrep_44432ab730e3410aad8cae818225226f'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 3774dfba61379a92e786b42000a651cd
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '261'
+            etag: 'W/"d3f0dc075bfc66bd38da92f0612b9f17"'
+            x-request-id: deda32d7-ee39-482b-b596-f3a5091e9804
+            x-runtime: '0.034212'
+            x-node: bigweb6nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq 543ba58655', 'extlb1nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"plrep_44432ab730e3410aad8cae818225226f","object":"PaymentLogReport","created_at":"2021-09-07T16:58:49Z","updated_at":"2021-09-07T16:58:49Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"empty","url":null,"url_expires_at":null}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/reports/plrep_44432ab730e3410aad8cae818225226f'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 774
+            request_size: 490
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.472639
+            namelookup_time: 0.012805
+            connect_time: 0.116267
+            pretransfer_time: 0.226321
+            size_upload: !!float 0
+            size_download: !!float 261
+            speed_download: !!float 552
+            speed_upload: !!float 0
+            download_content_length: !!float 261
+            upload_content_length: !!float 0
+            starttransfer_time: 0.472541
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50446
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 226249
+            connect_time_us: 116267
+            namelookup_time_us: 12805
+            pretransfer_time_us: 226321
+            redirect_time_us: 0
+            starttransfer_time_us: 472541
+            total_time_us: 472639

--- a/test/cassettes/reports/retrieveRefundReport.yml
+++ b/test/cassettes/reports/retrieveRefundReport.yml
@@ -5,7 +5,7 @@
         url: 'https://api.easypost.com/v2/reports/refrep_eaf0cb1246a847c0b83e4d6c859a0b85'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            X-Client-User-Agent: ''
             User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
             Authorization: ''
             EasyPost-Version: '2'

--- a/test/cassettes/reports/retrieveRefundReport.yml
+++ b/test/cassettes/reports/retrieveRefundReport.yml
@@ -1,0 +1,76 @@
+
+-
+    request:
+        method: GET
+        url: 'https://api.easypost.com/v2/reports/refrep_eaf0cb1246a847c0b83e4d6c859a0b85'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 3774dfb961379b34e786b44300a6963c
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '665'
+            etag: 'W/"7e7856452e61683103b6bacf65f41321"'
+            x-request-id: 5c222ca5-a69a-40cb-aadd-ca742efe123e
+            x-runtime: '0.041363'
+            x-node: bigweb1nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq 543ba58655', 'extlb1nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"refrep_eaf0cb1246a847c0b83e4d6c859a0b85","object":"RefundReport","created_at":"2021-09-07T16:58:48Z","updated_at":"2021-09-07T16:58:50Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/refund_report/20210907/refrep_eaf0cb1246a847c0b83e4d6c859a0b85.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20210907%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210907T170244Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=b5a56a9f92ce578bc3a66025eda5372dfa210ab20d75eb69e8d65b22a4960bcb","url_expires_at":"2021-09-07T17:03:14Z"}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/reports/refrep_eaf0cb1246a847c0b83e4d6c859a0b85'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 774
+            request_size: 491
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.309156
+            namelookup_time: 0.051939
+            connect_time: 0.112876
+            pretransfer_time: 0.200764
+            size_upload: !!float 0
+            size_download: !!float 665
+            speed_download: !!float 2151
+            speed_upload: !!float 0
+            download_content_length: !!float 665
+            upload_content_length: !!float 0
+            starttransfer_time: 0.309046
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50458
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 200662
+            connect_time_us: 112876
+            namelookup_time_us: 51939
+            pretransfer_time_us: 200764
+            redirect_time_us: 0
+            starttransfer_time_us: 309046
+            total_time_us: 309156

--- a/test/cassettes/reports/retrieveShipmentReport.yml
+++ b/test/cassettes/reports/retrieveShipmentReport.yml
@@ -1,0 +1,151 @@
+
+-
+    request:
+        method: GET
+        url: 'https://api.easypost.com/v2/reports/shprep_1c2b5100501646c783fa7ed9179098ff'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 3774dfbd61379b35e786b44400a6964b
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '694'
+            etag: 'W/"d74fa53dd0fed1745aa540fd6b934f66"'
+            x-request-id: 566434c5-cb50-44f1-be96-e50ccc2fdcf0
+            x-runtime: '0.038089'
+            x-node: bigweb8nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq 543ba58655', 'extlb1nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"shprep_1c2b5100501646c783fa7ed9179098ff","object":"ShipmentReport","created_at":"2021-09-07T16:58:48Z","updated_at":"2021-09-07T16:58:48Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20210907/shprep_1c2b5100501646c783fa7ed9179098ff.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20210907%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210907T170245Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=25734f5d6fa3e67333c64f2bf92d6bd0936cf05989e02ad9654c40544aaa6b52","url_expires_at":"2021-09-07T17:03:15Z","include_children":false}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/reports/shprep_1c2b5100501646c783fa7ed9179098ff'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 774
+            request_size: 491
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.247384
+            namelookup_time: 0.001905
+            connect_time: 0.062445
+            pretransfer_time: 0.146675
+            size_upload: !!float 0
+            size_download: !!float 694
+            speed_download: !!float 2805
+            speed_upload: !!float 0
+            download_content_length: !!float 694
+            upload_content_length: !!float 0
+            starttransfer_time: 0.247339
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50459
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 146638
+            connect_time_us: 62445
+            namelookup_time_us: 1905
+            pretransfer_time_us: 146675
+            redirect_time_us: 0
+            starttransfer_time_us: 247339
+            total_time_us: 247384
+-
+    request:
+        method: GET
+        url: 'https://api.easypost.com/v2/reports/shpinvrep_810e174f49af44c1805ccc82d53816cb'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 3774dfbb61379b35e786b45c00a6966d
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '715'
+            etag: 'W/"9eca687f8f4db869cbd502dea9914a15"'
+            x-request-id: d6a1971f-7786-48ea-9cfc-193acc5fae53
+            x-runtime: '0.043877'
+            x-node: bigweb9nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq 543ba58655', 'extlb1nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"shpinvrep_810e174f49af44c1805ccc82d53816cb","object":"ShipmentInvoiceReport","created_at":"2021-09-07T16:58:49Z","updated_at":"2021-09-07T16:58:49Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_invoice_report/20210907/shpinvrep_810e174f49af44c1805ccc82d53816cb.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20210907%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210907T170245Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=ef1ef3bea790417678d0d44a052a80af353d43034f0c805e94adff02cfe0312e","url_expires_at":"2021-09-07T17:03:15Z","include_children":false}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/reports/shpinvrep_810e174f49af44c1805ccc82d53816cb'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 774
+            request_size: 494
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.290871
+            namelookup_time: 0.001844
+            connect_time: 0.062911
+            pretransfer_time: 0.183369
+            size_upload: !!float 0
+            size_download: !!float 715
+            speed_download: !!float 2458
+            speed_upload: !!float 0
+            download_content_length: !!float 715
+            upload_content_length: !!float 0
+            starttransfer_time: 0.290837
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50460
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 183318
+            connect_time_us: 62911
+            namelookup_time_us: 1844
+            pretransfer_time_us: 183369
+            redirect_time_us: 0
+            starttransfer_time_us: 290837
+            total_time_us: 290871

--- a/test/cassettes/reports/retrieveShipmentReport.yml
+++ b/test/cassettes/reports/retrieveShipmentReport.yml
@@ -5,7 +5,7 @@
         url: 'https://api.easypost.com/v2/reports/shprep_1c2b5100501646c783fa7ed9179098ff'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            X-Client-User-Agent: ''
             User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
             Authorization: ''
             EasyPost-Version: '2'

--- a/test/cassettes/reports/retrieveTrackerReport.yml
+++ b/test/cassettes/reports/retrieveTrackerReport.yml
@@ -1,0 +1,76 @@
+
+-
+    request:
+        method: GET
+        url: 'https://api.easypost.com/v2/reports/trkrep_f3a8b8c133ff4ebaaf185272ccd32e5c'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 3774dfbc61379b35e786b45d00a69680
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '692'
+            etag: 'W/"131feb5eb0a79106c72b563ca0558b1c"'
+            x-request-id: 4ad851a2-3f3a-4d48-90db-a4334fcc0f0e
+            x-runtime: '0.034730'
+            x-node: bigweb5nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq 543ba58655', 'extlb1nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"trkrep_f3a8b8c133ff4ebaaf185272ccd32e5c","object":"TrackerReport","created_at":"2021-09-07T16:58:49Z","updated_at":"2021-09-07T16:58:49Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20210907/trkrep_f3a8b8c133ff4ebaaf185272ccd32e5c.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20210907%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210907T170245Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=e63efadef3b00a8cb93224ff2a1f0e340925162023339517c793e18151c77315","url_expires_at":"2021-09-07T17:03:15Z","include_children":false}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/reports/trkrep_f3a8b8c133ff4ebaaf185272ccd32e5c'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 774
+            request_size: 491
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.238348
+            namelookup_time: 0.001631
+            connect_time: 0.06155
+            pretransfer_time: 0.141429
+            size_upload: !!float 0
+            size_download: !!float 692
+            speed_download: !!float 2903
+            speed_upload: !!float 0
+            download_content_length: !!float 692
+            upload_content_length: !!float 0
+            starttransfer_time: 0.238305
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50461
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 141356
+            connect_time_us: 61550
+            namelookup_time_us: 1631
+            pretransfer_time_us: 141429
+            redirect_time_us: 0
+            starttransfer_time_us: 238305
+            total_time_us: 238348

--- a/test/cassettes/reports/retrieveTrackerReport.yml
+++ b/test/cassettes/reports/retrieveTrackerReport.yml
@@ -5,7 +5,7 @@
         url: 'https://api.easypost.com/v2/reports/trkrep_f3a8b8c133ff4ebaaf185272ccd32e5c'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            X-Client-User-Agent: ''
             User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
             Authorization: ''
             EasyPost-Version: '2'

--- a/test/cassettes/shipments/buy.yml
+++ b/test/cassettes/shipments/buy.yml
@@ -1,0 +1,77 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/shipments/shp_cc46dc3741114299ba02a99b8c483645/buy'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: ''
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+        body: rate%5Bid%5D=rate_94ad5814f2be4c9e97dc6256b8ec940a
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 8b9087be613be558e788ddc60042af06
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '9830'
+            etag: 'W/"97f50f0295b03d812871cfa69162af9c"'
+            x-request-id: a4bc860b-5c06-4437-9b1b-5b30629cad64
+            x-runtime: '0.927170'
+            x-node: bigweb1nuq
+            x-version-label: easypost-202109102144-93513c99cc-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq 543ba58655', 'extlb2nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"created_at":"2021-09-07T17:14:19Z","is_return":false,"messages":[{"carrier":"Canpar","carrier_account_id":"ca_58451e27b5bc4f6cb419d9be15705847","type":"rate_error","message":"Unable to retrieve Canpar rates for non-CA origin shipments."}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9405500895232079129637","updated_at":"2021-09-10T23:08:09Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_9aaadb0761084fb290098a7c04468af7","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_490ff015123b49d9832d88dd0815b338","object":"Parcel","created_at":"2021-09-07T17:14:19Z","updated_at":"2021-09-07T17:14:19Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_e705fa9a1a274ed58f2df7d295e833ca","created_at":"2021-09-10T23:08:09Z","updated_at":"2021-09-10T23:08:09Z","date_advance":0,"integrated_form":"none","label_date":"2021-09-10T23:08:09Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20210910/4f13576d8fa043b89147fc6645453354.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_8d341242c91c458ab336fddb0f4e7381","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.00","currency":"USD","retail_rate":"26.75","retail_currency":"USD","list_rate":"23.00","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_94ad5814f2be4c9e97dc6256b8ec940a","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.16","currency":"USD","retail_rate":"7.70","retail_currency":"USD","list_rate":"7.16","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_8720740b8efd44d3b9ad210456b3c107","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.01","currency":"USD","retail_rate":"7.01","retail_currency":"USD","list_rate":"7.01","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_8591d7eef54c4c5195e20ae0f772fb2e","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"First","carrier":"USPS","rate":"5.19","currency":"USD","retail_rate":"5.19","retail_currency":"USD","list_rate":"5.19","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_242be45f50a64cc6934c3cc7ce9019db","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"19.18","currency":"USD","retail_rate":"19.18","retail_currency":"USD","list_rate":"19.42","list_currency":"USD","delivery_days":3,"delivery_date":"2021-09-10T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":3,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_4f781fb5782d4eb383ab8f68b8b52b83","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"73.23","currency":"USD","retail_rate":"73.23","retail_currency":"USD","list_rate":"75.33","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T08:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_623b5dc9b66144a09c33b05e2b3816bb","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Ground","carrier":"UPS","rate":"11.14","currency":"USD","retail_rate":"11.14","retail_currency":"USD","list_rate":"14.59","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_ebfff836cf984fb7978e370711283ef8","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"37.61","currency":"USD","retail_rate":"37.61","retail_currency":"USD","list_rate":"40.46","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_a12a01061a4441e388d5ae935e2e8659","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"40.68","currency":"USD","retail_rate":"40.68","retail_currency":"USD","list_rate":"42.78","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T10:30:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_36e12bc1f5a849f4a114fa73950ba894","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"26.51","currency":"USD","retail_rate":"26.51","retail_currency":"USD","list_rate":"27.03","list_currency":"USD","delivery_days":2,"delivery_date":"2021-09-09T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_94ad5814f2be4c9e97dc6256b8ec940a","object":"Rate","created_at":"2021-09-10T23:08:09Z","updated_at":"2021-09-10T23:08:09Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.16","currency":"USD","retail_rate":"7.70","retail_currency":"USD","list_rate":"7.16","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},"tracker":{"id":"trk_b89db068e9f94b4190099bf69b8b7e71","object":"Tracker","mode":"test","tracking_code":"9405500895232079129637","status":"unknown","status_detail":"unknown","created_at":"2021-09-10T23:08:09Z","updated_at":"2021-09-10T23:08:09Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2I4OWRiMDY4ZTlmOTRiNDE5MDA5OWJmNjliOGI3ZTcx"},"to_address":{"id":"adr_45484e572d1d466799518b77628f322b","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-10T23:08:09+00:00","name":null,"company":null,"street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_9aaadb0761084fb290098a7c04468af7","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_45484e572d1d466799518b77628f322b","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-10T23:08:09+00:00","name":null,"company":null,"street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"7.16000","charged":true,"refunded":false}],"id":"shp_cc46dc3741114299ba02a99b8c483645","object":"Shipment"}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/shipments/shp_cc46dc3741114299ba02a99b8c483645/buy'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 775
+            request_size: 614
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 1.27774
+            namelookup_time: 0.012679
+            connect_time: 0.079736
+            pretransfer_time: 0.164645
+            size_upload: !!float 50
+            size_download: !!float 9830
+            speed_download: !!float 7693
+            speed_upload: !!float 39
+            download_content_length: !!float 9830
+            upload_content_length: !!float 50
+            starttransfer_time: 1.277659
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.130
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.5
+            local_port: 54295
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 164506
+            connect_time_us: 79736
+            namelookup_time_us: 12679
+            pretransfer_time_us: 164645
+            redirect_time_us: 0
+            starttransfer_time_us: 1277659
+            total_time_us: 1277740

--- a/test/cassettes/shipments/create.yml
+++ b/test/cassettes/shipments/create.yml
@@ -1,0 +1,79 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/shipments'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+        body: 'shipment%5Bto_address%5D%5Bstreet1%5D=388+Townsend+St&shipment%5Bto_address%5D%5Bstreet2%5D=Apt+20&shipment%5Bto_address%5D%5Bcity%5D=San+Francisco&shipment%5Bto_address%5D%5Bstate%5D=CA&shipment%5Bto_address%5D%5Bzip%5D=94107&shipment%5Bfrom_address%5D%5Bstreet1%5D=388+Townsend+St&shipment%5Bfrom_address%5D%5Bstreet2%5D=Apt+20&shipment%5Bfrom_address%5D%5Bcity%5D=San+Francisco&shipment%5Bfrom_address%5D%5Bstate%5D=CA&shipment%5Bfrom_address%5D%5Bzip%5D=94107&shipment%5Bparcel%5D%5Blength%5D=10&shipment%5Bparcel%5D%5Bwidth%5D=8&shipment%5Bparcel%5D%5Bheight%5D=4&shipment%5Bparcel%5D%5Bweight%5D=15'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 3774dfbc61379debe786b7dd00a79f5d
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            location: /api/v2/shipments/shp_cc46dc3741114299ba02a99b8c483645
+            content-type: 'application/json; charset=utf-8'
+            content-length: '7758'
+            etag: 'W/"f09b298391cb04e8b22c86b16c7f9e53"'
+            x-request-id: 6e215e00-922f-4c4e-90d9-aacd73ccaa13
+            x-runtime: '1.196013'
+            x-node: bigweb7nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-canary: direct
+            x-proxied: ['intlb2nuq 543ba58655', 'extlb1nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"created_at":"2021-09-07T17:14:19Z","is_return":false,"messages":[{"carrier":"Canpar","carrier_account_id":"ca_58451e27b5bc4f6cb419d9be15705847","type":"rate_error","message":"Unable to retrieve Canpar rates for non-CA origin shipments."}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2021-09-07T17:14:20Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_9aaadb0761084fb290098a7c04468af7","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_490ff015123b49d9832d88dd0815b338","object":"Parcel","created_at":"2021-09-07T17:14:19Z","updated_at":"2021-09-07T17:14:19Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_8d341242c91c458ab336fddb0f4e7381","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.00","currency":"USD","retail_rate":"26.75","retail_currency":"USD","list_rate":"23.00","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_94ad5814f2be4c9e97dc6256b8ec940a","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.16","currency":"USD","retail_rate":"7.70","retail_currency":"USD","list_rate":"7.16","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_8720740b8efd44d3b9ad210456b3c107","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.01","currency":"USD","retail_rate":"7.01","retail_currency":"USD","list_rate":"7.01","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_8591d7eef54c4c5195e20ae0f772fb2e","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"First","carrier":"USPS","rate":"5.19","currency":"USD","retail_rate":"5.19","retail_currency":"USD","list_rate":"5.19","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_242be45f50a64cc6934c3cc7ce9019db","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"19.18","currency":"USD","retail_rate":"19.18","retail_currency":"USD","list_rate":"19.42","list_currency":"USD","delivery_days":3,"delivery_date":"2021-09-10T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":3,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_4f781fb5782d4eb383ab8f68b8b52b83","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"73.23","currency":"USD","retail_rate":"73.23","retail_currency":"USD","list_rate":"75.33","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T08:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_623b5dc9b66144a09c33b05e2b3816bb","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Ground","carrier":"UPS","rate":"11.14","currency":"USD","retail_rate":"11.14","retail_currency":"USD","list_rate":"14.59","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_ebfff836cf984fb7978e370711283ef8","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"37.61","currency":"USD","retail_rate":"37.61","retail_currency":"USD","list_rate":"40.46","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_a12a01061a4441e388d5ae935e2e8659","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"40.68","currency":"USD","retail_rate":"40.68","retail_currency":"USD","list_rate":"42.78","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T10:30:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_36e12bc1f5a849f4a114fa73950ba894","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"26.51","currency":"USD","retail_rate":"26.51","retail_currency":"USD","list_rate":"27.03","list_currency":"USD","delivery_days":2,"delivery_date":"2021-09-09T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_45484e572d1d466799518b77628f322b","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_9aaadb0761084fb290098a7c04468af7","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_45484e572d1d466799518b77628f322b","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_cc46dc3741114299ba02a99b8c483645","object":"Shipment"}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/shipments'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 864
+            request_size: 1128
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 1.470423
+            namelookup_time: 0.050117
+            connect_time: 0.109508
+            pretransfer_time: 0.18349
+            size_upload: !!float 604
+            size_download: !!float 7758
+            speed_download: !!float 5276
+            speed_upload: !!float 410
+            download_content_length: !!float 7758
+            upload_content_length: !!float 604
+            starttransfer_time: 1.470315
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50506
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 183448
+            connect_time_us: 109508
+            namelookup_time_us: 50117
+            pretransfer_time_us: 183490
+            redirect_time_us: 0
+            starttransfer_time_us: 1470315
+            total_time_us: 1470423

--- a/test/cassettes/shipments/create.yml
+++ b/test/cassettes/shipments/create.yml
@@ -5,7 +5,7 @@
         url: 'https://api.easypost.com/v2/shipments'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            X-Client-User-Agent: ''
             User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
             Authorization: ''
             EasyPost-Version: '2'

--- a/test/cassettes/shipments/retrieve.yml
+++ b/test/cassettes/shipments/retrieve.yml
@@ -5,7 +5,7 @@
         url: 'https://api.easypost.com/v2/shipments/shp_cc46dc3741114299ba02a99b8c483645'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            X-Client-User-Agent: ''
             User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
             Authorization: ''
             EasyPost-Version: '2'

--- a/test/cassettes/shipments/retrieve.yml
+++ b/test/cassettes/shipments/retrieve.yml
@@ -1,0 +1,76 @@
+
+-
+    request:
+        method: GET
+        url: 'https://api.easypost.com/v2/shipments/shp_cc46dc3741114299ba02a99b8c483645'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 3774dfbc61379dede786b7de00a79ff0
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '7758'
+            etag: 'W/"f09b298391cb04e8b22c86b16c7f9e53"'
+            x-request-id: 5040b66e-ff03-42ad-92cf-e05839c4b4fa
+            x-runtime: '0.099349'
+            x-node: bigweb3nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq 543ba58655', 'extlb1nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"created_at":"2021-09-07T17:14:19Z","is_return":false,"messages":[{"carrier":"Canpar","carrier_account_id":"ca_58451e27b5bc4f6cb419d9be15705847","type":"rate_error","message":"Unable to retrieve Canpar rates for non-CA origin shipments."}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2021-09-07T17:14:20Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_9aaadb0761084fb290098a7c04468af7","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_490ff015123b49d9832d88dd0815b338","object":"Parcel","created_at":"2021-09-07T17:14:19Z","updated_at":"2021-09-07T17:14:19Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_8d341242c91c458ab336fddb0f4e7381","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.00","currency":"USD","retail_rate":"26.75","retail_currency":"USD","list_rate":"23.00","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_94ad5814f2be4c9e97dc6256b8ec940a","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.16","currency":"USD","retail_rate":"7.70","retail_currency":"USD","list_rate":"7.16","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_8720740b8efd44d3b9ad210456b3c107","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.01","currency":"USD","retail_rate":"7.01","retail_currency":"USD","list_rate":"7.01","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_8591d7eef54c4c5195e20ae0f772fb2e","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"First","carrier":"USPS","rate":"5.19","currency":"USD","retail_rate":"5.19","retail_currency":"USD","list_rate":"5.19","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_242be45f50a64cc6934c3cc7ce9019db","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"19.18","currency":"USD","retail_rate":"19.18","retail_currency":"USD","list_rate":"19.42","list_currency":"USD","delivery_days":3,"delivery_date":"2021-09-10T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":3,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_4f781fb5782d4eb383ab8f68b8b52b83","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"73.23","currency":"USD","retail_rate":"73.23","retail_currency":"USD","list_rate":"75.33","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T08:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_623b5dc9b66144a09c33b05e2b3816bb","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Ground","carrier":"UPS","rate":"11.14","currency":"USD","retail_rate":"11.14","retail_currency":"USD","list_rate":"14.59","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_ebfff836cf984fb7978e370711283ef8","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"37.61","currency":"USD","retail_rate":"37.61","retail_currency":"USD","list_rate":"40.46","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_a12a01061a4441e388d5ae935e2e8659","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"40.68","currency":"USD","retail_rate":"40.68","retail_currency":"USD","list_rate":"42.78","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T10:30:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_36e12bc1f5a849f4a114fa73950ba894","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"26.51","currency":"USD","retail_rate":"26.51","retail_currency":"USD","list_rate":"27.03","list_currency":"USD","delivery_days":2,"delivery_date":"2021-09-09T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_45484e572d1d466799518b77628f322b","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_9aaadb0761084fb290098a7c04468af7","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_45484e572d1d466799518b77628f322b","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_cc46dc3741114299ba02a99b8c483645","object":"Shipment"}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/shipments/shp_cc46dc3741114299ba02a99b8c483645'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 775
+            request_size: 490
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.307879
+            namelookup_time: 0.001624
+            connect_time: 0.062255
+            pretransfer_time: 0.143319
+            size_upload: !!float 0
+            size_download: !!float 7758
+            speed_download: !!float 25198
+            speed_upload: !!float 0
+            download_content_length: !!float 7758
+            upload_content_length: !!float 0
+            starttransfer_time: 0.307829
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50507
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 143273
+            connect_time_us: 62255
+            namelookup_time_us: 1624
+            pretransfer_time_us: 143319
+            redirect_time_us: 0
+            starttransfer_time_us: 307829
+            total_time_us: 307879

--- a/test/cassettes/shipments/smartrates.yml
+++ b/test/cassettes/shipments/smartrates.yml
@@ -5,7 +5,7 @@
         url: 'https://api.easypost.com/v2/shipments'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            X-Client-User-Agent: ''
             User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
             Authorization: ''
             EasyPost-Version: '2'

--- a/test/cassettes/shipments/smartrates.yml
+++ b/test/cassettes/shipments/smartrates.yml
@@ -1,0 +1,154 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/shipments'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+        body: 'shipment%5Bto_address%5D%5Bstreet1%5D=388+Townsend+St&shipment%5Bto_address%5D%5Bstreet2%5D=Apt+20&shipment%5Bto_address%5D%5Bcity%5D=San+Francisco&shipment%5Bto_address%5D%5Bstate%5D=CA&shipment%5Bto_address%5D%5Bzip%5D=94107&shipment%5Bfrom_address%5D%5Bstreet1%5D=388+Townsend+St&shipment%5Bfrom_address%5D%5Bstreet2%5D=Apt+20&shipment%5Bfrom_address%5D%5Bcity%5D=San+Francisco&shipment%5Bfrom_address%5D%5Bstate%5D=CA&shipment%5Bfrom_address%5D%5Bzip%5D=94107&shipment%5Bparcel%5D%5Blength%5D=10&shipment%5Bparcel%5D%5Bwidth%5D=8&shipment%5Bparcel%5D%5Bheight%5D=4&shipment%5Bparcel%5D%5Bweight%5D=15'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 3774dfba61379dede786b7df00a7a00e
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            location: /api/v2/shipments/shp_280e141790b24462b6b1da283d6f5d53
+            content-type: 'application/json; charset=utf-8'
+            content-length: '7758'
+            etag: 'W/"69bc287de54402795cc45412e7af3f37"'
+            x-request-id: 5762217d-c10f-40a3-a74e-5a87922e5524
+            x-runtime: '1.158583'
+            x-node: bigweb7nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-canary: direct
+            x-proxied: ['intlb2nuq 543ba58655', 'extlb1nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"created_at":"2021-09-07T17:14:21Z","is_return":false,"messages":[{"carrier":"Canpar","carrier_account_id":"ca_58451e27b5bc4f6cb419d9be15705847","type":"rate_error","message":"Unable to retrieve Canpar rates for non-CA origin shipments."}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2021-09-07T17:14:22Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_4199aebbb60b455a868c9bc9aa579fa4","object":"Address","created_at":"2021-09-07T17:14:21+00:00","updated_at":"2021-09-07T17:14:21+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_f76e75bf9c7348498d0dc8179278b3fa","object":"Parcel","created_at":"2021-09-07T17:14:21Z","updated_at":"2021-09-07T17:14:21Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_cb93540531954f3f9f79af5e36cdcac3","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.00","currency":"USD","retail_rate":"26.75","retail_currency":"USD","list_rate":"23.00","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_19d4a686529b4afda7a8a127321f649b","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.16","currency":"USD","retail_rate":"7.70","retail_currency":"USD","list_rate":"7.16","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_d321ceb31f354da6b8c79189ffc27465","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.01","currency":"USD","retail_rate":"7.01","retail_currency":"USD","list_rate":"7.01","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_a3a4a2bf4e284013804570da1a8514e0","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"First","carrier":"USPS","rate":"5.19","currency":"USD","retail_rate":"5.19","retail_currency":"USD","list_rate":"5.19","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_cd5745337b0e45cd8d84ab7750f4b059","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"19.18","currency":"USD","retail_rate":"19.18","retail_currency":"USD","list_rate":"19.42","list_currency":"USD","delivery_days":3,"delivery_date":"2021-09-10T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":3,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_b712faf9c2784cc08e43bac3ee23923c","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"73.23","currency":"USD","retail_rate":"73.23","retail_currency":"USD","list_rate":"75.33","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T08:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_5305640e68164ee39c8f3642369de21e","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"Ground","carrier":"UPS","rate":"11.14","currency":"USD","retail_rate":"11.14","retail_currency":"USD","list_rate":"14.59","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_d753e4e8ad134e758b14db8f7d261d7e","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"37.61","currency":"USD","retail_rate":"37.61","retail_currency":"USD","list_rate":"40.46","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_2d38436fd47f4d569f1d262966da9485","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"40.68","currency":"USD","retail_rate":"40.68","retail_currency":"USD","list_rate":"42.78","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T10:30:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_017c5a5781084012823c89c1a684811e","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"26.51","currency":"USD","retail_rate":"26.51","retail_currency":"USD","list_rate":"27.03","list_currency":"USD","delivery_days":2,"delivery_date":"2021-09-09T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":2,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_fe82e7b28d5842c8bdd4036d195e3cb9","object":"Address","created_at":"2021-09-07T17:14:21+00:00","updated_at":"2021-09-07T17:14:21+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_4199aebbb60b455a868c9bc9aa579fa4","object":"Address","created_at":"2021-09-07T17:14:21+00:00","updated_at":"2021-09-07T17:14:21+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_fe82e7b28d5842c8bdd4036d195e3cb9","object":"Address","created_at":"2021-09-07T17:14:21+00:00","updated_at":"2021-09-07T17:14:21+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_280e141790b24462b6b1da283d6f5d53","object":"Shipment"}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/shipments'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 864
+            request_size: 1128
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 1.364615
+            namelookup_time: 0.001127
+            connect_time: 0.0599
+            pretransfer_time: 0.140029
+            size_upload: !!float 604
+            size_download: !!float 7758
+            speed_download: !!float 5685
+            speed_upload: !!float 442
+            download_content_length: !!float 7758
+            upload_content_length: !!float 604
+            starttransfer_time: 1.364545
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50508
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 139954
+            connect_time_us: 59900
+            namelookup_time_us: 1127
+            pretransfer_time_us: 140029
+            redirect_time_us: 0
+            starttransfer_time_us: 1364545
+            total_time_us: 1364615
+-
+    request:
+        method: GET
+        url: 'https://api.easypost.com/v2/shipments/shp_280e141790b24462b6b1da283d6f5d53/smartrate'
+        headers:
+            Host: api.easypost.com
+            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Authorization: ''
+            EasyPost-Version: '2'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 3774dfba61379deee786b7e000a7a0a2
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '6447'
+            etag: 'W/"4eb49ff0723a26dab28ecc7d33e46aca"'
+            x-request-id: 0c75c757-efd5-4b4e-a034-74b94c401309
+            x-runtime: '0.095307'
+            x-node: bigweb1nuq
+            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq 543ba58655', 'extlb1nuq 543ba58655']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-09-07T17:14:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_cb93540531954f3f9f79af5e36cdcac3","list_currency":"USD","list_rate":23.0,"mode":"test","object":"Rate","rate":23.0,"retail_currency":"USD","retail_rate":26.75,"service":"Express","shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":3,"percentile_99":4},"updated_at":"2021-09-07T17:14:22Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-09-07T17:14:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_19d4a686529b4afda7a8a127321f649b","list_currency":"USD","list_rate":7.16,"mode":"test","object":"Rate","rate":7.16,"retail_currency":"USD","retail_rate":7.7,"service":"Priority","shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2021-09-07T17:14:22Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-09-07T17:14:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_d321ceb31f354da6b8c79189ffc27465","list_currency":"USD","list_rate":7.01,"mode":"test","object":"Rate","rate":7.01,"retail_currency":"USD","retail_rate":7.01,"service":"ParcelSelect","shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":3,"percentile_95":4,"percentile_97":5,"percentile_99":9},"updated_at":"2021-09-07T17:14:22Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-09-07T17:14:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_a3a4a2bf4e284013804570da1a8514e0","list_currency":"USD","list_rate":5.19,"mode":"test","object":"Rate","rate":5.19,"retail_currency":"USD","retail_rate":5.19,"service":"First","shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":2,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2021-09-07T17:14:22Z"},{"id":"rate_cd5745337b0e45cd8d84ab7750f4b059","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"19.18","currency":"USD","retail_rate":"19.18","retail_currency":"USD","list_rate":"19.42","list_currency":"USD","delivery_days":3,"delivery_date":"2021-09-10T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":3,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":3,"percentile_75":3,"percentile_85":3,"percentile_90":3,"percentile_95":3,"percentile_97":3,"percentile_99":3}},{"id":"rate_b712faf9c2784cc08e43bac3ee23923c","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"73.23","currency":"USD","retail_rate":"73.23","retail_currency":"USD","list_rate":"75.33","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T08:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":1}},{"id":"rate_5305640e68164ee39c8f3642369de21e","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"Ground","carrier":"UPS","rate":"11.14","currency":"USD","retail_rate":"11.14","retail_currency":"USD","list_rate":"14.59","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":1}},{"id":"rate_d753e4e8ad134e758b14db8f7d261d7e","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"37.61","currency":"USD","retail_rate":"37.61","retail_currency":"USD","list_rate":"40.46","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":1}},{"id":"rate_2d38436fd47f4d569f1d262966da9485","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"40.68","currency":"USD","retail_rate":"40.68","retail_currency":"USD","list_rate":"42.78","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T10:30:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":1}},{"id":"rate_017c5a5781084012823c89c1a684811e","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"26.51","currency":"USD","retail_rate":"26.51","retail_currency":"USD","list_rate":"27.03","list_currency":"USD","delivery_days":2,"delivery_date":"2021-09-09T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":2,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":2,"percentile_75":2,"percentile_85":2,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":2}}]}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/shipments/shp_280e141790b24462b6b1da283d6f5d53/smartrate'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 775
+            request_size: 500
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.306874
+            namelookup_time: 0.001937
+            connect_time: 0.062354
+            pretransfer_time: 0.148083
+            size_upload: !!float 0
+            size_download: !!float 6447
+            speed_download: !!float 21008
+            speed_upload: !!float 0
+            download_content_length: !!float 6447
+            upload_content_length: !!float 0
+            starttransfer_time: 0.306733
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.9
+            local_port: 50509
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 148028
+            connect_time_us: 62354
+            namelookup_time_us: 1937
+            pretransfer_time_us: 148083
+            redirect_time_us: 0
+            starttransfer_time_us: 306733
+            total_time_us: 306874


### PR DESCRIPTION
This PR adds long overdue `VCR` support to the PHP client library. This carries multiple benefits:

1. Consistent tests. We can now replay HTTP responses instead of hitting the live API on every test run
2. We can remove the poorly constructed "random date" logic in the reports tests which is now much less flakey
3. We can assert real values for items such as SmartRate integers on delivery days because we can return the same value each time

This PR includes another library called `php-vcr-sanitizer` that I personally contributed to that redacts items such as the `Authorization` header so we don't expose API keys in the cassettes. This library is needed because `php-vcr` is not privacy conscious out of the box.

The hardcoded API Key was removed from tests and replaced with `getenv` to grab the `API_KEY` environment variable. Documentation and CI were updated appropriately.

We also remove testing on PHP 7.2 as it's EOL and bump PHP Unit to v9 to better support newer versions of PHP and as this also drops support for 7.2.