### PR TITLE
feat: adds empty TaxIdentifier class

### DIFF
--- a/lib/EasyPost/TaxIdentifier.php
+++ b/lib/EasyPost/TaxIdentifier.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost;
+
+class TaxIdentifier extends EasypostResource
+{
+}

--- a/lib/easypost.php
+++ b/lib/easypost.php
@@ -38,6 +38,7 @@ require(dirname(__FILE__) . '/EasyPost/Refund.php');
 require(dirname(__FILE__) . '/EasyPost/Report.php');
 require(dirname(__FILE__) . '/EasyPost/ScanForm.php');
 require(dirname(__FILE__) . '/EasyPost/Shipment.php');
+require(dirname(__FILE__) . '/EasyPost/TaxIdentifier.php');
 require(dirname(__FILE__) . '/EasyPost/Tracker.php');
 require(dirname(__FILE__) . '/EasyPost/User.php');
 require(dirname(__FILE__) . '/EasyPost/Webhook.php');


### PR DESCRIPTION
Following convention, I'm adding an empty TaxIdentifier class here; however, it's not technically required to start using tax identifiers (once #111 lands)