### PR TITLE
chore: fix syntax errors and clean up comments

### DIFF
--- a/lib/EasyPost/CarrierAccount.php
+++ b/lib/EasyPost/CarrierAccount.php
@@ -49,7 +49,7 @@ class CarrierAccount extends EasypostResource
      */
     public function save()
     {
-        return self::_save(get_class());
+        return $this->_save(get_class());
     }
 
     /**
@@ -59,7 +59,7 @@ class CarrierAccount extends EasypostResource
      */
     public function delete()
     {
-        return self::_delete(get_class());
+        return $this->_delete();
     }
 
     /**

--- a/lib/EasyPost/EasyPostObject.php
+++ b/lib/EasyPost/EasyPostObject.php
@@ -160,7 +160,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
     /**
      * Construct from.
      *
-     * @param array  $values
+     * @param array $values
      * @param string $class
      * @param string $apiKey
      * @param string $parent
@@ -182,7 +182,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
     /**
      * Refresh from.
      *
-     * @param array  $values
+     * @param array $values
      * @param string $apiKey
      * @param bool $partial
      */

--- a/lib/EasyPost/EasypostResource.php
+++ b/lib/EasyPost/EasypostResource.php
@@ -80,14 +80,13 @@ abstract class EasypostResource extends EasyPostObject
     }
 
     /**
-     * Validate usage library.
+     * Validate library usage.
      *
-     * @param string $method
      * @param array $params
      * @param string $apiKey
      * @throws \EasyPost\Error
      */
-    protected static function _validate($method, $params = null, $apiKey = null)
+    protected static function _validate($params = null, $apiKey = null)
     {
         if ($params && !is_array($params)) {
             throw new Error("You must pass an array as the first argument to EasyPost API method calls.");
@@ -127,7 +126,7 @@ abstract class EasypostResource extends EasyPostObject
      */
     protected static function _all($class, $params = null, $apiKey = null)
     {
-        self::_validate('all', $params, $apiKey);
+        self::_validate($params, $apiKey);
         $requestor = new Requestor($apiKey);
         $url = self::classUrl($class);
         list($response, $apiKey) = $requestor->request('get', $url, $params);
@@ -147,7 +146,7 @@ abstract class EasypostResource extends EasyPostObject
      */
     protected static function _create($class, $params = null, $apiKey = null, $urlModifier = null, $apiKeyRequired = true)
     {
-        self::_validate('create', $params, $apiKey);
+        self::_validate($params, $apiKey);
         $requestor = new Requestor($apiKey);
         $url = self::classUrl($class);
         if ($urlModifier != null) {
@@ -168,7 +167,7 @@ abstract class EasypostResource extends EasyPostObject
      */
     protected function _save($class)
     {
-        self::_validate('save');
+        self::_validate();
         if (count($this->_unsavedValues)) {
             $requestor = new Requestor($this->_apiKey);
             $url = $this->instanceUrl();
@@ -183,14 +182,13 @@ abstract class EasypostResource extends EasyPostObject
     /**
      * Internal delete method.
      *
-     * @param string $class
      * @param mixed $params
      * @return $this
      * @throws \EasyPost\Error
      */
-    protected function _delete($class, $params = null, $no_refresh = null)
+    protected function _delete($params = null, $no_refresh = null)
     {
-        self::_validate('delete');
+        self::_validate();
         $requestor = new Requestor($this->_apiKey);
         $url = $this->instanceUrl();
         list($response, $apiKey) = $requestor->request('delete', $url, $params);
@@ -204,14 +202,13 @@ abstract class EasypostResource extends EasyPostObject
     /**
      * Internal update method.
      *
-     * @param string $class
      * @param mixed $params
      * @return $this
      * @throws \EasyPost\Error
      */
-    protected function _update($class, $params = null)
+    protected function _update($params = null)
     {
-        self::_validate('put');
+        self::_validate();
         $requestor = new Requestor($this->_apiKey);
         $url = $this->instanceUrl();
         list($response, $apiKey) = $requestor->request('put', $url, $params);

--- a/lib/EasyPost/Error.php
+++ b/lib/EasyPost/Error.php
@@ -48,7 +48,7 @@ class Error extends \Exception
     }
 
     /**
-     * get the HTTP status code
+     * Get the HTTP status code.
      *
      * @return int
      */
@@ -58,7 +58,7 @@ class Error extends \Exception
     }
 
     /**
-     * get the HTTP body
+     * Get the HTTP body.
      *
      * @return string
      */
@@ -68,7 +68,7 @@ class Error extends \Exception
     }
 
     /**
-     * print out the error
+     * Pretty print the error.
      *
      * @return void
      */

--- a/lib/EasyPost/Report.php
+++ b/lib/EasyPost/Report.php
@@ -47,7 +47,7 @@ class Report extends EasypostResource
         } else {
             $type = $params['type'];
 
-            self::_validate('all', $params, $apiKey);
+            self::_validate($params, $apiKey);
             $requestor = new Requestor($apiKey);
 
             $url = self::reportUrl($type);
@@ -72,7 +72,7 @@ class Report extends EasypostResource
         } else {
             $type = $params['type'];
 
-            self::_validate('create', $params, $apiKey);
+            self::_validate($params, $apiKey);
             $requestor = new Requestor($apiKey);
 
             $url = self::reportUrl($type);

--- a/lib/EasyPost/Shipment.php
+++ b/lib/EasyPost/Shipment.php
@@ -123,7 +123,7 @@ class Shipment extends EasypostResource
     {
         $requestor = new Requestor($this->_apiKey);
         $url = $this->instanceUrl() . '/smartrate';
-        list($response, $apiKey) = $requestor->request('get', $url);
+        list($response, $_) = $requestor->request('get', $url);
 
         return isset($response['result']) ? $response['result'] : [];
     }

--- a/lib/EasyPost/Tracker.php
+++ b/lib/EasyPost/Tracker.php
@@ -88,6 +88,8 @@ class Tracker extends EasypostResource
 
         $requestor = new Requestor($apiKey);
         $url = self::classUrl($class);
-        list($response, $apiKey) = $requestor->request('post', $url . '/create_list', $encoded_params);
+        list($_, $apiKey) = $requestor->request('post', $url . '/create_list', $encoded_params);
+
+        return true;
     }
 }

--- a/lib/EasyPost/Tracker.php
+++ b/lib/EasyPost/Tracker.php
@@ -78,7 +78,6 @@ class Tracker extends EasypostResource
      */
     public static function create_list($params = null, $apiKey = null)
     {
-        $class = get_class();
         if (!isset($params['trackers']) || !is_array($params['trackers'])) {
             $clone = $params;
             unset($params);
@@ -88,7 +87,7 @@ class Tracker extends EasypostResource
         $encoded_params = str_replace("\\", '', json_encode($params));
 
         $requestor = new Requestor($apiKey);
-        $url = self::classUrl($class);
+        $url = self::classUrl(get_class());
         list($_, $apiKey) = $requestor->request('post', $url . '/create_list', $encoded_params);
 
         return true;

--- a/lib/EasyPost/Tracker.php
+++ b/lib/EasyPost/Tracker.php
@@ -74,6 +74,7 @@ class Tracker extends EasypostResource
      *
      * @param mixed  $params
      * @param string $apiKey
+     * @return bool
      */
     public static function create_list($params = null, $apiKey = null)
     {

--- a/lib/EasyPost/User.php
+++ b/lib/EasyPost/User.php
@@ -41,7 +41,7 @@ class User extends EasypostResource
      */
     public function save()
     {
-        return self::_save(get_class());
+        return $this->_save(get_class());
     }
 
     /**
@@ -80,7 +80,7 @@ class User extends EasypostResource
      */
     public function delete($params = null, $apiKey = null)
     {
-        return self::_delete(get_class(), $params, true);
+        return $this->_delete($params, true);
     }
 
     /**

--- a/lib/EasyPost/Util.php
+++ b/lib/EasyPost/Util.php
@@ -53,7 +53,7 @@ abstract class Util
      * @param string $apiKey
      * @param string $parent
      * @param string $name
-     * @return array
+     * @return mixed
      */
     public static function convertToEasyPostObject($response, $apiKey, $parent = null, $name = null)
     {

--- a/lib/EasyPost/Webhook.php
+++ b/lib/EasyPost/Webhook.php
@@ -27,7 +27,7 @@ class Webhook extends EasypostResource
     /**
      * Retrieve all webhooks.
      *
-     * @param mixed  $params
+     * @param mixed $params
      * @param string $apiKey
      * @return mixed
      */
@@ -44,13 +44,13 @@ class Webhook extends EasypostResource
      */
     public function delete($params = null, $apiKey = null)
     {
-        return self::_delete(get_class(), $params, true);
+        return $this->_delete($params, true);
     }
 
     /**
      * Update a webhook.
      *
-     * @param mixed  $params
+     * @param mixed $params
      * @param string $apiKey
      * @return $this
      */
@@ -62,13 +62,13 @@ class Webhook extends EasypostResource
             $params['webhook'] = $clone;
         }
 
-        return self::_update(get_class(), $params);
+        return $this->_update($params);
     }
 
     /**
      * Create a webhook.
      *
-     * @param mixed  $params
+     * @param mixed $params
      * @param string $apiKey
      * @return mixed
      */

--- a/test/EasyPost/Test/WebhookTest.php
+++ b/test/EasyPost/Test/WebhookTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace EasyPost\Test;
+
+use VCR\VCR;
+use EasyPost\Webhook;
+use EasyPost\EasyPost;
+
+EasyPost::setApiKey(getenv('API_KEY'));
+
+class WebhookTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Set up VCR before running tests in this file
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass(): void
+    {
+        VCR::turnOn();
+    }
+
+    /**
+     * Spin down VCR after running tests
+     *
+     * @return void
+     */
+    public static function tearDownAfterClass(): void
+    {
+        VCR::eject();
+        VCR::turnOff();
+    }
+
+    /**
+     * Test the creation of a Webhook
+     *
+     * @return Webhook
+     */
+    public function testCreate()
+    {
+        VCR::insertCassette('webhooks/create.yml');
+
+        $webhook = Webhook::create(array(
+            "url" => "http://example.com"
+        ));
+
+        $this->assertInstanceOf('\EasyPost\Webhook', $webhook);
+        $this->assertIsString($webhook->id);
+        $this->assertStringMatchesFormat('hook_%s', $webhook->id);
+        $this->assertEquals($webhook->url, 'http://example.com');
+
+        // Return so the `retrieve` test can reuse this object
+        return $webhook;
+    }
+
+    /**
+     * Test the retrieval of a Webhook
+     *
+     * @param Webhook $webhook
+     * @return void
+     * @depends testCreate
+     */
+    public function testRetrieve(Webhook $webhook)
+    {
+        VCR::insertCassette('webhooks/retrieve.yml');
+
+        $retrieved_webhook = Webhook::retrieve($webhook->id);
+
+        $this->assertInstanceOf('\EasyPost\Webhook', $retrieved_webhook);
+        $this->assertEquals($retrieved_webhook->id, $webhook->id);
+        $this->assertEquals($retrieved_webhook, $webhook);
+
+        // Return so the `delete` test can reuse this object
+        return $webhook;
+    }
+
+    /**
+     * Test the deletion of a Webhook
+     *
+     * @param Webhook $webhook
+     * @return void
+     * @depends testRetrieve
+     */
+    public function testDelete(Webhook $webhook)
+    {
+        VCR::insertCassette('webhooks/delete.yml');
+
+        $webhook->delete();
+
+        // This endpoint/method does not return anything, just make sure the request doesn't fail
+        $this->expectNotToPerformAssertions();
+    }
+}

--- a/test/cassettes/webhooks/create.yml
+++ b/test/cassettes/webhooks/create.yml
@@ -1,0 +1,79 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/webhooks'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+            X-Client-User-Agent: ''
+            EasyPost-Version: '2'
+        body: '{"webhook":{"url":"http:\/\/example.com"}}'
+    response:
+        status:
+            http_version: '2'
+            code: '201'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 64ca848261f9a15aefb479f40002e681
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '161'
+            etag: 'W/"259e839dfab2ba334e67b8f7fd7c1785"'
+            x-request-id: 83f38ddc-085c-446a-a104-3770d0b7f1a2
+            x-runtime: '0.170541'
+            x-node: bigweb8nuq
+            x-version-label: easypost-202202011947-c38087e26d-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq 88c34981dc', 'extlb2nuq 88c34981dc']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"hook_22bf160c83a311ec8eae6d4230948063","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-02-01T21:08:43Z","disabled_at":null}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/webhooks'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 770
+            request_size: 554
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.284009
+            namelookup_time: 0.008662
+            connect_time: 0.037398
+            pretransfer_time: 0.083274
+            size_upload: 42.0
+            size_download: 161.0
+            speed_download: 566.0
+            speed_upload: 147.0
+            download_content_length: 161.0
+            upload_content_length: 42.0
+            starttransfer_time: 0.083289
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.130
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.128.167
+            local_port: 51575
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 82906
+            connect_time_us: 37398
+            namelookup_time_us: 8662
+            pretransfer_time_us: 83274
+            redirect_time_us: 0
+            starttransfer_time_us: 83289
+            total_time_us: 284009

--- a/test/cassettes/webhooks/delete.yml
+++ b/test/cassettes/webhooks/delete.yml
@@ -1,0 +1,78 @@
+
+-
+    request:
+        method: DELETE
+        url: 'https://api.easypost.com/v2/webhooks/hook_22bf160c83a311ec8eae6d4230948063'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+            X-Client-User-Agent: ''
+            EasyPost-Version: '2'
+    response:
+        status:
+            http_version: '2'
+            code: '200'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 64ca848861f9a15befb479f60002e6ac
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '2'
+            etag: 'W/"44136fa355b3678a1146ad16f7e8649e"'
+            x-request-id: 4772e9bf-00a1-4caf-91ae-e737ed3e3fca
+            x-runtime: '0.284577'
+            x-node: bigweb4nuq
+            x-version-label: easypost-202202011947-c38087e26d-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq 88c34981dc', 'extlb2nuq 88c34981dc']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/webhooks/hook_22bf160c83a311ec8eae6d4230948063'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 768
+            request_size: 574
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.38967
+            namelookup_time: 0.001724
+            connect_time: 0.030638
+            pretransfer_time: 0.074925
+            size_upload: 0.0
+            size_download: 2.0
+            speed_download: 5.0
+            speed_upload: 0.0
+            download_content_length: 2.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.389648
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.130
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.128.167
+            local_port: 51577
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 74849
+            connect_time_us: 30638
+            namelookup_time_us: 1724
+            pretransfer_time_us: 74925
+            redirect_time_us: 0
+            starttransfer_time_us: 389648
+            total_time_us: 389670

--- a/test/cassettes/webhooks/retrieve.yml
+++ b/test/cassettes/webhooks/retrieve.yml
@@ -1,0 +1,78 @@
+
+-
+    request:
+        method: GET
+        url: 'https://api.easypost.com/v2/webhooks/hook_22bf160c83a311ec8eae6d4230948063'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+            X-Client-User-Agent: ''
+            EasyPost-Version: '2'
+    response:
+        status:
+            http_version: '2'
+            code: '200'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 64ca848561f9a15befb479f50002e69c
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '161'
+            etag: 'W/"259e839dfab2ba334e67b8f7fd7c1785"'
+            x-request-id: be421fc4-3822-4aec-889b-a7a4f440919c
+            x-runtime: '0.027239'
+            x-node: bigweb1nuq
+            x-version-label: easypost-202202011947-c38087e26d-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq 88c34981dc', 'extlb2nuq 88c34981dc']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"hook_22bf160c83a311ec8eae6d4230948063","object":"Webhook","mode":"test","url":"http://example.com","created_at":"2022-02-01T21:08:43Z","disabled_at":null}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/webhooks/hook_22bf160c83a311ec8eae6d4230948063'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 770
+            request_size: 571
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.133109
+            namelookup_time: 0.001046
+            connect_time: 0.029679
+            pretransfer_time: 0.075834
+            size_upload: 0.0
+            size_download: 161.0
+            speed_download: 1209.0
+            speed_upload: 0.0
+            download_content_length: 161.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.13308
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.130
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.128.167
+            local_port: 51576
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 75654
+            connect_time_us: 29679
+            namelookup_time_us: 1046
+            pretransfer_time_us: 75834
+            redirect_time_us: 0
+            starttransfer_time_us: 133080
+            total_time_us: 133109


### PR DESCRIPTION
Cleans up a few deprecated syntax issues (calling static vs non-static methods incorrectly, remove unused parameters) and cleans up a few comments.

I added webhook tests to ensure the switching of static/non-static delete/update calls still works.