### PR TITLE
fix: json encode bodies instead of urlencoding

### DIFF
--- a/test/EasyPost/Test/ReportTest.php
+++ b/test/EasyPost/Test/ReportTest.php
@@ -41,8 +41,8 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('reports/createPaymentLogReport.yml');
 
         $payment_log_report = Report::create(array(
-            "start_date" => "2021-01-01",
-            "end_date" => "2021-01-02",
+            "start_date" => "2021-01-02",
+            "end_date" => "2021-01-03",
             "type" => "payment_log"
         ));
 
@@ -64,8 +64,8 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('reports/createRefundReport.yml');
 
         $refund_report = Report::create(array(
-            "start_date" => "2021-01-01",
-            "end_date" => "2021-01-02",
+            "start_date" => "2021-01-02",
+            "end_date" => "2021-01-03",
             "type" => "refund"
         ));
 
@@ -87,8 +87,8 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('reports/createShipmentReport.yml');
 
         $shipment_report = Report::create(array(
-            "start_date" => "2021-01-01",
-            "end_date" => "2021-01-02",
+            "start_date" => "2021-01-02",
+            "end_date" => "2021-01-03",
             "type" => "shipment"
         ));
 
@@ -110,8 +110,8 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('reports/createShipmentInvoiceReport.yml');
 
         $shipment_invoice_report = Report::create(array(
-            "start_date" => "2021-01-01",
-            "end_date" => "2021-01-02",
+            "start_date" => "2021-01-02",
+            "end_date" => "2021-01-03",
             "type" => "shipment_invoice"
         ));
 
@@ -133,8 +133,8 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('reports/createTrackerReport.yml');
 
         $tracker_report = Report::create(array(
-            "start_date" => "2021-01-01",
-            "end_date" => "2021-01-02",
+            "start_date" => "2021-01-02",
+            "end_date" => "2021-01-03",
             "type" => "tracker"
         ));
 

--- a/test/EasyPost/Test/ShipmentTest.php
+++ b/test/EasyPost/Test/ShipmentTest.php
@@ -106,7 +106,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('shipments/buy.yml');
 
         $shipment->buy(array(
-            'id' => 'rate_94ad5814f2be4c9e97dc6256b8ec940a',
+            'rate' => $shipment->lowest_rate(),
         ));
 
         $this->assertNotNull($shipment->postage_label);
@@ -154,6 +154,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($smartrates[0]['time_in_transit']['percentile_90'], 2);
         $this->assertEquals($smartrates[0]['time_in_transit']['percentile_95'], 2);
         $this->assertEquals($smartrates[0]['time_in_transit']['percentile_97'], 3);
-        $this->assertEquals($smartrates[0]['time_in_transit']['percentile_99'], 4);
+        $this->assertEquals($smartrates[0]['time_in_transit']['percentile_99'], 5);
     }
 }

--- a/test/cassettes/addresses/create.yml
+++ b/test/cassettes/addresses/create.yml
@@ -5,11 +5,13 @@
         url: 'https://api.easypost.com/v2/addresses'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
-        body: 'address%5Bstreet1%5D=388+Townsend+St&address%5Bstreet2%5D=Apt+20&address%5Bcity%5D=San+Francisco&address%5Bstate%5D=CA&address%5Bzip%5D=94107'
+        body: '{"address":{"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107"}}'
     response:
         status:
             http_version: '1.1'
@@ -22,57 +24,57 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 917ccb3f61379629e786af7e009e7905
+            x-ep-request-uuid: 8d29b69361578bbbe78bb42b003aed86
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
-            location: /api/v2/addresses/adr_ee8ef1e75fa842e68bb9688f2e78f9f0
+            location: /api/v2/addresses/adr_059da1d447734818bee9a1a2fa429230
             content-type: 'application/json; charset=utf-8'
             content-length: '429'
-            etag: 'W/"590bb5c4349e8e6b32b4e63c2dc70e7e"'
-            x-request-id: dd8933f3-e203-4549-97a7-9f836b7c1b63
-            x-runtime: '0.037233'
-            x-node: bigweb4nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            etag: 'W/"8a84928b0f256fa81df9d80b69ef7c60"'
+            x-request-id: 025de43a-2840-4d07-bdd0-99543de1234c
+            x-runtime: '0.033085'
+            x-node: bigweb5nuq
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 543ba58655', 'extlb2nuq 543ba58655']
+            x-proxied: ['intlb1nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"adr_ee8ef1e75fa842e68bb9688f2e78f9f0","object":"Address","created_at":"2021-09-07T16:41:13+00:00","updated_at":"2021-09-07T16:41:13+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
+        body: '{"id":"adr_059da1d447734818bee9a1a2fa429230","object":"Address","created_at":"2021-10-01T22:29:15+00:00","updated_at":"2021-10-01T22:29:15+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
         curl_info:
             url: 'https://api.easypost.com/v2/addresses'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
             header_size: 845
-            request_size: 665
+            request_size: 630
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.255859
-            namelookup_time: 0.008096
-            connect_time: 0.074502
-            pretransfer_time: 0.15727
-            size_upload: !!float 141
+            total_time: 0.290406
+            namelookup_time: 0.044905
+            connect_time: 0.109719
+            pretransfer_time: 0.194584
+            size_upload: !!float 110
             size_download: !!float 429
-            speed_download: !!float 1676
-            speed_upload: !!float 551
+            speed_download: !!float 1477
+            speed_upload: !!float 378
             download_content_length: !!float 429
-            upload_content_length: !!float 141
-            starttransfer_time: 0.255781
+            upload_content_length: !!float 110
+            starttransfer_time: 0.290299
             redirect_time: !!float 0
             redirect_url: ''
             primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50318
+            local_ip: 10.130.6.13
+            local_port: 59817
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 157215
-            connect_time_us: 74502
-            namelookup_time_us: 8096
-            pretransfer_time_us: 157270
+            appconnect_time_us: 194515
+            connect_time_us: 109719
+            namelookup_time_us: 44905
+            pretransfer_time_us: 194584
             redirect_time_us: 0
-            starttransfer_time_us: 255781
-            total_time_us: 255859
+            starttransfer_time_us: 290299
+            total_time_us: 290406

--- a/test/cassettes/addresses/retrieve.yml
+++ b/test/cassettes/addresses/retrieve.yml
@@ -2,12 +2,14 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/addresses/adr_ee8ef1e75fa842e68bb9688f2e78f9f0'
+        url: 'https://api.easypost.com/v2/addresses/adr_059da1d447734818bee9a1a2fa429230'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
     response:
         status:
@@ -21,56 +23,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 917ccb4161379c70e786b49f00a093a4
+            x-ep-request-uuid: 8d29b69961578bbbe78bb42c003aeda7
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '429'
-            etag: 'W/"590bb5c4349e8e6b32b4e63c2dc70e7e"'
-            x-request-id: c2ed6931-75f9-4195-a611-d26340ce6ea5
-            x-runtime: '0.022779'
-            x-node: bigweb8nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            etag: 'W/"8a84928b0f256fa81df9d80b69ef7c60"'
+            x-request-id: 67c6b326-9644-4ebd-ab31-480b70e325d9
+            x-runtime: '0.024227'
+            x-node: bigweb6nuq
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 543ba58655', 'extlb2nuq 543ba58655']
+            x-proxied: ['intlb2nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"adr_ee8ef1e75fa842e68bb9688f2e78f9f0","object":"Address","created_at":"2021-09-07T16:41:13+00:00","updated_at":"2021-09-07T16:41:13+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
+        body: '{"id":"adr_059da1d447734818bee9a1a2fa429230","object":"Address","created_at":"2021-10-01T22:29:15+00:00","updated_at":"2021-10-01T22:29:15+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
         curl_info:
-            url: 'https://api.easypost.com/v2/addresses/adr_ee8ef1e75fa842e68bb9688f2e78f9f0'
+            url: 'https://api.easypost.com/v2/addresses/adr_059da1d447734818bee9a1a2fa429230'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 774
-            request_size: 490
+            request_size: 535
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.301913
-            namelookup_time: 0.047044
-            connect_time: 0.109122
-            pretransfer_time: 0.216986
+            total_time: 0.224275
+            namelookup_time: 0.001475
+            connect_time: 0.06067
+            pretransfer_time: 0.138363
             size_upload: !!float 0
             size_download: !!float 429
-            speed_download: !!float 1420
+            speed_download: !!float 1912
             speed_upload: !!float 0
             download_content_length: !!float 429
             upload_content_length: !!float 0
-            starttransfer_time: 0.301812
+            starttransfer_time: 0.224243
             redirect_time: !!float 0
             redirect_url: ''
             primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50481
+            local_ip: 10.130.6.13
+            local_port: 59818
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 216887
-            connect_time_us: 109122
-            namelookup_time_us: 47044
-            pretransfer_time_us: 216986
+            appconnect_time_us: 138332
+            connect_time_us: 60670
+            namelookup_time_us: 1475
+            pretransfer_time_us: 138363
             redirect_time_us: 0
-            starttransfer_time_us: 301812
-            total_time_us: 301913
+            starttransfer_time_us: 224243
+            total_time_us: 224275

--- a/test/cassettes/parcels/create.yml
+++ b/test/cassettes/parcels/create.yml
@@ -5,11 +5,13 @@
         url: 'https://api.easypost.com/v2/parcels'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
-        body: 'parcel%5Blength%5D=10&parcel%5Bwidth%5D=8&parcel%5Bheight%5D=4&parcel%5Bweight%5D=15'
+        body: '{"parcel":{"length":"10","width":"8","height":"4","weight":"15"}}'
     response:
         status:
             http_version: '1.1'
@@ -22,57 +24,57 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3774dfba613797cbe786b01b00a56f0d
+            x-ep-request-uuid: 8d29b69461578bbce78bb42d003aedbd
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
-            location: /api/v2/parcels.prcl_7241cc3cb20f477aa22b72a3d84bf9ad
+            location: /api/v2/parcels.prcl_055f28d3bd8b4fca91ab64a174612b01
             content-type: 'application/json; charset=utf-8'
             content-length: '229'
-            etag: 'W/"54d2a86f8938779b86ccc7d0045116b0"'
-            x-request-id: 18b0591d-bf9d-4fc1-b3e3-06c623520f31
-            x-runtime: '0.027235'
-            x-node: bigweb2nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            etag: 'W/"0f49dcf52e72851ce4c98ae929ed072f"'
+            x-request-id: 7292d60a-91ee-45fe-9fce-f5e98d04cea9
+            x-runtime: '0.026217'
+            x-node: bigweb4nuq
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 543ba58655', 'extlb1nuq 543ba58655']
+            x-proxied: ['intlb2nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"prcl_7241cc3cb20f477aa22b72a3d84bf9ad","object":"Parcel","created_at":"2021-09-07T16:48:11Z","updated_at":"2021-09-07T16:48:11Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"}'
+        body: '{"id":"prcl_055f28d3bd8b4fca91ab64a174612b01","object":"Parcel","created_at":"2021-10-01T22:29:16Z","updated_at":"2021-10-01T22:29:16Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"}'
         curl_info:
             url: 'https://api.easypost.com/v2/parcels'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
             header_size: 844
-            request_size: 605
+            request_size: 582
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.247968
-            namelookup_time: 0.011111
-            connect_time: 0.072226
-            pretransfer_time: 0.158324
-            size_upload: !!float 84
+            total_time: 0.233404
+            namelookup_time: 0.001814
+            connect_time: 0.062673
+            pretransfer_time: 0.142633
+            size_upload: !!float 65
             size_download: !!float 229
-            speed_download: !!float 923
-            speed_upload: !!float 338
+            speed_download: !!float 981
+            speed_upload: !!float 278
             download_content_length: !!float 229
-            upload_content_length: !!float 84
-            starttransfer_time: 0.247866
+            upload_content_length: !!float 65
+            starttransfer_time: 0.233373
             redirect_time: !!float 0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50360
+            local_ip: 10.130.6.13
+            local_port: 59819
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 158249
-            connect_time_us: 72226
-            namelookup_time_us: 11111
-            pretransfer_time_us: 158324
+            appconnect_time_us: 142515
+            connect_time_us: 62673
+            namelookup_time_us: 1814
+            pretransfer_time_us: 142633
             redirect_time_us: 0
-            starttransfer_time_us: 247866
-            total_time_us: 247968
+            starttransfer_time_us: 233373
+            total_time_us: 233404

--- a/test/cassettes/parcels/retrieve.yml
+++ b/test/cassettes/parcels/retrieve.yml
@@ -2,12 +2,14 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/parcels/prcl_7241cc3cb20f477aa22b72a3d84bf9ad'
+        url: 'https://api.easypost.com/v2/parcels/prcl_055f28d3bd8b4fca91ab64a174612b01'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
     response:
         status:
@@ -21,56 +23,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3774dfbe61379c59e786b48200a707d7
+            x-ep-request-uuid: 8d29b69461578bbce78bb445003aedd1
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '229'
-            etag: 'W/"54d2a86f8938779b86ccc7d0045116b0"'
-            x-request-id: 16a57108-fdad-4794-8114-d62ef2ac762c
+            etag: 'W/"0f49dcf52e72851ce4c98ae929ed072f"'
+            x-request-id: 430b44cf-79b9-47ee-b078-58e0c41969e9
             x-runtime: '0.022581'
             x-node: bigweb6nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 543ba58655', 'extlb1nuq 543ba58655']
+            x-proxied: ['intlb2nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"prcl_7241cc3cb20f477aa22b72a3d84bf9ad","object":"Parcel","created_at":"2021-09-07T16:48:11Z","updated_at":"2021-09-07T16:48:11Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"}'
+        body: '{"id":"prcl_055f28d3bd8b4fca91ab64a174612b01","object":"Parcel","created_at":"2021-10-01T22:29:16Z","updated_at":"2021-10-01T22:29:16Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"}'
         curl_info:
-            url: 'https://api.easypost.com/v2/parcels/prcl_7241cc3cb20f477aa22b72a3d84bf9ad'
+            url: 'https://api.easypost.com/v2/parcels/prcl_055f28d3bd8b4fca91ab64a174612b01'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 774
-            request_size: 489
+            request_size: 534
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.253545
-            namelookup_time: 0.025458
-            connect_time: 0.086451
-            pretransfer_time: 0.168849
+            total_time: 0.22553
+            namelookup_time: 0.001688
+            connect_time: 0.060999
+            pretransfer_time: 0.142482
             size_upload: !!float 0
             size_download: !!float 229
-            speed_download: !!float 903
+            speed_download: !!float 1015
             speed_upload: !!float 0
             download_content_length: !!float 229
             upload_content_length: !!float 0
-            starttransfer_time: 0.253468
+            starttransfer_time: 0.22549
             redirect_time: !!float 0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50475
+            local_ip: 10.130.6.13
+            local_port: 59820
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 168774
-            connect_time_us: 86451
-            namelookup_time_us: 25458
-            pretransfer_time_us: 168849
+            appconnect_time_us: 142428
+            connect_time_us: 60999
+            namelookup_time_us: 1688
+            pretransfer_time_us: 142482
             redirect_time_us: 0
-            starttransfer_time_us: 253468
-            total_time_us: 253545
+            starttransfer_time_us: 225490
+            total_time_us: 225530

--- a/test/cassettes/reports/createPaymentLogReport.yml
+++ b/test/cassettes/reports/createPaymentLogReport.yml
@@ -5,11 +5,13 @@
         url: 'https://api.easypost.com/v2/reports/payment_log/'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
-        body: 'start_date=2021-01-01&end_date=2021-01-02&type=payment_log'
+        body: '{"start_date":"2021-01-02","end_date":"2021-01-03","type":"payment_log"}'
     response:
         status:
             http_version: '1.1'
@@ -22,56 +24,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3774dfb861379a49e786b3fe00a63af3
+            x-ep-request-uuid: 8d29b69561578bbde78bb448003aee11
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '259'
-            etag: 'W/"4bf8c4885141fa37247ccc0ff8caf4a6"'
-            x-request-id: e3350907-9b6e-4ade-82f1-adcedb12469c
-            x-runtime: '0.045816'
-            x-node: bigweb3nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            etag: 'W/"f9972d230bf50141840f074c83a672c1"'
+            x-request-id: cfa329bf-fb23-42d3-88b8-034a4a42fe28
+            x-runtime: '0.041282'
+            x-node: bigweb5nuq
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 543ba58655', 'extlb1nuq 543ba58655']
+            x-proxied: ['intlb2nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"plrep_44432ab730e3410aad8cae818225226f","object":"PaymentLogReport","created_at":"2021-09-07T16:58:49Z","updated_at":"2021-09-07T16:58:49Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"new","url":null,"url_expires_at":null}'
+        body: '{"id":"plrep_b9e02c7929f24078acdc3db792bf3f20","object":"PaymentLogReport","created_at":"2021-10-01T22:29:17Z","updated_at":"2021-10-01T22:29:17Z","start_date":"2021-01-02","end_date":"2021-01-03","mode":"test","status":"new","url":null,"url_expires_at":null}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/payment_log/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
             header_size: 779
-            request_size: 592
+            request_size: 602
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.254214
-            namelookup_time: 0.00168
-            connect_time: 0.064012
-            pretransfer_time: 0.137754
-            size_upload: !!float 58
+            total_time: 0.244623
+            namelookup_time: 0.00149
+            connect_time: 0.060401
+            pretransfer_time: 0.140568
+            size_upload: !!float 72
             size_download: !!float 259
-            speed_download: !!float 1018
-            speed_upload: !!float 228
+            speed_download: !!float 1058
+            speed_upload: !!float 294
             download_content_length: !!float 259
-            upload_content_length: !!float 58
-            starttransfer_time: 0.254151
+            upload_content_length: !!float 72
+            starttransfer_time: 0.244596
             redirect_time: !!float 0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50435
+            local_ip: 10.130.6.13
+            local_port: 59823
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 137653
-            connect_time_us: 64012
-            namelookup_time_us: 1680
-            pretransfer_time_us: 137754
+            appconnect_time_us: 140508
+            connect_time_us: 60401
+            namelookup_time_us: 1490
+            pretransfer_time_us: 140568
             redirect_time_us: 0
-            starttransfer_time_us: 254151
-            total_time_us: 254214
+            starttransfer_time_us: 244596
+            total_time_us: 244623

--- a/test/cassettes/reports/createRefundReport.yml
+++ b/test/cassettes/reports/createRefundReport.yml
@@ -5,11 +5,13 @@
         url: 'https://api.easypost.com/v2/reports/refund/'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
-        body: 'start_date=2021-01-01&end_date=2021-01-02&type=refund'
+        body: '{"start_date":"2021-01-02","end_date":"2021-01-03","type":"refund"}'
     response:
         status:
             http_version: '1.1'
@@ -22,56 +24,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3774dfbe61379a48e786b3fc00a63a88
+            x-ep-request-uuid: 8d29b69961578bbde78bb449003aee27
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '256'
-            etag: 'W/"9a2fb1b03b03bd9b6d28de8c26fa214f"'
-            x-request-id: 3199f487-79f9-4f41-af08-b0ae106d97f0
-            x-runtime: '0.065057'
-            x-node: bigweb2nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            etag: 'W/"92625adf408678e38afa59fe71b6e2e4"'
+            x-request-id: 2cb8823f-e6d8-4f46-a022-b8a4ba10022d
+            x-runtime: '0.041630'
+            x-node: bigweb8nuq
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 543ba58655', 'extlb1nuq 543ba58655']
+            x-proxied: ['intlb2nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"refrep_eaf0cb1246a847c0b83e4d6c859a0b85","object":"RefundReport","created_at":"2021-09-07T16:58:48Z","updated_at":"2021-09-07T16:58:48Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"new","url":null,"url_expires_at":null}'
+        body: '{"id":"refrep_7b14834d2318435b82b3d3d336c073d7","object":"RefundReport","created_at":"2021-10-01T22:29:17Z","updated_at":"2021-10-01T22:29:17Z","start_date":"2021-01-02","end_date":"2021-01-03","mode":"test","status":"new","url":null,"url_expires_at":null}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/refund/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
             header_size: 779
-            request_size: 582
+            request_size: 592
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.268631
-            namelookup_time: 0.001788
-            connect_time: 0.06137
-            pretransfer_time: 0.141702
-            size_upload: !!float 53
+            total_time: 0.2467
+            namelookup_time: 0.001449
+            connect_time: 0.061891
+            pretransfer_time: 0.143055
+            size_upload: !!float 67
             size_download: !!float 256
-            speed_download: !!float 952
-            speed_upload: !!float 197
+            speed_download: !!float 1037
+            speed_upload: !!float 271
             download_content_length: !!float 256
-            upload_content_length: !!float 53
-            starttransfer_time: 0.268596
+            upload_content_length: !!float 67
+            starttransfer_time: 0.246657
             redirect_time: !!float 0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50433
+            local_ip: 10.130.6.13
+            local_port: 59824
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 141623
-            connect_time_us: 61370
-            namelookup_time_us: 1788
-            pretransfer_time_us: 141702
+            appconnect_time_us: 142996
+            connect_time_us: 61891
+            namelookup_time_us: 1449
+            pretransfer_time_us: 143055
             redirect_time_us: 0
-            starttransfer_time_us: 268596
-            total_time_us: 268631
+            starttransfer_time_us: 246657
+            total_time_us: 246700

--- a/test/cassettes/reports/createShipmentInvoiceReport.yml
+++ b/test/cassettes/reports/createShipmentInvoiceReport.yml
@@ -5,11 +5,13 @@
         url: 'https://api.easypost.com/v2/reports/shipment_invoice/'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
-        body: 'start_date=2021-01-01&end_date=2021-01-02&type=shipment_invoice'
+        body: '{"start_date":"2021-01-02","end_date":"2021-01-03","type":"shipment_invoice"}'
     response:
         status:
             http_version: '1.1'
@@ -22,56 +24,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3774dfbc61379a49e786b3ff00a63b20
+            x-ep-request-uuid: 8d29b69661578bbce78bb446003aede8
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '293'
-            etag: 'W/"cc0e002ffdfa7d851bd06202277c8ead"'
-            x-request-id: 19fd09b4-0dbd-4e32-9759-fd75c79619dd
-            x-runtime: '0.039551'
-            x-node: bigweb5nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            etag: 'W/"3ebacfdce2cf32da62568faa06106a2c"'
+            x-request-id: 3728250c-d35c-4dc0-afb4-31e79d09ade8
+            x-runtime: '0.042307'
+            x-node: bigweb2nuq
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 543ba58655', 'extlb1nuq 543ba58655']
+            x-proxied: ['intlb1nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shpinvrep_810e174f49af44c1805ccc82d53816cb","object":"ShipmentInvoiceReport","created_at":"2021-09-07T16:58:49Z","updated_at":"2021-09-07T16:58:49Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shpinvrep_b1461e064b04446d9637a9144bc07b35","object":"ShipmentInvoiceReport","created_at":"2021-10-01T22:29:16Z","updated_at":"2021-10-01T22:29:16Z","start_date":"2021-01-02","end_date":"2021-01-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/shipment_invoice/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
             header_size: 779
-            request_size: 602
+            request_size: 612
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.232416
-            namelookup_time: 0.001906
-            connect_time: 0.06123
-            pretransfer_time: 0.13219
-            size_upload: !!float 63
+            total_time: 0.241637
+            namelookup_time: 0.001872
+            connect_time: 0.061711
+            pretransfer_time: 0.139001
+            size_upload: !!float 77
             size_download: !!float 293
-            speed_download: !!float 1260
-            speed_upload: !!float 271
+            speed_download: !!float 1212
+            speed_upload: !!float 318
             download_content_length: !!float 293
-            upload_content_length: !!float 63
-            starttransfer_time: 0.232384
+            upload_content_length: !!float 77
+            starttransfer_time: 0.241594
             redirect_time: !!float 0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50436
+            local_ip: 10.130.6.13
+            local_port: 59821
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 132125
-            connect_time_us: 61230
-            namelookup_time_us: 1906
-            pretransfer_time_us: 132190
+            appconnect_time_us: 138952
+            connect_time_us: 61711
+            namelookup_time_us: 1872
+            pretransfer_time_us: 139001
             redirect_time_us: 0
-            starttransfer_time_us: 232384
-            total_time_us: 232416
+            starttransfer_time_us: 241594
+            total_time_us: 241637

--- a/test/cassettes/reports/createShipmentReport.yml
+++ b/test/cassettes/reports/createShipmentReport.yml
@@ -5,11 +5,13 @@
         url: 'https://api.easypost.com/v2/reports/shipment/'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
-        body: 'start_date=2021-01-01&end_date=2021-01-02&type=shipment'
+        body: '{"start_date":"2021-01-02","end_date":"2021-01-03","type":"shipment"}'
     response:
         status:
             http_version: '1.1'
@@ -22,56 +24,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3774dfbd61379a48e786b3fb00a63a73
+            x-ep-request-uuid: 8d29b69661578bbde78bb44a003aee41
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '283'
-            etag: 'W/"d85ad54c0e4ee0d6c9d4f6f7b4066b2d"'
-            x-request-id: 8439cc0f-3c76-4240-ad10-03eb3498e2c7
-            x-runtime: '0.044387'
+            etag: 'W/"b32ad5e7e95c448dfbeb42820ee4c5ab"'
+            x-request-id: 62951230-d73f-42dc-a6d1-bc70655944fd
+            x-runtime: '0.049582'
             x-node: bigweb6nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 543ba58655', 'extlb1nuq 543ba58655']
+            x-proxied: ['intlb2nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_1c2b5100501646c783fa7ed9179098ff","object":"ShipmentReport","created_at":"2021-09-07T16:58:48Z","updated_at":"2021-09-07T16:58:48Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shprep_afc0505b01244b879126a0f5ac032ff3","object":"ShipmentReport","created_at":"2021-10-01T22:29:17Z","updated_at":"2021-10-01T22:29:17Z","start_date":"2021-01-02","end_date":"2021-01-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/shipment/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
             header_size: 779
-            request_size: 586
+            request_size: 596
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.275592
-            namelookup_time: 0.012444
-            connect_time: 0.079331
-            pretransfer_time: 0.167652
-            size_upload: !!float 55
+            total_time: 0.258868
+            namelookup_time: 0.001815
+            connect_time: 0.063448
+            pretransfer_time: 0.142094
+            size_upload: !!float 69
             size_download: !!float 283
-            speed_download: !!float 1026
-            speed_upload: !!float 199
+            speed_download: !!float 1093
+            speed_upload: !!float 266
             download_content_length: !!float 283
-            upload_content_length: !!float 55
-            starttransfer_time: 0.275498
+            upload_content_length: !!float 69
+            starttransfer_time: 0.258837
             redirect_time: !!float 0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50432
+            local_ip: 10.130.6.13
+            local_port: 59825
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 167439
-            connect_time_us: 79331
-            namelookup_time_us: 12444
-            pretransfer_time_us: 167652
+            appconnect_time_us: 142055
+            connect_time_us: 63448
+            namelookup_time_us: 1815
+            pretransfer_time_us: 142094
             redirect_time_us: 0
-            starttransfer_time_us: 275498
-            total_time_us: 275592
+            starttransfer_time_us: 258837
+            total_time_us: 258868

--- a/test/cassettes/reports/createTrackerReport.yml
+++ b/test/cassettes/reports/createTrackerReport.yml
@@ -5,11 +5,13 @@
         url: 'https://api.easypost.com/v2/reports/tracker/'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
-        body: 'start_date=2021-01-01&end_date=2021-01-02&type=tracker'
+        body: '{"start_date":"2021-01-02","end_date":"2021-01-03","type":"tracker"}'
     response:
         status:
             http_version: '1.1'
@@ -22,56 +24,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3774dfb861379a49e786b3fd00a63abc
+            x-ep-request-uuid: 8d29b69461578bbce78bb447003aee01
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '282'
-            etag: 'W/"54b1d381e58fa08a7280d3435549f6bf"'
-            x-request-id: f0580179-7bf8-4d8e-8956-d8ba3bf2c3f6
-            x-runtime: '0.048567'
+            etag: 'W/"9f0520ffba1716b0e6a3d55cd127b6b4"'
+            x-request-id: 2074dd1a-83af-4497-8709-8009dda8892b
+            x-runtime: '0.038858'
             x-node: bigweb8nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 543ba58655', 'extlb1nuq 543ba58655']
+            x-proxied: ['intlb2nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"trkrep_f3a8b8c133ff4ebaaf185272ccd32e5c","object":"TrackerReport","created_at":"2021-09-07T16:58:49Z","updated_at":"2021-09-07T16:58:49Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"trkrep_3d3cbd083ed74b2b931ec6c52ab4f448","object":"TrackerReport","created_at":"2021-10-01T22:29:16Z","updated_at":"2021-10-01T22:29:16Z","start_date":"2021-01-02","end_date":"2021-01-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/tracker/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
             header_size: 779
-            request_size: 584
+            request_size: 594
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.24534
-            namelookup_time: 0.00168
-            connect_time: 0.061869
-            pretransfer_time: 0.133431
-            size_upload: !!float 54
+            total_time: 0.245008
+            namelookup_time: 0.001632
+            connect_time: 0.064219
+            pretransfer_time: 0.145187
+            size_upload: !!float 68
             size_download: !!float 282
-            speed_download: !!float 1149
-            speed_upload: !!float 220
+            speed_download: !!float 1150
+            speed_upload: !!float 277
             download_content_length: !!float 282
-            upload_content_length: !!float 54
-            starttransfer_time: 0.245298
+            upload_content_length: !!float 68
+            starttransfer_time: 0.24498
             redirect_time: !!float 0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50434
+            local_ip: 10.130.6.13
+            local_port: 59822
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 133396
-            connect_time_us: 61869
-            namelookup_time_us: 1680
-            pretransfer_time_us: 133431
+            appconnect_time_us: 145130
+            connect_time_us: 64219
+            namelookup_time_us: 1632
+            pretransfer_time_us: 145187
             redirect_time_us: 0
-            starttransfer_time_us: 245298
-            total_time_us: 245340
+            starttransfer_time_us: 244980
+            total_time_us: 245008

--- a/test/cassettes/reports/retrievePaymentLogReport.yml
+++ b/test/cassettes/reports/retrievePaymentLogReport.yml
@@ -2,12 +2,14 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/reports/plrep_44432ab730e3410aad8cae818225226f'
+        url: 'https://api.easypost.com/v2/reports/plrep_b9e02c7929f24078acdc3db792bf3f20'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
     response:
         status:
@@ -21,56 +23,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3774dfba61379a92e786b42000a651cd
+            x-ep-request-uuid: 8d29b69361578bbee78bb44e003aeebd
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '261'
-            etag: 'W/"d3f0dc075bfc66bd38da92f0612b9f17"'
-            x-request-id: deda32d7-ee39-482b-b596-f3a5091e9804
-            x-runtime: '0.034212'
-            x-node: bigweb6nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            etag: 'W/"f6ae760ed2e35172f707608b685c1950"'
+            x-request-id: fd39548f-02cd-4de3-a22e-1b598cc17a38
+            x-runtime: '0.046666'
+            x-node: bigweb5nuq
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 543ba58655', 'extlb1nuq 543ba58655']
+            x-proxied: ['intlb1nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"plrep_44432ab730e3410aad8cae818225226f","object":"PaymentLogReport","created_at":"2021-09-07T16:58:49Z","updated_at":"2021-09-07T16:58:49Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"empty","url":null,"url_expires_at":null}'
+        body: '{"id":"plrep_b9e02c7929f24078acdc3db792bf3f20","object":"PaymentLogReport","created_at":"2021-10-01T22:29:17Z","updated_at":"2021-10-01T22:29:18Z","start_date":"2021-01-02","end_date":"2021-01-03","mode":"test","status":"empty","url":null,"url_expires_at":null}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/plrep_44432ab730e3410aad8cae818225226f'
+            url: 'https://api.easypost.com/v2/reports/plrep_b9e02c7929f24078acdc3db792bf3f20'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 774
-            request_size: 490
+            request_size: 535
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.472639
-            namelookup_time: 0.012805
-            connect_time: 0.116267
-            pretransfer_time: 0.226321
+            total_time: 0.334769
+            namelookup_time: 0.00177
+            connect_time: 0.144683
+            pretransfer_time: 0.227145
             size_upload: !!float 0
             size_download: !!float 261
-            speed_download: !!float 552
+            speed_download: !!float 779
             speed_upload: !!float 0
             download_content_length: !!float 261
             upload_content_length: !!float 0
-            starttransfer_time: 0.472541
+            starttransfer_time: 0.334728
             redirect_time: !!float 0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50446
+            local_ip: 10.130.6.13
+            local_port: 59829
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 226249
-            connect_time_us: 116267
-            namelookup_time_us: 12805
-            pretransfer_time_us: 226321
+            appconnect_time_us: 227049
+            connect_time_us: 144683
+            namelookup_time_us: 1770
+            pretransfer_time_us: 227145
             redirect_time_us: 0
-            starttransfer_time_us: 472541
-            total_time_us: 472639
+            starttransfer_time_us: 334728
+            total_time_us: 334769

--- a/test/cassettes/reports/retrieveRefundReport.yml
+++ b/test/cassettes/reports/retrieveRefundReport.yml
@@ -2,12 +2,14 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/reports/refrep_eaf0cb1246a847c0b83e4d6c859a0b85'
+        url: 'https://api.easypost.com/v2/reports/refrep_7b14834d2318435b82b3d3d336c073d7'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
     response:
         status:
@@ -21,56 +23,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3774dfb961379b34e786b44300a6963c
+            x-ep-request-uuid: 8d29b69261578bbde78bb44b003aee60
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
-            content-length: '665'
-            etag: 'W/"7e7856452e61683103b6bacf65f41321"'
-            x-request-id: 5c222ca5-a69a-40cb-aadd-ca742efe123e
-            x-runtime: '0.041363'
-            x-node: bigweb1nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            content-length: '256'
+            etag: 'W/"92625adf408678e38afa59fe71b6e2e4"'
+            x-request-id: f4624b67-f41a-4363-8616-7301ec1b068a
+            x-runtime: '0.035925'
+            x-node: bigweb2nuq
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 543ba58655', 'extlb1nuq 543ba58655']
+            x-proxied: ['intlb1nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"refrep_eaf0cb1246a847c0b83e4d6c859a0b85","object":"RefundReport","created_at":"2021-09-07T16:58:48Z","updated_at":"2021-09-07T16:58:50Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/refund_report/20210907/refrep_eaf0cb1246a847c0b83e4d6c859a0b85.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20210907%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210907T170244Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=b5a56a9f92ce578bc3a66025eda5372dfa210ab20d75eb69e8d65b22a4960bcb","url_expires_at":"2021-09-07T17:03:14Z"}'
+        body: '{"id":"refrep_7b14834d2318435b82b3d3d336c073d7","object":"RefundReport","created_at":"2021-10-01T22:29:17Z","updated_at":"2021-10-01T22:29:17Z","start_date":"2021-01-02","end_date":"2021-01-03","mode":"test","status":"new","url":null,"url_expires_at":null}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/refrep_eaf0cb1246a847c0b83e4d6c859a0b85'
+            url: 'https://api.easypost.com/v2/reports/refrep_7b14834d2318435b82b3d3d336c073d7'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 774
-            request_size: 491
+            request_size: 536
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.309156
-            namelookup_time: 0.051939
-            connect_time: 0.112876
-            pretransfer_time: 0.200764
+            total_time: 0.239974
+            namelookup_time: 0.001782
+            connect_time: 0.06228
+            pretransfer_time: 0.141574
             size_upload: !!float 0
-            size_download: !!float 665
-            speed_download: !!float 2151
+            size_download: !!float 256
+            speed_download: !!float 1066
             speed_upload: !!float 0
-            download_content_length: !!float 665
+            download_content_length: !!float 256
             upload_content_length: !!float 0
-            starttransfer_time: 0.309046
+            starttransfer_time: 0.239933
             redirect_time: !!float 0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50458
+            local_ip: 10.130.6.13
+            local_port: 59826
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 200662
-            connect_time_us: 112876
-            namelookup_time_us: 51939
-            pretransfer_time_us: 200764
+            appconnect_time_us: 141519
+            connect_time_us: 62280
+            namelookup_time_us: 1782
+            pretransfer_time_us: 141574
             redirect_time_us: 0
-            starttransfer_time_us: 309046
-            total_time_us: 309156
+            starttransfer_time_us: 239933
+            total_time_us: 239974

--- a/test/cassettes/reports/retrieveShipmentReport.yml
+++ b/test/cassettes/reports/retrieveShipmentReport.yml
@@ -2,12 +2,14 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/reports/shprep_1c2b5100501646c783fa7ed9179098ff'
+        url: 'https://api.easypost.com/v2/reports/shprep_afc0505b01244b879126a0f5ac032ff3'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
     response:
         status:
@@ -21,68 +23,71 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3774dfbd61379b35e786b44400a6964b
+            x-ep-request-uuid: 8d29b69661578bbee78bb44d003aee97
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
-            content-length: '694'
-            etag: 'W/"d74fa53dd0fed1745aa540fd6b934f66"'
-            x-request-id: 566434c5-cb50-44f1-be96-e50ccc2fdcf0
-            x-runtime: '0.038089'
-            x-node: bigweb8nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            content-length: '283'
+            etag: 'W/"b32ad5e7e95c448dfbeb42820ee4c5ab"'
+            x-request-id: b4643d51-20ae-4f96-b0a5-ec80ae053727
+            x-runtime: '0.038130'
+            x-node: bigweb7nuq
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 543ba58655', 'extlb1nuq 543ba58655']
+            x-canary: direct
+            x-proxied: ['intlb1nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_1c2b5100501646c783fa7ed9179098ff","object":"ShipmentReport","created_at":"2021-09-07T16:58:48Z","updated_at":"2021-09-07T16:58:48Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20210907/shprep_1c2b5100501646c783fa7ed9179098ff.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20210907%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210907T170245Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=25734f5d6fa3e67333c64f2bf92d6bd0936cf05989e02ad9654c40544aaa6b52","url_expires_at":"2021-09-07T17:03:15Z","include_children":false}'
+        body: '{"id":"shprep_afc0505b01244b879126a0f5ac032ff3","object":"ShipmentReport","created_at":"2021-10-01T22:29:17Z","updated_at":"2021-10-01T22:29:17Z","start_date":"2021-01-02","end_date":"2021-01-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shprep_1c2b5100501646c783fa7ed9179098ff'
+            url: 'https://api.easypost.com/v2/reports/shprep_afc0505b01244b879126a0f5ac032ff3'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 774
-            request_size: 491
+            header_size: 792
+            request_size: 536
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.247384
-            namelookup_time: 0.001905
-            connect_time: 0.062445
-            pretransfer_time: 0.146675
+            total_time: 0.243806
+            namelookup_time: 0.001738
+            connect_time: 0.062447
+            pretransfer_time: 0.143334
             size_upload: !!float 0
-            size_download: !!float 694
-            speed_download: !!float 2805
+            size_download: !!float 283
+            speed_download: !!float 1160
             speed_upload: !!float 0
-            download_content_length: !!float 694
+            download_content_length: !!float 283
             upload_content_length: !!float 0
-            starttransfer_time: 0.247339
+            starttransfer_time: 0.243766
             redirect_time: !!float 0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50459
+            local_ip: 10.130.6.13
+            local_port: 59828
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 146638
-            connect_time_us: 62445
-            namelookup_time_us: 1905
-            pretransfer_time_us: 146675
+            appconnect_time_us: 143257
+            connect_time_us: 62447
+            namelookup_time_us: 1738
+            pretransfer_time_us: 143334
             redirect_time_us: 0
-            starttransfer_time_us: 247339
-            total_time_us: 247384
+            starttransfer_time_us: 243766
+            total_time_us: 243806
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/reports/shpinvrep_810e174f49af44c1805ccc82d53816cb'
+        url: 'https://api.easypost.com/v2/reports/shpinvrep_b1461e064b04446d9637a9144bc07b35'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
     response:
         status:
@@ -96,56 +101,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3774dfbb61379b35e786b45c00a6966d
+            x-ep-request-uuid: 8d29b69361578bbfe78bb466003aeee0
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '715'
-            etag: 'W/"9eca687f8f4db869cbd502dea9914a15"'
-            x-request-id: d6a1971f-7786-48ea-9cfc-193acc5fae53
-            x-runtime: '0.043877'
-            x-node: bigweb9nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            etag: 'W/"50814dde60b46a95cb6b20255a328b8d"'
+            x-request-id: e6c66e12-2d4f-4d13-a07d-7dcc9ebf1762
+            x-runtime: '0.036713'
+            x-node: bigweb4nuq
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 543ba58655', 'extlb1nuq 543ba58655']
+            x-proxied: ['intlb1nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shpinvrep_810e174f49af44c1805ccc82d53816cb","object":"ShipmentInvoiceReport","created_at":"2021-09-07T16:58:49Z","updated_at":"2021-09-07T16:58:49Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_invoice_report/20210907/shpinvrep_810e174f49af44c1805ccc82d53816cb.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20210907%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210907T170245Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=ef1ef3bea790417678d0d44a052a80af353d43034f0c805e94adff02cfe0312e","url_expires_at":"2021-09-07T17:03:15Z","include_children":false}'
+        body: '{"id":"shpinvrep_b1461e064b04446d9637a9144bc07b35","object":"ShipmentInvoiceReport","created_at":"2021-10-01T22:29:16Z","updated_at":"2021-10-01T22:29:16Z","start_date":"2021-01-02","end_date":"2021-01-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_invoice_report/20211001/shpinvrep_b1461e064b04446d9637a9144bc07b35.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20211001%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211001T222919Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=cecf4ac1d3cfbbbd50d6834db0e69fdd5f5be9b88abd6a94640129c508c92769","url_expires_at":"2021-10-01T22:29:49Z","include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shpinvrep_810e174f49af44c1805ccc82d53816cb'
+            url: 'https://api.easypost.com/v2/reports/shpinvrep_b1461e064b04446d9637a9144bc07b35'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 774
-            request_size: 494
+            request_size: 539
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.290871
-            namelookup_time: 0.001844
-            connect_time: 0.062911
-            pretransfer_time: 0.183369
+            total_time: 0.24711
+            namelookup_time: 0.001749
+            connect_time: 0.062556
+            pretransfer_time: 0.146536
             size_upload: !!float 0
             size_download: !!float 715
-            speed_download: !!float 2458
+            speed_download: !!float 2893
             speed_upload: !!float 0
             download_content_length: !!float 715
             upload_content_length: !!float 0
-            starttransfer_time: 0.290837
+            starttransfer_time: 0.247079
             redirect_time: !!float 0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50460
+            local_ip: 10.130.6.13
+            local_port: 59830
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 183318
-            connect_time_us: 62911
-            namelookup_time_us: 1844
-            pretransfer_time_us: 183369
+            appconnect_time_us: 146464
+            connect_time_us: 62556
+            namelookup_time_us: 1749
+            pretransfer_time_us: 146536
             redirect_time_us: 0
-            starttransfer_time_us: 290837
-            total_time_us: 290871
+            starttransfer_time_us: 247079
+            total_time_us: 247110

--- a/test/cassettes/reports/retrieveTrackerReport.yml
+++ b/test/cassettes/reports/retrieveTrackerReport.yml
@@ -2,12 +2,14 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/reports/trkrep_f3a8b8c133ff4ebaaf185272ccd32e5c'
+        url: 'https://api.easypost.com/v2/reports/trkrep_3d3cbd083ed74b2b931ec6c52ab4f448'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
     response:
         status:
@@ -21,56 +23,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3774dfbc61379b35e786b45d00a69680
+            x-ep-request-uuid: 8d29b69261578bbee78bb44c003aee75
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '692'
-            etag: 'W/"131feb5eb0a79106c72b563ca0558b1c"'
-            x-request-id: 4ad851a2-3f3a-4d48-90db-a4334fcc0f0e
-            x-runtime: '0.034730'
+            etag: 'W/"fcdb804dec652a76e65572a6c89d2605"'
+            x-request-id: e494e28e-2dae-4a5c-b2f3-d91f4358a51a
+            x-runtime: '0.133604'
             x-node: bigweb5nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 543ba58655', 'extlb1nuq 543ba58655']
+            x-proxied: ['intlb1nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"trkrep_f3a8b8c133ff4ebaaf185272ccd32e5c","object":"TrackerReport","created_at":"2021-09-07T16:58:49Z","updated_at":"2021-09-07T16:58:49Z","start_date":"2021-01-01","end_date":"2021-01-02","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20210907/trkrep_f3a8b8c133ff4ebaaf185272ccd32e5c.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20210907%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210907T170245Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=e63efadef3b00a8cb93224ff2a1f0e340925162023339517c793e18151c77315","url_expires_at":"2021-09-07T17:03:15Z","include_children":false}'
+        body: '{"id":"trkrep_3d3cbd083ed74b2b931ec6c52ab4f448","object":"TrackerReport","created_at":"2021-10-01T22:29:16Z","updated_at":"2021-10-01T22:29:17Z","start_date":"2021-01-02","end_date":"2021-01-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20211001/trkrep_3d3cbd083ed74b2b931ec6c52ab4f448.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20211001%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211001T222918Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=25c27173c6de268a1bb11b59f34f62f27433d949901fc9d4982f910066c46d7a","url_expires_at":"2021-10-01T22:29:48Z","include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/trkrep_f3a8b8c133ff4ebaaf185272ccd32e5c'
+            url: 'https://api.easypost.com/v2/reports/trkrep_3d3cbd083ed74b2b931ec6c52ab4f448'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 774
-            request_size: 491
+            request_size: 536
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.238348
-            namelookup_time: 0.001631
-            connect_time: 0.06155
-            pretransfer_time: 0.141429
+            total_time: 0.344417
+            namelookup_time: 0.001758
+            connect_time: 0.062388
+            pretransfer_time: 0.145179
             size_upload: !!float 0
             size_download: !!float 692
-            speed_download: !!float 2903
+            speed_download: !!float 2009
             speed_upload: !!float 0
             download_content_length: !!float 692
             upload_content_length: !!float 0
-            starttransfer_time: 0.238305
+            starttransfer_time: 0.344373
             redirect_time: !!float 0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50461
+            local_ip: 10.130.6.13
+            local_port: 59827
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 141356
-            connect_time_us: 61550
-            namelookup_time_us: 1631
-            pretransfer_time_us: 141429
+            appconnect_time_us: 145125
+            connect_time_us: 62388
+            namelookup_time_us: 1758
+            pretransfer_time_us: 145179
             redirect_time_us: 0
-            starttransfer_time_us: 238305
-            total_time_us: 238348
+            starttransfer_time_us: 344373
+            total_time_us: 344417

--- a/test/cassettes/shipments/buy.yml
+++ b/test/cassettes/shipments/buy.yml
@@ -2,14 +2,16 @@
 -
     request:
         method: POST
-        url: 'https://api.easypost.com/v2/shipments/shp_cc46dc3741114299ba02a99b8c483645/buy'
+        url: 'https://api.easypost.com/v2/shipments/shp_ad1fdcca56c9404b807f2425ec447488/buy'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
-        body: rate%5Bid%5D=rate_94ad5814f2be4c9e97dc6256b8ec940a
+        body: '{"rate":{"id":"rate_367729f43a454348819f499a08e831bb"}}'
     response:
         status:
             http_version: '1.1'
@@ -22,56 +24,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 8b9087be613be558e788ddc60042af06
+            x-ep-request-uuid: 8d29b69561578bc0e78bb469003aef93
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
-            content-length: '9830'
-            etag: 'W/"97f50f0295b03d812871cfa69162af9c"'
-            x-request-id: a4bc860b-5c06-4437-9b1b-5b30629cad64
-            x-runtime: '0.927170'
-            x-node: bigweb1nuq
-            x-version-label: easypost-202109102144-93513c99cc-master
+            content-length: '6916'
+            etag: 'W/"ac9483ed6518590cae67be2eeea3477c"'
+            x-request-id: b73ae602-8aaa-43b8-b880-db9101359956
+            x-runtime: '0.852585'
+            x-node: bigweb6nuq
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 543ba58655', 'extlb2nuq 543ba58655']
+            x-proxied: ['intlb1nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"created_at":"2021-09-07T17:14:19Z","is_return":false,"messages":[{"carrier":"Canpar","carrier_account_id":"ca_58451e27b5bc4f6cb419d9be15705847","type":"rate_error","message":"Unable to retrieve Canpar rates for non-CA origin shipments."}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9405500895232079129637","updated_at":"2021-09-10T23:08:09Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_9aaadb0761084fb290098a7c04468af7","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_490ff015123b49d9832d88dd0815b338","object":"Parcel","created_at":"2021-09-07T17:14:19Z","updated_at":"2021-09-07T17:14:19Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_e705fa9a1a274ed58f2df7d295e833ca","created_at":"2021-09-10T23:08:09Z","updated_at":"2021-09-10T23:08:09Z","date_advance":0,"integrated_form":"none","label_date":"2021-09-10T23:08:09Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20210910/4f13576d8fa043b89147fc6645453354.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_8d341242c91c458ab336fddb0f4e7381","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.00","currency":"USD","retail_rate":"26.75","retail_currency":"USD","list_rate":"23.00","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_94ad5814f2be4c9e97dc6256b8ec940a","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.16","currency":"USD","retail_rate":"7.70","retail_currency":"USD","list_rate":"7.16","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_8720740b8efd44d3b9ad210456b3c107","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.01","currency":"USD","retail_rate":"7.01","retail_currency":"USD","list_rate":"7.01","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_8591d7eef54c4c5195e20ae0f772fb2e","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"First","carrier":"USPS","rate":"5.19","currency":"USD","retail_rate":"5.19","retail_currency":"USD","list_rate":"5.19","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_242be45f50a64cc6934c3cc7ce9019db","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"19.18","currency":"USD","retail_rate":"19.18","retail_currency":"USD","list_rate":"19.42","list_currency":"USD","delivery_days":3,"delivery_date":"2021-09-10T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":3,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_4f781fb5782d4eb383ab8f68b8b52b83","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"73.23","currency":"USD","retail_rate":"73.23","retail_currency":"USD","list_rate":"75.33","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T08:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_623b5dc9b66144a09c33b05e2b3816bb","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Ground","carrier":"UPS","rate":"11.14","currency":"USD","retail_rate":"11.14","retail_currency":"USD","list_rate":"14.59","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_ebfff836cf984fb7978e370711283ef8","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"37.61","currency":"USD","retail_rate":"37.61","retail_currency":"USD","list_rate":"40.46","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_a12a01061a4441e388d5ae935e2e8659","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"40.68","currency":"USD","retail_rate":"40.68","retail_currency":"USD","list_rate":"42.78","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T10:30:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_36e12bc1f5a849f4a114fa73950ba894","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"26.51","currency":"USD","retail_rate":"26.51","retail_currency":"USD","list_rate":"27.03","list_currency":"USD","delivery_days":2,"delivery_date":"2021-09-09T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_94ad5814f2be4c9e97dc6256b8ec940a","object":"Rate","created_at":"2021-09-10T23:08:09Z","updated_at":"2021-09-10T23:08:09Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.16","currency":"USD","retail_rate":"7.70","retail_currency":"USD","list_rate":"7.16","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},"tracker":{"id":"trk_b89db068e9f94b4190099bf69b8b7e71","object":"Tracker","mode":"test","tracking_code":"9405500895232079129637","status":"unknown","status_detail":"unknown","created_at":"2021-09-10T23:08:09Z","updated_at":"2021-09-10T23:08:09Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2I4OWRiMDY4ZTlmOTRiNDE5MDA5OWJmNjliOGI3ZTcx"},"to_address":{"id":"adr_45484e572d1d466799518b77628f322b","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-10T23:08:09+00:00","name":null,"company":null,"street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_9aaadb0761084fb290098a7c04468af7","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_45484e572d1d466799518b77628f322b","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-10T23:08:09+00:00","name":null,"company":null,"street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"7.16000","charged":true,"refunded":false}],"id":"shp_cc46dc3741114299ba02a99b8c483645","object":"Shipment"}'
+        body: '{"created_at":"2021-10-01T22:29:19Z","is_return":false,"messages":[{"carrier":"Canpar","carrier_account_id":"ca_58451e27b5bc4f6cb419d9be15705847","type":"rate_error","message":"Unable to retrieve Canpar rates for non-CA origin shipments."},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","type":"rate_error","message":"XML Rating and Service Selection Service Unavailable"}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100895232080194904","updated_at":"2021-10-01T22:29:21Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_e6e1d2acb2d74797919029c83070c071","object":"Address","created_at":"2021-10-01T22:29:19+00:00","updated_at":"2021-10-01T22:29:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_c91ef71134d349eda1f2e7e409ad648a","object":"Parcel","created_at":"2021-10-01T22:29:19Z","updated_at":"2021-10-01T22:29:19Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_9ccc2d95b60242f58b2f210bf47f5d43","created_at":"2021-10-01T22:29:21Z","updated_at":"2021-10-01T22:29:21Z","date_advance":0,"integrated_form":"none","label_date":"2021-10-01T22:29:21Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20211001/64a48af28f5c42d08424ff99ceff7a46.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_b7d9b96e638c4b4d97a83683418a42e2","object":"Rate","created_at":"2021-10-01T22:29:20Z","updated_at":"2021-10-01T22:29:20Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.16","currency":"USD","retail_rate":"7.70","retail_currency":"USD","list_rate":"7.16","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_ad1fdcca56c9404b807f2425ec447488","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_367729f43a454348819f499a08e831bb","object":"Rate","created_at":"2021-10-01T22:29:20Z","updated_at":"2021-10-01T22:29:20Z","mode":"test","service":"First","carrier":"USPS","rate":"5.19","currency":"USD","retail_rate":"5.19","retail_currency":"USD","list_rate":"5.19","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ad1fdcca56c9404b807f2425ec447488","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_14f04074ce1a4980a45bc0887568f0d8","object":"Rate","created_at":"2021-10-01T22:29:20Z","updated_at":"2021-10-01T22:29:20Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.00","currency":"USD","retail_rate":"26.75","retail_currency":"USD","list_rate":"23.00","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_ad1fdcca56c9404b807f2425ec447488","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_6894ae6e80f143d092e0ad480ed6033d","object":"Rate","created_at":"2021-10-01T22:29:20Z","updated_at":"2021-10-01T22:29:20Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.01","currency":"USD","retail_rate":"7.01","retail_currency":"USD","list_rate":"7.01","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ad1fdcca56c9404b807f2425ec447488","carrier_account_id":"ca_qn6QC6fd"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_367729f43a454348819f499a08e831bb","object":"Rate","created_at":"2021-10-01T22:29:21Z","updated_at":"2021-10-01T22:29:21Z","mode":"test","service":"First","carrier":"USPS","rate":"5.19","currency":"USD","retail_rate":"5.19","retail_currency":"USD","list_rate":"5.19","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ad1fdcca56c9404b807f2425ec447488","carrier_account_id":"ca_qn6QC6fd"},"tracker":{"id":"trk_08bcdad759f34936ac75ca38ffb165c5","object":"Tracker","mode":"test","tracking_code":"9400100895232080194904","status":"unknown","status_detail":"unknown","created_at":"2021-10-01T22:29:21Z","updated_at":"2021-10-01T22:29:21Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_ad1fdcca56c9404b807f2425ec447488","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzA4YmNkYWQ3NTlmMzQ5MzZhYzc1Y2EzOGZmYjE2NWM1"},"to_address":{"id":"adr_dfa74fed4855426b9f962f48cb12f10e","object":"Address","created_at":"2021-10-01T22:29:19+00:00","updated_at":"2021-10-01T22:29:21+00:00","name":null,"company":null,"street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_e6e1d2acb2d74797919029c83070c071","object":"Address","created_at":"2021-10-01T22:29:19+00:00","updated_at":"2021-10-01T22:29:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_dfa74fed4855426b9f962f48cb12f10e","object":"Address","created_at":"2021-10-01T22:29:19+00:00","updated_at":"2021-10-01T22:29:21+00:00","name":null,"company":null,"street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.19000","charged":true,"refunded":false}],"id":"shp_ad1fdcca56c9404b807f2425ec447488","object":"Shipment"}'
         curl_info:
-            url: 'https://api.easypost.com/v2/shipments/shp_cc46dc3741114299ba02a99b8c483645/buy'
+            url: 'https://api.easypost.com/v2/shipments/shp_ad1fdcca56c9404b807f2425ec447488/buy'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 775
-            request_size: 614
+            request_size: 615
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 1.27774
-            namelookup_time: 0.012679
-            connect_time: 0.079736
-            pretransfer_time: 0.164645
-            size_upload: !!float 50
-            size_download: !!float 9830
-            speed_download: !!float 7693
-            speed_upload: !!float 39
-            download_content_length: !!float 9830
-            upload_content_length: !!float 50
-            starttransfer_time: 1.277659
+            total_time: 1.064676
+            namelookup_time: 0.001201
+            connect_time: 0.061882
+            pretransfer_time: 0.146356
+            size_upload: !!float 55
+            size_download: !!float 6916
+            speed_download: !!float 6495
+            speed_upload: !!float 51
+            download_content_length: !!float 6916
+            upload_content_length: !!float 55
+            starttransfer_time: 1.064648
             redirect_time: !!float 0
             redirect_url: ''
             primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.5
-            local_port: 54295
+            local_ip: 10.130.6.13
+            local_port: 59833
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 164506
-            connect_time_us: 79736
-            namelookup_time_us: 12679
-            pretransfer_time_us: 164645
+            appconnect_time_us: 146270
+            connect_time_us: 61882
+            namelookup_time_us: 1201
+            pretransfer_time_us: 146356
             redirect_time_us: 0
-            starttransfer_time_us: 1277659
-            total_time_us: 1277740
+            starttransfer_time_us: 1064648
+            total_time_us: 1064676

--- a/test/cassettes/shipments/create.yml
+++ b/test/cassettes/shipments/create.yml
@@ -5,11 +5,13 @@
         url: 'https://api.easypost.com/v2/shipments'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
-        body: 'shipment%5Bto_address%5D%5Bstreet1%5D=388+Townsend+St&shipment%5Bto_address%5D%5Bstreet2%5D=Apt+20&shipment%5Bto_address%5D%5Bcity%5D=San+Francisco&shipment%5Bto_address%5D%5Bstate%5D=CA&shipment%5Bto_address%5D%5Bzip%5D=94107&shipment%5Bfrom_address%5D%5Bstreet1%5D=388+Townsend+St&shipment%5Bfrom_address%5D%5Bstreet2%5D=Apt+20&shipment%5Bfrom_address%5D%5Bcity%5D=San+Francisco&shipment%5Bfrom_address%5D%5Bstate%5D=CA&shipment%5Bfrom_address%5D%5Bzip%5D=94107&shipment%5Bparcel%5D%5Blength%5D=10&shipment%5Bparcel%5D%5Bwidth%5D=8&shipment%5Bparcel%5D%5Bheight%5D=4&shipment%5Bparcel%5D%5Bweight%5D=15'
+        body: '{"shipment":{"to_address":{"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107"},"from_address":{"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107"},"parcel":{"length":"10","width":"8","height":"4","weight":"15"}}}'
     response:
         status:
             http_version: '1.1'
@@ -22,58 +24,57 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3774dfbc61379debe786b7dd00a79f5d
+            x-ep-request-uuid: 8d29b69561578bbfe78bb467003aeef0
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
-            location: /api/v2/shipments/shp_cc46dc3741114299ba02a99b8c483645
+            location: /api/v2/shipments/shp_ad1fdcca56c9404b807f2425ec447488
             content-type: 'application/json; charset=utf-8'
-            content-length: '7758'
-            etag: 'W/"f09b298391cb04e8b22c86b16c7f9e53"'
-            x-request-id: 6e215e00-922f-4c4e-90d9-aacd73ccaa13
-            x-runtime: '1.196013'
-            x-node: bigweb7nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            content-length: '4847'
+            etag: 'W/"ac2d7255924151044a15758a710ae62b"'
+            x-request-id: 8d37c66e-d966-42e5-9a66-a8342d44ed07
+            x-runtime: '1.049280'
+            x-node: bigweb5nuq
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-canary: direct
-            x-proxied: ['intlb2nuq 543ba58655', 'extlb1nuq 543ba58655']
+            x-proxied: ['intlb1nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"created_at":"2021-09-07T17:14:19Z","is_return":false,"messages":[{"carrier":"Canpar","carrier_account_id":"ca_58451e27b5bc4f6cb419d9be15705847","type":"rate_error","message":"Unable to retrieve Canpar rates for non-CA origin shipments."}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2021-09-07T17:14:20Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_9aaadb0761084fb290098a7c04468af7","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_490ff015123b49d9832d88dd0815b338","object":"Parcel","created_at":"2021-09-07T17:14:19Z","updated_at":"2021-09-07T17:14:19Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_8d341242c91c458ab336fddb0f4e7381","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.00","currency":"USD","retail_rate":"26.75","retail_currency":"USD","list_rate":"23.00","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_94ad5814f2be4c9e97dc6256b8ec940a","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.16","currency":"USD","retail_rate":"7.70","retail_currency":"USD","list_rate":"7.16","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_8720740b8efd44d3b9ad210456b3c107","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.01","currency":"USD","retail_rate":"7.01","retail_currency":"USD","list_rate":"7.01","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_8591d7eef54c4c5195e20ae0f772fb2e","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"First","carrier":"USPS","rate":"5.19","currency":"USD","retail_rate":"5.19","retail_currency":"USD","list_rate":"5.19","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_242be45f50a64cc6934c3cc7ce9019db","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"19.18","currency":"USD","retail_rate":"19.18","retail_currency":"USD","list_rate":"19.42","list_currency":"USD","delivery_days":3,"delivery_date":"2021-09-10T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":3,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_4f781fb5782d4eb383ab8f68b8b52b83","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"73.23","currency":"USD","retail_rate":"73.23","retail_currency":"USD","list_rate":"75.33","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T08:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_623b5dc9b66144a09c33b05e2b3816bb","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Ground","carrier":"UPS","rate":"11.14","currency":"USD","retail_rate":"11.14","retail_currency":"USD","list_rate":"14.59","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_ebfff836cf984fb7978e370711283ef8","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"37.61","currency":"USD","retail_rate":"37.61","retail_currency":"USD","list_rate":"40.46","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_a12a01061a4441e388d5ae935e2e8659","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"40.68","currency":"USD","retail_rate":"40.68","retail_currency":"USD","list_rate":"42.78","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T10:30:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_36e12bc1f5a849f4a114fa73950ba894","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"26.51","currency":"USD","retail_rate":"26.51","retail_currency":"USD","list_rate":"27.03","list_currency":"USD","delivery_days":2,"delivery_date":"2021-09-09T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_45484e572d1d466799518b77628f322b","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_9aaadb0761084fb290098a7c04468af7","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_45484e572d1d466799518b77628f322b","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_cc46dc3741114299ba02a99b8c483645","object":"Shipment"}'
+        body: '{"created_at":"2021-10-01T22:29:19Z","is_return":false,"messages":[{"carrier":"Canpar","carrier_account_id":"ca_58451e27b5bc4f6cb419d9be15705847","type":"rate_error","message":"Unable to retrieve Canpar rates for non-CA origin shipments."},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","type":"rate_error","message":"XML Rating and Service Selection Service Unavailable"}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2021-10-01T22:29:20Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_e6e1d2acb2d74797919029c83070c071","object":"Address","created_at":"2021-10-01T22:29:19+00:00","updated_at":"2021-10-01T22:29:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_c91ef71134d349eda1f2e7e409ad648a","object":"Parcel","created_at":"2021-10-01T22:29:19Z","updated_at":"2021-10-01T22:29:19Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_b7d9b96e638c4b4d97a83683418a42e2","object":"Rate","created_at":"2021-10-01T22:29:20Z","updated_at":"2021-10-01T22:29:20Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.16","currency":"USD","retail_rate":"7.70","retail_currency":"USD","list_rate":"7.16","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_ad1fdcca56c9404b807f2425ec447488","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_367729f43a454348819f499a08e831bb","object":"Rate","created_at":"2021-10-01T22:29:20Z","updated_at":"2021-10-01T22:29:20Z","mode":"test","service":"First","carrier":"USPS","rate":"5.19","currency":"USD","retail_rate":"5.19","retail_currency":"USD","list_rate":"5.19","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ad1fdcca56c9404b807f2425ec447488","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_14f04074ce1a4980a45bc0887568f0d8","object":"Rate","created_at":"2021-10-01T22:29:20Z","updated_at":"2021-10-01T22:29:20Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.00","currency":"USD","retail_rate":"26.75","retail_currency":"USD","list_rate":"23.00","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_ad1fdcca56c9404b807f2425ec447488","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_6894ae6e80f143d092e0ad480ed6033d","object":"Rate","created_at":"2021-10-01T22:29:20Z","updated_at":"2021-10-01T22:29:20Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.01","currency":"USD","retail_rate":"7.01","retail_currency":"USD","list_rate":"7.01","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ad1fdcca56c9404b807f2425ec447488","carrier_account_id":"ca_qn6QC6fd"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_dfa74fed4855426b9f962f48cb12f10e","object":"Address","created_at":"2021-10-01T22:29:19+00:00","updated_at":"2021-10-01T22:29:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_e6e1d2acb2d74797919029c83070c071","object":"Address","created_at":"2021-10-01T22:29:19+00:00","updated_at":"2021-10-01T22:29:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_dfa74fed4855426b9f962f48cb12f10e","object":"Address","created_at":"2021-10-01T22:29:19+00:00","updated_at":"2021-10-01T22:29:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_ad1fdcca56c9404b807f2425ec447488","object":"Shipment"}'
         curl_info:
             url: 'https://api.easypost.com/v2/shipments'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 864
-            request_size: 1128
+            header_size: 846
+            request_size: 824
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 1.470423
-            namelookup_time: 0.050117
-            connect_time: 0.109508
-            pretransfer_time: 0.18349
-            size_upload: !!float 604
-            size_download: !!float 7758
-            speed_download: !!float 5276
-            speed_upload: !!float 410
-            download_content_length: !!float 7758
-            upload_content_length: !!float 604
-            starttransfer_time: 1.470315
+            total_time: 1.307841
+            namelookup_time: 0.001472
+            connect_time: 0.062316
+            pretransfer_time: 0.144081
+            size_upload: !!float 304
+            size_download: !!float 4847
+            speed_download: !!float 3706
+            speed_upload: !!float 232
+            download_content_length: !!float 4847
+            upload_content_length: !!float 304
+            starttransfer_time: 1.307809
             redirect_time: !!float 0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50506
+            local_ip: 10.130.6.13
+            local_port: 59831
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 183448
-            connect_time_us: 109508
-            namelookup_time_us: 50117
-            pretransfer_time_us: 183490
+            appconnect_time_us: 144021
+            connect_time_us: 62316
+            namelookup_time_us: 1472
+            pretransfer_time_us: 144081
             redirect_time_us: 0
-            starttransfer_time_us: 1470315
-            total_time_us: 1470423
+            starttransfer_time_us: 1307809
+            total_time_us: 1307841

--- a/test/cassettes/shipments/retrieve.yml
+++ b/test/cassettes/shipments/retrieve.yml
@@ -2,12 +2,14 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/shipments/shp_cc46dc3741114299ba02a99b8c483645'
+        url: 'https://api.easypost.com/v2/shipments/shp_ad1fdcca56c9404b807f2425ec447488'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
     response:
         status:
@@ -21,56 +23,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3774dfbc61379dede786b7de00a79ff0
+            x-ep-request-uuid: 8d29b69361578bc0e78bb468003aef6e
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
-            content-length: '7758'
-            etag: 'W/"f09b298391cb04e8b22c86b16c7f9e53"'
-            x-request-id: 5040b66e-ff03-42ad-92cf-e05839c4b4fa
-            x-runtime: '0.099349'
-            x-node: bigweb3nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            content-length: '4847'
+            etag: 'W/"ac2d7255924151044a15758a710ae62b"'
+            x-request-id: d2f7b178-6266-4825-8346-a5610229c130
+            x-runtime: '0.070853'
+            x-node: bigweb6nuq
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 543ba58655', 'extlb1nuq 543ba58655']
+            x-proxied: ['intlb1nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"created_at":"2021-09-07T17:14:19Z","is_return":false,"messages":[{"carrier":"Canpar","carrier_account_id":"ca_58451e27b5bc4f6cb419d9be15705847","type":"rate_error","message":"Unable to retrieve Canpar rates for non-CA origin shipments."}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2021-09-07T17:14:20Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_9aaadb0761084fb290098a7c04468af7","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_490ff015123b49d9832d88dd0815b338","object":"Parcel","created_at":"2021-09-07T17:14:19Z","updated_at":"2021-09-07T17:14:19Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_8d341242c91c458ab336fddb0f4e7381","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.00","currency":"USD","retail_rate":"26.75","retail_currency":"USD","list_rate":"23.00","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_94ad5814f2be4c9e97dc6256b8ec940a","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.16","currency":"USD","retail_rate":"7.70","retail_currency":"USD","list_rate":"7.16","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_8720740b8efd44d3b9ad210456b3c107","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.01","currency":"USD","retail_rate":"7.01","retail_currency":"USD","list_rate":"7.01","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_8591d7eef54c4c5195e20ae0f772fb2e","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"First","carrier":"USPS","rate":"5.19","currency":"USD","retail_rate":"5.19","retail_currency":"USD","list_rate":"5.19","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_242be45f50a64cc6934c3cc7ce9019db","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"19.18","currency":"USD","retail_rate":"19.18","retail_currency":"USD","list_rate":"19.42","list_currency":"USD","delivery_days":3,"delivery_date":"2021-09-10T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":3,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_4f781fb5782d4eb383ab8f68b8b52b83","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"73.23","currency":"USD","retail_rate":"73.23","retail_currency":"USD","list_rate":"75.33","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T08:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_623b5dc9b66144a09c33b05e2b3816bb","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"Ground","carrier":"UPS","rate":"11.14","currency":"USD","retail_rate":"11.14","retail_currency":"USD","list_rate":"14.59","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_ebfff836cf984fb7978e370711283ef8","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"37.61","currency":"USD","retail_rate":"37.61","retail_currency":"USD","list_rate":"40.46","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_a12a01061a4441e388d5ae935e2e8659","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"40.68","currency":"USD","retail_rate":"40.68","retail_currency":"USD","list_rate":"42.78","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T10:30:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_36e12bc1f5a849f4a114fa73950ba894","object":"Rate","created_at":"2021-09-07T17:14:20Z","updated_at":"2021-09-07T17:14:20Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"26.51","currency":"USD","retail_rate":"26.51","retail_currency":"USD","list_rate":"27.03","list_currency":"USD","delivery_days":2,"delivery_date":"2021-09-09T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":2,"shipment_id":"shp_cc46dc3741114299ba02a99b8c483645","carrier_account_id":"ca_r8hLl9jS"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_45484e572d1d466799518b77628f322b","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_9aaadb0761084fb290098a7c04468af7","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_45484e572d1d466799518b77628f322b","object":"Address","created_at":"2021-09-07T17:14:19+00:00","updated_at":"2021-09-07T17:14:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_cc46dc3741114299ba02a99b8c483645","object":"Shipment"}'
+        body: '{"created_at":"2021-10-01T22:29:19Z","is_return":false,"messages":[{"carrier":"Canpar","carrier_account_id":"ca_58451e27b5bc4f6cb419d9be15705847","type":"rate_error","message":"Unable to retrieve Canpar rates for non-CA origin shipments."},{"carrier":"UPS","carrier_account_id":"ca_r8hLl9jS","type":"rate_error","message":"XML Rating and Service Selection Service Unavailable"}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2021-10-01T22:29:20Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_e6e1d2acb2d74797919029c83070c071","object":"Address","created_at":"2021-10-01T22:29:19+00:00","updated_at":"2021-10-01T22:29:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_c91ef71134d349eda1f2e7e409ad648a","object":"Parcel","created_at":"2021-10-01T22:29:19Z","updated_at":"2021-10-01T22:29:19Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_b7d9b96e638c4b4d97a83683418a42e2","object":"Rate","created_at":"2021-10-01T22:29:20Z","updated_at":"2021-10-01T22:29:20Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.16","currency":"USD","retail_rate":"7.70","retail_currency":"USD","list_rate":"7.16","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_ad1fdcca56c9404b807f2425ec447488","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_367729f43a454348819f499a08e831bb","object":"Rate","created_at":"2021-10-01T22:29:20Z","updated_at":"2021-10-01T22:29:20Z","mode":"test","service":"First","carrier":"USPS","rate":"5.19","currency":"USD","retail_rate":"5.19","retail_currency":"USD","list_rate":"5.19","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ad1fdcca56c9404b807f2425ec447488","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_14f04074ce1a4980a45bc0887568f0d8","object":"Rate","created_at":"2021-10-01T22:29:20Z","updated_at":"2021-10-01T22:29:20Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.00","currency":"USD","retail_rate":"26.75","retail_currency":"USD","list_rate":"23.00","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_ad1fdcca56c9404b807f2425ec447488","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_6894ae6e80f143d092e0ad480ed6033d","object":"Rate","created_at":"2021-10-01T22:29:20Z","updated_at":"2021-10-01T22:29:20Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.01","currency":"USD","retail_rate":"7.01","retail_currency":"USD","list_rate":"7.01","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ad1fdcca56c9404b807f2425ec447488","carrier_account_id":"ca_qn6QC6fd"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_dfa74fed4855426b9f962f48cb12f10e","object":"Address","created_at":"2021-10-01T22:29:19+00:00","updated_at":"2021-10-01T22:29:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_e6e1d2acb2d74797919029c83070c071","object":"Address","created_at":"2021-10-01T22:29:19+00:00","updated_at":"2021-10-01T22:29:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_dfa74fed4855426b9f962f48cb12f10e","object":"Address","created_at":"2021-10-01T22:29:19+00:00","updated_at":"2021-10-01T22:29:19+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_ad1fdcca56c9404b807f2425ec447488","object":"Shipment"}'
         curl_info:
-            url: 'https://api.easypost.com/v2/shipments/shp_cc46dc3741114299ba02a99b8c483645'
+            url: 'https://api.easypost.com/v2/shipments/shp_ad1fdcca56c9404b807f2425ec447488'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 775
-            request_size: 490
+            request_size: 535
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.307879
-            namelookup_time: 0.001624
-            connect_time: 0.062255
-            pretransfer_time: 0.143319
+            total_time: 0.268224
+            namelookup_time: 0.001894
+            connect_time: 0.060689
+            pretransfer_time: 0.134796
             size_upload: !!float 0
-            size_download: !!float 7758
-            speed_download: !!float 25198
+            size_download: !!float 4847
+            speed_download: !!float 18070
             speed_upload: !!float 0
-            download_content_length: !!float 7758
+            download_content_length: !!float 4847
             upload_content_length: !!float 0
-            starttransfer_time: 0.307829
+            starttransfer_time: 0.268149
             redirect_time: !!float 0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50507
+            local_ip: 10.130.6.13
+            local_port: 59832
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 143273
-            connect_time_us: 62255
-            namelookup_time_us: 1624
-            pretransfer_time_us: 143319
+            appconnect_time_us: 134741
+            connect_time_us: 60689
+            namelookup_time_us: 1894
+            pretransfer_time_us: 134796
             redirect_time_us: 0
-            starttransfer_time_us: 307829
-            total_time_us: 307879
+            starttransfer_time_us: 268149
+            total_time_us: 268224

--- a/test/cassettes/shipments/smartrates.yml
+++ b/test/cassettes/shipments/smartrates.yml
@@ -5,11 +5,13 @@
         url: 'https://api.easypost.com/v2/shipments'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: ''
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
-        body: 'shipment%5Bto_address%5D%5Bstreet1%5D=388+Townsend+St&shipment%5Bto_address%5D%5Bstreet2%5D=Apt+20&shipment%5Bto_address%5D%5Bcity%5D=San+Francisco&shipment%5Bto_address%5D%5Bstate%5D=CA&shipment%5Bto_address%5D%5Bzip%5D=94107&shipment%5Bfrom_address%5D%5Bstreet1%5D=388+Townsend+St&shipment%5Bfrom_address%5D%5Bstreet2%5D=Apt+20&shipment%5Bfrom_address%5D%5Bcity%5D=San+Francisco&shipment%5Bfrom_address%5D%5Bstate%5D=CA&shipment%5Bfrom_address%5D%5Bzip%5D=94107&shipment%5Bparcel%5D%5Blength%5D=10&shipment%5Bparcel%5D%5Bwidth%5D=8&shipment%5Bparcel%5D%5Bheight%5D=4&shipment%5Bparcel%5D%5Bweight%5D=15'
+        body: '{"shipment":{"to_address":{"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107"},"from_address":{"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107"},"parcel":{"length":"10","width":"8","height":"4","weight":"15"}}}'
     response:
         status:
             http_version: '1.1'
@@ -22,70 +24,71 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3774dfba61379dede786b7df00a7a00e
+            x-ep-request-uuid: 8d29b69361578bc1e78bb46a003aeff3
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
-            location: /api/v2/shipments/shp_280e141790b24462b6b1da283d6f5d53
+            location: /api/v2/shipments/shp_163e1965f73b4882b86789583079b82d
             content-type: 'application/json; charset=utf-8'
             content-length: '7758'
-            etag: 'W/"69bc287de54402795cc45412e7af3f37"'
-            x-request-id: 5762217d-c10f-40a3-a74e-5a87922e5524
-            x-runtime: '1.158583'
-            x-node: bigweb7nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            etag: 'W/"c0c328eb61fe8ccb1434b69d9d214749"'
+            x-request-id: 3776e564-c1c4-4522-9d01-c52c920e56ab
+            x-runtime: '1.279248'
+            x-node: bigweb4nuq
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-canary: direct
-            x-proxied: ['intlb2nuq 543ba58655', 'extlb1nuq 543ba58655']
+            x-proxied: ['intlb2nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"created_at":"2021-09-07T17:14:21Z","is_return":false,"messages":[{"carrier":"Canpar","carrier_account_id":"ca_58451e27b5bc4f6cb419d9be15705847","type":"rate_error","message":"Unable to retrieve Canpar rates for non-CA origin shipments."}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2021-09-07T17:14:22Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_4199aebbb60b455a868c9bc9aa579fa4","object":"Address","created_at":"2021-09-07T17:14:21+00:00","updated_at":"2021-09-07T17:14:21+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_f76e75bf9c7348498d0dc8179278b3fa","object":"Parcel","created_at":"2021-09-07T17:14:21Z","updated_at":"2021-09-07T17:14:21Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_cb93540531954f3f9f79af5e36cdcac3","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.00","currency":"USD","retail_rate":"26.75","retail_currency":"USD","list_rate":"23.00","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_19d4a686529b4afda7a8a127321f649b","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.16","currency":"USD","retail_rate":"7.70","retail_currency":"USD","list_rate":"7.16","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_d321ceb31f354da6b8c79189ffc27465","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.01","currency":"USD","retail_rate":"7.01","retail_currency":"USD","list_rate":"7.01","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_a3a4a2bf4e284013804570da1a8514e0","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"First","carrier":"USPS","rate":"5.19","currency":"USD","retail_rate":"5.19","retail_currency":"USD","list_rate":"5.19","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_cd5745337b0e45cd8d84ab7750f4b059","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"19.18","currency":"USD","retail_rate":"19.18","retail_currency":"USD","list_rate":"19.42","list_currency":"USD","delivery_days":3,"delivery_date":"2021-09-10T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":3,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_b712faf9c2784cc08e43bac3ee23923c","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"73.23","currency":"USD","retail_rate":"73.23","retail_currency":"USD","list_rate":"75.33","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T08:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_5305640e68164ee39c8f3642369de21e","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"Ground","carrier":"UPS","rate":"11.14","currency":"USD","retail_rate":"11.14","retail_currency":"USD","list_rate":"14.59","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_d753e4e8ad134e758b14db8f7d261d7e","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"37.61","currency":"USD","retail_rate":"37.61","retail_currency":"USD","list_rate":"40.46","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_2d38436fd47f4d569f1d262966da9485","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"40.68","currency":"USD","retail_rate":"40.68","retail_currency":"USD","list_rate":"42.78","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T10:30:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_017c5a5781084012823c89c1a684811e","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"26.51","currency":"USD","retail_rate":"26.51","retail_currency":"USD","list_rate":"27.03","list_currency":"USD","delivery_days":2,"delivery_date":"2021-09-09T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":2,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_fe82e7b28d5842c8bdd4036d195e3cb9","object":"Address","created_at":"2021-09-07T17:14:21+00:00","updated_at":"2021-09-07T17:14:21+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_4199aebbb60b455a868c9bc9aa579fa4","object":"Address","created_at":"2021-09-07T17:14:21+00:00","updated_at":"2021-09-07T17:14:21+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_fe82e7b28d5842c8bdd4036d195e3cb9","object":"Address","created_at":"2021-09-07T17:14:21+00:00","updated_at":"2021-09-07T17:14:21+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_280e141790b24462b6b1da283d6f5d53","object":"Shipment"}'
+        body: '{"created_at":"2021-10-01T22:29:22Z","is_return":false,"messages":[{"carrier":"Canpar","carrier_account_id":"ca_58451e27b5bc4f6cb419d9be15705847","type":"rate_error","message":"Unable to retrieve Canpar rates for non-CA origin shipments."}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2021-10-01T22:29:23Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_9e04f64c7c644e2d8a087d249839b299","object":"Address","created_at":"2021-10-01T22:29:21+00:00","updated_at":"2021-10-01T22:29:21+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_1eb492f38aa24b548a8c21ace80bb64d","object":"Parcel","created_at":"2021-10-01T22:29:22Z","updated_at":"2021-10-01T22:29:22Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.0,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_e7e7c2b0820d48068d7298704a4cd788","object":"Rate","created_at":"2021-10-01T22:29:23Z","updated_at":"2021-10-01T22:29:23Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.00","currency":"USD","retail_rate":"26.75","retail_currency":"USD","list_rate":"23.00","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_163e1965f73b4882b86789583079b82d","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_25099844fbc1486db6278c9a1a24cbac","object":"Rate","created_at":"2021-10-01T22:29:23Z","updated_at":"2021-10-01T22:29:23Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.16","currency":"USD","retail_rate":"7.70","retail_currency":"USD","list_rate":"7.16","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_163e1965f73b4882b86789583079b82d","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_42c011907ae7489fa10ab8758f972590","object":"Rate","created_at":"2021-10-01T22:29:23Z","updated_at":"2021-10-01T22:29:23Z","mode":"test","service":"First","carrier":"USPS","rate":"5.19","currency":"USD","retail_rate":"5.19","retail_currency":"USD","list_rate":"5.19","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_163e1965f73b4882b86789583079b82d","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_f70aa26c1a2a4c979b5537651c4f36d6","object":"Rate","created_at":"2021-10-01T22:29:23Z","updated_at":"2021-10-01T22:29:23Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.01","currency":"USD","retail_rate":"7.01","retail_currency":"USD","list_rate":"7.01","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_163e1965f73b4882b86789583079b82d","carrier_account_id":"ca_qn6QC6fd"},{"id":"rate_66a581671a2f44849960ed20d09d23cd","object":"Rate","created_at":"2021-10-01T22:29:23Z","updated_at":"2021-10-01T22:29:23Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"19.31","currency":"USD","retail_rate":"19.31","retail_currency":"USD","list_rate":"19.55","list_currency":"USD","delivery_days":3,"delivery_date":"2021-10-06T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":3,"shipment_id":"shp_163e1965f73b4882b86789583079b82d","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_c6534094298c486bbc56e1a5c34fa14e","object":"Rate","created_at":"2021-10-01T22:29:23Z","updated_at":"2021-10-01T22:29:23Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"73.73","currency":"USD","retail_rate":"73.73","retail_currency":"USD","list_rate":"75.85","list_currency":"USD","delivery_days":1,"delivery_date":"2021-10-04T08:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_163e1965f73b4882b86789583079b82d","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_eada5c33798543e2ba04911dbf9241c3","object":"Rate","created_at":"2021-10-01T22:29:23Z","updated_at":"2021-10-01T22:29:23Z","mode":"test","service":"Ground","carrier":"UPS","rate":"11.14","currency":"USD","retail_rate":"11.14","retail_currency":"USD","list_rate":"14.59","list_currency":"USD","delivery_days":1,"delivery_date":"2021-10-02T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_163e1965f73b4882b86789583079b82d","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_9489bc6808e24bdbb945c713a69c71cc","object":"Rate","created_at":"2021-10-01T22:29:23Z","updated_at":"2021-10-01T22:29:23Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"37.86","currency":"USD","retail_rate":"37.86","retail_currency":"USD","list_rate":"40.73","list_currency":"USD","delivery_days":1,"delivery_date":"2021-10-04T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_163e1965f73b4882b86789583079b82d","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_261aa8e20d6143488bc5d9a6d1af9e4b","object":"Rate","created_at":"2021-10-01T22:29:23Z","updated_at":"2021-10-01T22:29:23Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"40.95","currency":"USD","retail_rate":"40.95","retail_currency":"USD","list_rate":"43.07","list_currency":"USD","delivery_days":1,"delivery_date":"2021-10-04T10:30:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_163e1965f73b4882b86789583079b82d","carrier_account_id":"ca_r8hLl9jS"},{"id":"rate_cce15e35cd564faebe8124eb47281876","object":"Rate","created_at":"2021-10-01T22:29:23Z","updated_at":"2021-10-01T22:29:23Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"26.69","currency":"USD","retail_rate":"26.69","retail_currency":"USD","list_rate":"27.21","list_currency":"USD","delivery_days":2,"delivery_date":"2021-10-05T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":2,"shipment_id":"shp_163e1965f73b4882b86789583079b82d","carrier_account_id":"ca_r8hLl9jS"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_de03340cd75e431b87352a1fac61bdfd","object":"Address","created_at":"2021-10-01T22:29:21+00:00","updated_at":"2021-10-01T22:29:21+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_9e04f64c7c644e2d8a087d249839b299","object":"Address","created_at":"2021-10-01T22:29:21+00:00","updated_at":"2021-10-01T22:29:21+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_de03340cd75e431b87352a1fac61bdfd","object":"Address","created_at":"2021-10-01T22:29:21+00:00","updated_at":"2021-10-01T22:29:21+00:00","name":null,"company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":null,"email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_163e1965f73b4882b86789583079b82d","object":"Shipment"}'
         curl_info:
             url: 'https://api.easypost.com/v2/shipments'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 864
-            request_size: 1128
+            header_size: 846
+            request_size: 824
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 1.364615
-            namelookup_time: 0.001127
-            connect_time: 0.0599
-            pretransfer_time: 0.140029
-            size_upload: !!float 604
+            total_time: 1.491835
+            namelookup_time: 0.001118
+            connect_time: 0.059669
+            pretransfer_time: 0.132285
+            size_upload: !!float 304
             size_download: !!float 7758
-            speed_download: !!float 5685
-            speed_upload: !!float 442
+            speed_download: !!float 5200
+            speed_upload: !!float 203
             download_content_length: !!float 7758
-            upload_content_length: !!float 604
-            starttransfer_time: 1.364545
+            upload_content_length: !!float 304
+            starttransfer_time: 1.491769
             redirect_time: !!float 0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50508
+            local_ip: 10.130.6.13
+            local_port: 59834
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 139954
-            connect_time_us: 59900
-            namelookup_time_us: 1127
-            pretransfer_time_us: 140029
+            appconnect_time_us: 132204
+            connect_time_us: 59669
+            namelookup_time_us: 1118
+            pretransfer_time_us: 132285
             redirect_time_us: 0
-            starttransfer_time_us: 1364545
-            total_time_us: 1364615
+            starttransfer_time_us: 1491769
+            total_time_us: 1491835
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/shipments/shp_280e141790b24462b6b1da283d6f5d53/smartrate'
+        url: 'https://api.easypost.com/v2/shipments/shp_163e1965f73b4882b86789583079b82d/smartrate'
         headers:
             Host: api.easypost.com
-            X-Client-User-Agent: '{"bindings_version":"3.6.0","lang":"php","lang_version":"7.4.23","publisher":"easypost","uname":"Darwin MacBook-Pro-Justin-EasyPost 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5\/RELEASE_X86_64 x86_64"}'
-            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            Accept: application/json
             Authorization: ''
+            Content-Type: application/json
+            User-Agent: 'EasyPost/v2 PhpClient/3.6.0'
+            X-Client-User-Agent: ''
             EasyPost-Version: '2'
     response:
         status:
@@ -99,56 +102,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3774dfba61379deee786b7e000a7a0a2
+            x-ep-request-uuid: 8d29b69661578bc3e78bb46b003af08b
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
-            content-length: '6447'
-            etag: 'W/"4eb49ff0723a26dab28ecc7d33e46aca"'
-            x-request-id: 0c75c757-efd5-4b4e-a034-74b94c401309
-            x-runtime: '0.095307'
-            x-node: bigweb1nuq
-            x-version-label: easypost-202109032253-dc86ce0535-master
+            content-length: '6448'
+            etag: 'W/"ab183b1859923e43d23ba5687f65b178"'
+            x-request-id: a32a54fa-ee07-4c98-9a84-b7360d417e48
+            x-runtime: '0.169529'
+            x-node: bigweb3nuq
+            x-version-label: easypost-202110011858-559f609973-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 543ba58655', 'extlb1nuq 543ba58655']
+            x-proxied: ['intlb1nuq d40607e4ab', 'extlb2nuq d40607e4ab']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-09-07T17:14:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_cb93540531954f3f9f79af5e36cdcac3","list_currency":"USD","list_rate":23.0,"mode":"test","object":"Rate","rate":23.0,"retail_currency":"USD","retail_rate":26.75,"service":"Express","shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":3,"percentile_99":4},"updated_at":"2021-09-07T17:14:22Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-09-07T17:14:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_19d4a686529b4afda7a8a127321f649b","list_currency":"USD","list_rate":7.16,"mode":"test","object":"Rate","rate":7.16,"retail_currency":"USD","retail_rate":7.7,"service":"Priority","shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2021-09-07T17:14:22Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-09-07T17:14:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_d321ceb31f354da6b8c79189ffc27465","list_currency":"USD","list_rate":7.01,"mode":"test","object":"Rate","rate":7.01,"retail_currency":"USD","retail_rate":7.01,"service":"ParcelSelect","shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":3,"percentile_95":4,"percentile_97":5,"percentile_99":9},"updated_at":"2021-09-07T17:14:22Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-09-07T17:14:22Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_a3a4a2bf4e284013804570da1a8514e0","list_currency":"USD","list_rate":5.19,"mode":"test","object":"Rate","rate":5.19,"retail_currency":"USD","retail_rate":5.19,"service":"First","shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":2,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2021-09-07T17:14:22Z"},{"id":"rate_cd5745337b0e45cd8d84ab7750f4b059","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"19.18","currency":"USD","retail_rate":"19.18","retail_currency":"USD","list_rate":"19.42","list_currency":"USD","delivery_days":3,"delivery_date":"2021-09-10T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":3,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":3,"percentile_75":3,"percentile_85":3,"percentile_90":3,"percentile_95":3,"percentile_97":3,"percentile_99":3}},{"id":"rate_b712faf9c2784cc08e43bac3ee23923c","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"73.23","currency":"USD","retail_rate":"73.23","retail_currency":"USD","list_rate":"75.33","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T08:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":1}},{"id":"rate_5305640e68164ee39c8f3642369de21e","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"Ground","carrier":"UPS","rate":"11.14","currency":"USD","retail_rate":"11.14","retail_currency":"USD","list_rate":"14.59","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":1}},{"id":"rate_d753e4e8ad134e758b14db8f7d261d7e","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"37.61","currency":"USD","retail_rate":"37.61","retail_currency":"USD","list_rate":"40.46","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":1}},{"id":"rate_2d38436fd47f4d569f1d262966da9485","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"40.68","currency":"USD","retail_rate":"40.68","retail_currency":"USD","list_rate":"42.78","list_currency":"USD","delivery_days":1,"delivery_date":"2021-09-08T10:30:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":1}},{"id":"rate_017c5a5781084012823c89c1a684811e","object":"Rate","created_at":"2021-09-07T17:14:22Z","updated_at":"2021-09-07T17:14:22Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"26.51","currency":"USD","retail_rate":"26.51","retail_currency":"USD","list_rate":"27.03","list_currency":"USD","delivery_days":2,"delivery_date":"2021-09-09T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":2,"shipment_id":"shp_280e141790b24462b6b1da283d6f5d53","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":2,"percentile_75":2,"percentile_85":2,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":2}}]}'
+        body: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-10-01T22:29:23Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_e7e7c2b0820d48068d7298704a4cd788","list_currency":"USD","list_rate":23.0,"mode":"test","object":"Rate","rate":23.0,"retail_currency":"USD","retail_rate":26.75,"service":"Express","shipment_id":"shp_163e1965f73b4882b86789583079b82d","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":3,"percentile_99":5},"updated_at":"2021-10-01T22:29:23Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-10-01T22:29:23Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_25099844fbc1486db6278c9a1a24cbac","list_currency":"USD","list_rate":7.16,"mode":"test","object":"Rate","rate":7.16,"retail_currency":"USD","retail_rate":7.7,"service":"Priority","shipment_id":"shp_163e1965f73b4882b86789583079b82d","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2021-10-01T22:29:23Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-10-01T22:29:23Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_42c011907ae7489fa10ab8758f972590","list_currency":"USD","list_rate":5.19,"mode":"test","object":"Rate","rate":5.19,"retail_currency":"USD","retail_rate":5.19,"service":"First","shipment_id":"shp_163e1965f73b4882b86789583079b82d","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":2,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2021-10-01T22:29:23Z"},{"carrier":"USPS","carrier_account_id":"ca_qn6QC6fd","created_at":"2021-10-01T22:29:23Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_f70aa26c1a2a4c979b5537651c4f36d6","list_currency":"USD","list_rate":7.01,"mode":"test","object":"Rate","rate":7.01,"retail_currency":"USD","retail_rate":7.01,"service":"ParcelSelect","shipment_id":"shp_163e1965f73b4882b86789583079b82d","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":6,"percentile_97":6,"percentile_99":10},"updated_at":"2021-10-01T22:29:23Z"},{"id":"rate_66a581671a2f44849960ed20d09d23cd","object":"Rate","created_at":"2021-10-01T22:29:23Z","updated_at":"2021-10-01T22:29:23Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"19.31","currency":"USD","retail_rate":"19.31","retail_currency":"USD","list_rate":"19.55","list_currency":"USD","delivery_days":3,"delivery_date":"2021-10-06T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":3,"shipment_id":"shp_163e1965f73b4882b86789583079b82d","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":3,"percentile_75":3,"percentile_85":3,"percentile_90":3,"percentile_95":3,"percentile_97":3,"percentile_99":3}},{"id":"rate_c6534094298c486bbc56e1a5c34fa14e","object":"Rate","created_at":"2021-10-01T22:29:23Z","updated_at":"2021-10-01T22:29:23Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"73.73","currency":"USD","retail_rate":"73.73","retail_currency":"USD","list_rate":"75.85","list_currency":"USD","delivery_days":1,"delivery_date":"2021-10-04T08:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_163e1965f73b4882b86789583079b82d","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":1}},{"id":"rate_eada5c33798543e2ba04911dbf9241c3","object":"Rate","created_at":"2021-10-01T22:29:23Z","updated_at":"2021-10-01T22:29:23Z","mode":"test","service":"Ground","carrier":"UPS","rate":"11.14","currency":"USD","retail_rate":"11.14","retail_currency":"USD","list_rate":"14.59","list_currency":"USD","delivery_days":1,"delivery_date":"2021-10-02T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_163e1965f73b4882b86789583079b82d","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":1}},{"id":"rate_9489bc6808e24bdbb945c713a69c71cc","object":"Rate","created_at":"2021-10-01T22:29:23Z","updated_at":"2021-10-01T22:29:23Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"37.86","currency":"USD","retail_rate":"37.86","retail_currency":"USD","list_rate":"40.73","list_currency":"USD","delivery_days":1,"delivery_date":"2021-10-04T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_163e1965f73b4882b86789583079b82d","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":1}},{"id":"rate_261aa8e20d6143488bc5d9a6d1af9e4b","object":"Rate","created_at":"2021-10-01T22:29:23Z","updated_at":"2021-10-01T22:29:23Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"40.95","currency":"USD","retail_rate":"40.95","retail_currency":"USD","list_rate":"43.07","list_currency":"USD","delivery_days":1,"delivery_date":"2021-10-04T10:30:00Z","delivery_date_guaranteed":true,"est_delivery_days":1,"shipment_id":"shp_163e1965f73b4882b86789583079b82d","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":1,"percentile_97":1,"percentile_99":1}},{"id":"rate_cce15e35cd564faebe8124eb47281876","object":"Rate","created_at":"2021-10-01T22:29:23Z","updated_at":"2021-10-01T22:29:23Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"26.69","currency":"USD","retail_rate":"26.69","retail_currency":"USD","list_rate":"27.21","list_currency":"USD","delivery_days":2,"delivery_date":"2021-10-05T23:00:00Z","delivery_date_guaranteed":true,"est_delivery_days":2,"shipment_id":"shp_163e1965f73b4882b86789583079b82d","carrier_account_id":"ca_r8hLl9jS","time_in_transit":{"percentile_50":2,"percentile_75":2,"percentile_85":2,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":2}}]}'
         curl_info:
-            url: 'https://api.easypost.com/v2/shipments/shp_280e141790b24462b6b1da283d6f5d53/smartrate'
+            url: 'https://api.easypost.com/v2/shipments/shp_163e1965f73b4882b86789583079b82d/smartrate'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 775
-            request_size: 500
+            request_size: 545
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.306874
-            namelookup_time: 0.001937
-            connect_time: 0.062354
-            pretransfer_time: 0.148083
+            total_time: 0.381981
+            namelookup_time: 0.001346
+            connect_time: 0.06239
+            pretransfer_time: 0.148501
             size_upload: !!float 0
-            size_download: !!float 6447
-            speed_download: !!float 21008
+            size_download: !!float 6448
+            speed_download: !!float 16880
             speed_upload: !!float 0
-            download_content_length: !!float 6447
+            download_content_length: !!float 6448
             upload_content_length: !!float 0
-            starttransfer_time: 0.306733
+            starttransfer_time: 0.381937
             redirect_time: !!float 0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.9
-            local_port: 50509
+            local_ip: 10.130.6.13
+            local_port: 59835
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 148028
-            connect_time_us: 62354
-            namelookup_time_us: 1937
-            pretransfer_time_us: 148083
+            appconnect_time_us: 148422
+            connect_time_us: 62390
+            namelookup_time_us: 1346
+            pretransfer_time_us: 148501
             redirect_time_us: 0
-            starttransfer_time_us: 306733
-            total_time_us: 306874
+            starttransfer_time_us: 381937
+            total_time_us: 381981


### PR DESCRIPTION
JSON encodes bodies instead of formencoding them, this will pave the way for new features such as `tax_identifiers`.

We leave GET and DELETE requests alone with url encoding (since you cannot pass a POST body on those items) and JSON encode POST/PATCH/PUT requests instead of form encoding them. Refactored a couple items and renamed for a clearer experience.

Re-recorded all cassettes and they worked great.