### PR TITLE
chore: sets a default timeout of 60 seconds on requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT RELEASE
 
-* Set a default timeout of 60 seconds for connections and requests
+* Set a default timeout of 30 seconds for connections and 60 seconds for requests
 
 ### 4.0.2 2021-10-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT RELEASE
 
-* Set a default timeout of 30 seconds for connections and requests
+* Set a default timeout of 60 seconds for connections and requests
 
 ### 4.0.2 2021-10-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### NEXT RELEASE
+
+* Set a default timeout of 30 seconds for connections and requests
+
 ### 4.0.2 2021-10-20
 
 * Further fixes JSON encoding by dropping null key/values, sending values as strings where necessary (returning to previous behavior), and removing the `array_filter` from the previous release

--- a/lib/EasyPost/EasyPost.php
+++ b/lib/EasyPost/EasyPost.php
@@ -26,7 +26,7 @@ abstract class EasyPost
      *
      * @var int|null
      */
-    public static $connectTimeout;
+    public static $connectTimeout = 30000;
 
     /**
      * Time in milliseconds to wait for a response.
@@ -35,7 +35,7 @@ abstract class EasyPost
      *
      * @var int|null
      */
-    public static $responseTimeout;
+    public static $responseTimeout = 30000;
 
     /**
      * @var string

--- a/lib/EasyPost/EasyPost.php
+++ b/lib/EasyPost/EasyPost.php
@@ -26,7 +26,7 @@ abstract class EasyPost
      *
      * @var int|null
      */
-    public static $connectTimeout = 30000;
+    public static $connectTimeout = 60000;
 
     /**
      * Time in milliseconds to wait for a response.
@@ -35,7 +35,7 @@ abstract class EasyPost
      *
      * @var int|null
      */
-    public static $responseTimeout = 30000;
+    public static $responseTimeout = 60000;
 
     /**
      * @var string

--- a/lib/EasyPost/EasyPost.php
+++ b/lib/EasyPost/EasyPost.php
@@ -26,7 +26,7 @@ abstract class EasyPost
      *
      * @var int|null
      */
-    public static $connectTimeout = 60000;
+    public static $connectTimeout = 30000;
 
     /**
      * Time in milliseconds to wait for a response.

--- a/lib/EasyPost/Requestor.php
+++ b/lib/EasyPost/Requestor.php
@@ -305,7 +305,7 @@ class Requestor
         switch ($errorNum) {
             case CURLE_COULDNT_CONNECT:
             case CURLE_COULDNT_RESOLVE_HOST:
-            case CURLE_OPERATION_TIMEOUTED:
+            case CURLE_OPERATION_TIMEDOUT:
                 $msg = "Could not connect to EasyPost ({$apiBase}). Please check your internet connection and try again.  If this problem persists please let us know at {$supportEmail}.";
                 break;
             case CURLE_SSL_CACERT:


### PR DESCRIPTION
This sets a default timeout of 30 seconds for connections and 60 seconds for requests. Currently, there is no timeout at all set and connections will stay open forever (or until the EasyPost servers kill them off).

60 seconds was chosen as it's long enough not to be hostile but short enough to not leave connections open for vast amounts of time.

Similarly, `CURLE_OPERATION_TIMEOUTED` is aliased to `CURLE_OPERATION_TIMEDOUT` which is now the proper way of writing this option. See https://www.php.net/manual/en/curl.constants.php for details.

This was end to end tested by setting the timeout to `1ms` and receiving a timeout error, then removing the timeout call to use the new default which sent the request through under 60 seconds.