### PR TITLE
chore: removes the remainder of API keys from examples

### DIFF
--- a/examples/addresses.php
+++ b/examples/addresses.php
@@ -2,7 +2,7 @@
 
 // require_once("../vendor/autoload.php");
 require_once("../lib/easypost.php");
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 try {
     // create address

--- a/examples/addresses_verify.php
+++ b/examples/addresses_verify.php
@@ -2,7 +2,7 @@
 
 // require_once("../vendor/autoload.php");
 require_once("../lib/easypost.php");
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // create address
 $address_params = array(

--- a/examples/addresses_verify_failure.php
+++ b/examples/addresses_verify_failure.php
@@ -2,7 +2,7 @@
 
 // require_once("../vendor/autoload.php");
 require_once("../lib/easypost.php");
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // create address
 $address_params = array(

--- a/examples/addresses_verify_strict_failure.php
+++ b/examples/addresses_verify_strict_failure.php
@@ -2,7 +2,7 @@
 
 // require_once("../vendor/autoload.php");
 require_once("../lib/easypost.php");
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 try {
     // create address

--- a/examples/batches.php
+++ b/examples/batches.php
@@ -2,7 +2,7 @@
 
 require_once("../lib/easypost.php");
 
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // create addresses
 $from_address = array(

--- a/examples/carrier_account_management.php
+++ b/examples/carrier_account_management.php
@@ -2,7 +2,7 @@
 
 require_once("../lib/easypost.php");
 
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 define("ECHO_ALL_CA", true);
 define("ECHO_CA_TYPES", false);

--- a/examples/customsinfos.php
+++ b/examples/customsinfos.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once("../vendor/autoload.php");
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // CustomsItem: create
 $params = array("description"      => "I like your dog, he's vry nice.",

--- a/examples/insurance.php
+++ b/examples/insurance.php
@@ -2,7 +2,7 @@
 
 require_once("../lib/easypost.php");
 
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 $tracking_code = "EZ2000000002";
 $carrier = "USPS";

--- a/examples/intl_shipments.php
+++ b/examples/intl_shipments.php
@@ -3,7 +3,7 @@
 // require_once("../vendor/autoload.php");
 require_once("../lib/easypost.php");
 
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // create addresses
 $sf_address_params = array(

--- a/examples/order_international.php
+++ b/examples/order_international.php
@@ -2,7 +2,7 @@
 
 require_once("../lib/easypost.php");
 
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 $sf = array(
     "name"    => "EasyPost.com",

--- a/examples/orders.php
+++ b/examples/orders.php
@@ -2,7 +2,7 @@
 
 require_once("../lib/easypost.php");
 
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 $sf = array(
     "name"    => "EasyPost.com",

--- a/examples/parcels.php
+++ b/examples/parcels.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once("../vendor/autoload.php");
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // Parcel: create
 $params = array("length" => 20.2,

--- a/examples/pickups.php
+++ b/examples/pickups.php
@@ -2,7 +2,7 @@
 
 require_once("../lib/easypost.php");
 
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 $to_address = \EasyPost\Address::create(
     array(

--- a/examples/rates.php
+++ b/examples/rates.php
@@ -2,7 +2,7 @@
 
 require_once("../lib/easypost.php");
 
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // get shipment rates (assumes you have a shipment object)
 // this is optional as rates are added to the obj when it's created if addresses and parcel are present

--- a/examples/readme.php
+++ b/examples/readme.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once("../vendor/autoload.php");
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 $to_address = \EasyPost\Address::create(
     array(

--- a/examples/refunds.php
+++ b/examples/refunds.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once("../vendor/autoload.php");
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 try {
     // create refund

--- a/examples/reports.php
+++ b/examples/reports.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once("../lib/easypost.php");
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 
 // Create a shipment report

--- a/examples/scanforms.php
+++ b/examples/scanforms.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once("../lib/easypost.php");
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // create addresses
 $from_address = array(

--- a/examples/shipment.php
+++ b/examples/shipment.php
@@ -2,7 +2,7 @@
 
 require_once("../lib/easypost.php");
 
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 $shipment = \EasyPost\Shipment::create(array(
   'to_address' => array(

--- a/examples/shipment_from_tracking_codes.php
+++ b/examples/shipment_from_tracking_codes.php
@@ -2,7 +2,7 @@
 
 require_once("../lib/easypost.php");
 
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 $shipment = \EasyPost\Shipment::create_from_tracking_code(array("tracking_code" => "1Z0X89330378901784", "options" => array("residential_to_address" => 1)));
 

--- a/examples/timeouts.php
+++ b/examples/timeouts.php
@@ -2,7 +2,7 @@
 
 require_once("../lib/easypost.php");
 
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 $tracking_code = "EZ2000000002";
 $carrier = "USPS";

--- a/examples/tracker_batch_create.php
+++ b/examples/tracker_batch_create.php
@@ -2,7 +2,7 @@
 
 require_once("../lib/easypost.php");
 
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 $trackers_rep = array();
 

--- a/examples/trackers.php
+++ b/examples/trackers.php
@@ -2,7 +2,7 @@
 
 require_once("../lib/easypost.php");
 
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 $tracking_code = "EZ2000000002";
 $carrier = "USPS";

--- a/examples/users.php
+++ b/examples/users.php
@@ -2,7 +2,7 @@
 
 require_once("../lib/easypost.php");
 
-\EasyPost\EasyPost::setApiKey('PROD_MODE_KEY');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 define("ECHO_ME", true);
 define("CREATE_CHILD", false);

--- a/examples/webhooks.php
+++ b/examples/webhooks.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once("../lib/easypost.php");
-\EasyPost\EasyPost::setApiKey('cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi');
+\EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // Webhook: create
 $create_params = array("url" => "http://example.com");


### PR DESCRIPTION
Removes the remainder of the hard-coded API keys from example files.