### PR TITLE
fix: adds ReturnTypeWillChange to temporarily ignore deprecation warnings

### DIFF
--- a/lib/EasyPost/EasyPostObject.php
+++ b/lib/EasyPost/EasyPostObject.php
@@ -258,6 +258,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      * @param string $k
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($k)
     {
         return array_key_exists($k, $this->_values) ? $this->_values[$k] : null;
@@ -290,6 +291,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->_values);

--- a/lib/EasyPost/EasyPostObject.php
+++ b/lib/EasyPost/EasyPostObject.php
@@ -223,6 +223,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      * @param string $k
      * @param mixed $v
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($k, $v)
     {
         $this->$k = $v;
@@ -234,6 +235,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      * @param string $k
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($k)
     {
         return array_key_exists($k, $this->_values);
@@ -244,6 +246,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @param string $k
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($k)
     {
         unset($this->$k);
@@ -265,6 +268,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->_values);
@@ -275,6 +279,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return current($this->_values);
@@ -295,6 +300,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         return next($this->_values);
@@ -305,6 +311,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         $key = key($this->_values);


### PR DESCRIPTION
Adds `#[\ReturnTypeWillChange]` to some EasyPostObject methods to remove the deprecation warnings on PHP 8.1. The return type definitions will be required for PHP 9; however, because we will still be supporting PHP 7.3 for some time and the `mixed` return type which is required to fix this but not included until PHP 8 isn't possible at the moment, we'll temporarily ignore these deprecation notices until we drop support for PHP 7 altogether (I'd assume about the same time we adopt PHP 9 once it's out.)

Closes #124 