### PR TITLE
chore: test library against PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: set up php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.1
       - name: install composer
         run: composer self-update
       - name: install dependencies
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        phpversion: [7.3, 7.4, 8.0]
+        phpversion: [7.3, 7.4, 8.0, 8.1]
     steps:
       - uses: actions/checkout@v2
       - name: set up php


### PR DESCRIPTION
PHP 8.1 just came out. This adds PHP 8.1 to the matrix of versions to test against.