### PR TITLE
chore: use more modern array syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,44 +45,38 @@ require_once("/path/to/vendor/easypost/autoload.php");
 
 \EasyPost\EasyPost::setApiKey('API_KEY');
 
-$to_address = \EasyPost\Address::create(
-    array(
-        "name"    => "Dr. Steve Brule",
-        "street1" => "179 N Harbor Dr",
-        "city"    => "Redondo Beach",
-        "state"   => "CA",
-        "zip"     => "90277",
-        "phone"   => "310-808-5243"
-    )
-);
-$from_address = \EasyPost\Address::create(
-    array(
-        "company" => "EasyPost",
-        "street1" => "118 2nd Street",
-        "street2" => "4th Floor",
-        "city"    => "San Francisco",
-        "state"   => "CA",
-        "zip"     => "94105",
-        "phone"   => "415-456-7890"
-    )
-);
-$parcel = \EasyPost\Parcel::create(
-    array(
-        "predefined_package" => "LargeFlatRateBox",
-        "weight" => 76.9
-    )
-);
-$shipment = \EasyPost\Shipment::create(
-    array(
-        "to_address"   => $to_address,
-        "from_address" => $from_address,
-        "parcel"       => $parcel
-    )
-);
+$to_address = \EasyPost\Address::create([
+    "name"    => "Dr. Steve Brule",
+    "street1" => "179 N Harbor Dr",
+    "city"    => "Redondo Beach",
+    "state"   => "CA",
+    "zip"     => "90277",
+    "phone"   => "310-808-5243",
+]);
+$from_address = \EasyPost\Address::create([
+    "company" => "EasyPost",
+    "street1" => "118 2nd Street",
+    "street2" => "4th Floor",
+    "city"    => "San Francisco",
+    "state"   => "CA",
+    "zip"     => "94105",
+    "phone"   => "415-456-7890",
+]);
+$parcel = \EasyPost\Parcel::create([
+    "predefined_package" => "LargeFlatRateBox",
+    "weight" => 76.9,
+]);
+$shipment = \EasyPost\Shipment::create([
+    "to_address"   => $to_address,
+    "from_address" => $from_address,
+    "parcel"       => $parcel,
+]);
 
 $shipment->buy($shipment->lowest_rate());
 
-$shipment->insure(array('amount' => 100));
+$shipment->insure([
+    'amount' => 100
+]);
 
 echo $shipment->postage_label->label_url;
 ```

--- a/examples/addresses.php
+++ b/examples/addresses.php
@@ -6,13 +6,15 @@ require_once("../lib/easypost.php");
 
 try {
     // create address
-    $address_params = array("name"    => "Sawyer Bateman",
-                            "street1" => "388 Townasend St",
-                            //"street2" => "Apt 20",
-                            "city"    => "San Francisco",
-                            "state"   => "CA",
-                            "zip"     => "94107",
-                            "country" => "US");
+    $address_params = [
+        "name"    => "Sawyer Bateman",
+        "street1" => "388 Townasend St",
+        //"street2" => "Apt 20",
+        "city"    => "San Francisco",
+        "state"   => "CA",
+        "zip"     => "94107",
+        "country" => "US"
+    ];
 
     $address = \EasyPost\Address::create($address_params);
     print_r($address);

--- a/examples/addresses_verify.php
+++ b/examples/addresses_verify.php
@@ -5,8 +5,8 @@ require_once("../lib/easypost.php");
 \EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // create address
-$address_params = array(
-    "verify"  =>  array("delivery"),
+$address_params = [
+    "verify"  =>  ["delivery"],
     "street1" => "118 2 streat",
     "street2" => "FL 4",
     "city"    => "San Francisco",
@@ -15,7 +15,7 @@ $address_params = array(
     "country" => "US",
     "company" => "EasyPost",
     "phone"   => "415-123-4567"
-);
+];
 
 $address = \EasyPost\Address::create($address_params);
 echo $address->street1 . "\n";

--- a/examples/addresses_verify_failure.php
+++ b/examples/addresses_verify_failure.php
@@ -5,8 +5,8 @@ require_once("../lib/easypost.php");
 \EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // create address
-$address_params = array(
-    "verify"  =>  array("delivery"),
+$address_params = [
+    "verify"  =>  ["delivery"],
     "street1" => "UNDELIEVRABLE ST",
     "street2" => "FL 4",
     "city"    => "San Francisco",
@@ -15,7 +15,7 @@ $address_params = array(
     "country" => "US",
     "company" => "EasyPost",
     "phone"   => "415-123-4567"
-);
+];
 
 $address = \EasyPost\Address::create($address_params);
 echo $address->verifications . "\n";

--- a/examples/addresses_verify_strict_failure.php
+++ b/examples/addresses_verify_strict_failure.php
@@ -6,8 +6,8 @@ require_once("../lib/easypost.php");
 
 try {
     // create address
-    $address_params = array(
-        "verify_strict"  =>  array("delivery"),
+    $address_params = [
+        "verify_strict"  =>  ["delivery"],
         "street1"        => "UNDELIEVRABLE ST",
         "street2"        => "FL 4",
         "city"           => "San Francisco",
@@ -16,7 +16,7 @@ try {
         "country"        => "US",
         "company"        => "EasyPost",
         "phone"          => "415-123-4567"
-    );
+    ];
 
     $address = \EasyPost\Address::create($address_params);
 } catch (Exception $e) {

--- a/examples/batches.php
+++ b/examples/batches.php
@@ -5,86 +5,86 @@ require_once("../lib/easypost.php");
 \EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // create addresses
-$from_address = array(
+$from_address = [
     "company" => "EasyPost",
     "street1" => "388 Townsend St",
     "city"    => "San Francisco",
     "state"   => "CA",
     "zip"     => "94107-8273",
     "phone"   => "415-456-7890"
-);
-$parcel = array(
+];
+$parcel = [
     "predefined_package" => 'Parcel',
     "weight"             => 22.9
-);
-$customs_item = array(
+];
+$customs_item = [
     "description"      => "T Shirt",
     "currency"         => "USD",
     "value"            => 35.0,
     "quantity"         => 7,
     "weight"           => 22.9,
     "hs_tariff_number" => "123456"
-);
-$customs_info = array(
+];
+$customs_info = [
     "contents_type" => "merchandise",
-    "customs_items" => array(
-      $customs_item
-    )
-);
+    "customs_items" => [
+        $customs_item
+    ]
+];
 
 // in your application orders will likely
 // come from an external data source
-$orders = array(
-    array(
-        "address"  => array(
+$orders = [
+    [
+        "address"  => [
             "name"    => "Ronald",
             "street1" => "6258 Amesbury St",
             "city"    => "San Diego",
             "state"   => "CA",
             "zip"     => "92114"
-        ),
+        ],
         "reference"   => "123456786",
         "carrier"     => "USPS",
         "service"     => "Priority"
-    ),
-    array(
-        "address"  => array(
+    ],
+    [
+        "address"  => [
             "name"    => "Hamburgler",
             "street1" => "8308 Fenway Rd",
             "city"    => "Bethesda",
             "state"   => "MD",
             "zip"     => "20817"
-        ),
+        ],
         "reference"   => "123456787",
         "carrier"     => "USPS",
         "service"     => "Priority"
-    ),
-    array(
-        "address"  => array(
+    ],
+    [
+        "address"  => [
             "name"    => "Grimace",
             "street1" => "10 Wall St",
             "city"    => "Burlington",
             "state"   => "MA",
             "zip"     => "01803"
-        ),
+        ],
         "reference"   => "123456788",
         "carrier"     => "USPS",
         "service"     => "Priority"
-    ),
-    array(
-        "address"  => array(
+    ],
+    [
+        "address"  => [
             "name"    => "Cosmc",
             "street1" => "3315 W Greenway Rd",
             "city"    => "Phoenix",
             "state"   => "AZ",
             "zip"     => "85053"
-        ),
+        ],
         "reference"   => "123456789",
         "carrier"     => "USPS",
         "service"     => "Express"
-    ),
-    array(
-        "address"      => array(
+    ],
+    [
+        "address"      => [
             "company" => "Tim Hortons",
             "street1" => "65 Queen St W",
             "city"    => "Toronto",
@@ -92,13 +92,13 @@ $orders = array(
             "zip"     => "M5H2M5",
             "phone"   => "+1 416-360-6776",
             "country" => "CA"
-        ),
+        ],
         "customs_info" => $customs_info,
         "reference"    => "timhortons",
         "carrier"      => "USPS",
         "service"      => "ExpressMailInternational"
-    )
-);
+    ]
+];
 
 // get a list of all my batches
 // $all = \EasyPost\Batch::all();
@@ -108,9 +108,9 @@ $orders = array(
 // $batch = \EasyPost\Batch::retrieve('batch_0SLoY64K');
 
 // create shipment batch
-$shipments = array();
+$shipments = [];
 for ($i = 0, $j = count($orders); $i < $j; $i++) {
-    $shipments[] = array(
+    $shipments[] = [
         "to_address"   => $orders[$i]["address"],
         "from_address" => $from_address,
         "parcel"       => $parcel,
@@ -118,10 +118,12 @@ for ($i = 0, $j = count($orders); $i < $j; $i++) {
         "reference"    => $orders[$i]["reference"],
         "carrier"      => $orders[$i]["carrier"],
         "service"      => $orders[$i]["service"]
-    );
+    ];
 }
 
-$batch = \EasyPost\Batch::create(array('shipments' => $shipments));
+$batch = \EasyPost\Batch::create([
+    'shipments' => $shipments
+]);
 
 // asynchronous creation means you can send us up to
 // 1000 shipments at once, but you'll have to wait
@@ -149,7 +151,9 @@ while ($batch->status->postage_purchased != count($orders)) {
 }
 
 // generate a consolidated file containing all batch labels
-$batch->label(array("file_format" => "pdf"));
+$batch->label([
+    "file_format" => "pdf"
+]);
 
 while (empty($batch->label_url)) {
     sleep(5);

--- a/examples/carrier_account_management.php
+++ b/examples/carrier_account_management.php
@@ -39,17 +39,17 @@ if (ECHO_CA_TYPES) {
 // create a new CarrierAccount
 if (CREATE_NEW_CA) {
     try {
-        $new_ups_account = \EasyPost\CarrierAccount::create(array(
-        'type' => "UpsAccount",
-        'description' => "My third UPS account.",
-        'reference' => "ups02",
-        'credentials' => array(
-        'account_number' => "A1A1A1",
-        'user_id' => "UPSDOTCOM_USERNAME",
-        'password' => "UPSDOTCOM_PASSWORD",
-        'access_license_number' => "UPS_ACCESS_LICENSE_NUMBER"
-        )
-        ));
+        $new_ups_account = \EasyPost\CarrierAccount::create([
+            'type' => "UpsAccount",
+            'description' => "My third UPS account.",
+            'reference' => "ups02",
+            'credentials' => [
+                'account_number' => "A1A1A1",
+                'user_id' => "UPSDOTCOM_USERNAME",
+                'password' => "UPSDOTCOM_PASSWORD",
+                'access_license_number' => "UPS_ACCESS_LICENSE_NUMBER"
+            ]
+        ]);
         print_r($new_ups_account);
     } catch (Exception $e) {
         $e->prettyPrint();

--- a/examples/customsinfos.php
+++ b/examples/customsinfos.php
@@ -4,13 +4,14 @@ require_once("../vendor/autoload.php");
 \EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // CustomsItem: create
-$params = array("description"      => "I like your dog, he's vry nice.",
-                "hs_tariff_number" => 123456,
-                "origin_country"   => "US",
-                "quantity"         => 2,
-                "value"            => 1.23,
-                "weight"           => 14
-);
+$params = [
+    "description"      => "I like your dog, he's very nice.",
+    "hs_tariff_number" => 123456,
+    "origin_country"   => "US",
+    "quantity"         => 2,
+    "value"            => 1.23,
+    "weight"           => 14
+];
 $customs_item = \EasyPost\CustomsItem::create($params);
 
 // retrieve
@@ -27,17 +28,18 @@ for($i = 0, $k = count($all); $i < $k; $i++) {
 */
 
 // CustomsInfo: create
-$params = array("integrated_form_type" => "form_2976",
-                "customs_certify"      => true,
-                "customs_signer"       => "Borat Sagdiyev",
-                "contents_type"        => "gift",
-                "contents_explanation" => "",
-                "eel_pfc"              => "NOEEI 30.37(a)",
-                "non_delivery_option"  => "abandon",
-                "restriction_type"     => "none",
-                "restriction_comments" => "",
-                "customs_items"        => array($customs_item)
-);
+$params = [
+    "integrated_form_type" => "form_2976",
+    "customs_certify"      => true,
+    "customs_signer"       => "Borat Sagdiyev",
+    "contents_type"        => "gift",
+    "contents_explanation" => "",
+    "eel_pfc"              => "NOEEI 30.37(a)",
+    "non_delivery_option"  => "abandon",
+    "restriction_type"     => "none",
+    "restriction_comments" => "",
+    "customs_items"        => [$customs_item]
+];
 $customs_info = \EasyPost\CustomsInfo::create($params);
 
 // retrieve

--- a/examples/insurance.php
+++ b/examples/insurance.php
@@ -8,34 +8,32 @@ $tracking_code = "EZ2000000002";
 $carrier = "USPS";
 $amount = 101.00;
 
-$to_address = array(
-  "name"    => "Dr. Steve Brule",
-  "street1" => "179 N Harbor Dr",
-  "city"    => "Redondo Beach",
-  "state"   => "CA",
-  "zip"     => "90277",
-  "phone"   => "310-808-5243"
-);
+$to_address = [
+    "name"    => "Dr. Steve Brule",
+    "street1" => "179 N Harbor Dr",
+    "city"    => "Redondo Beach",
+    "state"   => "CA",
+    "zip"     => "90277",
+    "phone"   => "310-808-5243"
+];
 
-$from_address = array(
-  "company" => "EasyPost",
-  "street1" => "118 2nd Street",
-  "street2" => "4th Floor",
-  "city"    => "San Francisco",
-  "state"   => "CA",
-  "zip"     => "94105",
-  "phone"   => "415-456-7890"
-);
+$from_address = [
+    "company" => "EasyPost",
+    "street1" => "118 2nd Street",
+    "street2" => "4th Floor",
+    "city"    => "San Francisco",
+    "state"   => "CA",
+    "zip"     => "94105",
+    "phone"   => "415-456-7890"
+];
 
-$insurance = \EasyPost\Insurance::create(
-    array(
-      'to_address' => $to_address,
-      'from_address' => $from_address,
-      'amount'    => $amount,
-      'tracking_code' => $tracking_code,
-      'carrier'   => $carrier
-    )
-);
+$insurance = \EasyPost\Insurance::create([
+    'to_address' => $to_address,
+    'from_address' => $from_address,
+    'amount'    => $amount,
+    'tracking_code' => $tracking_code,
+    'carrier'   => $carrier
+]);
 
 var_dump($insurance->id);                      // This is random
 
@@ -52,20 +50,18 @@ var_dump($insurances["has_more"]);             // Should be true, unless the cou
 var_dump($insurances["insurances"][0]->id);    // Should be an insurance ID
 
 // create another test insurance
-$insurance3 = \EasyPost\Insurance::create(
-    array(
-      'to_address' => $to_address,
-      'from_address' => $from_address,
-      'amount'    => $amount,
-      'tracking_code' => $tracking_code,
-      'carrier'   => $carrier
-    )
-);
+$insurance3 = \EasyPost\Insurance::create([
+    'to_address' => $to_address,
+    'from_address' => $from_address,
+    'amount'    => $amount,
+    'tracking_code' => $tracking_code,
+    'carrier'   => $carrier
+]);
 
 var_dump($insurance3->id);                     // This is random
 
 // retrieve all created since 'insurance'
-$insurances2 = \EasyPost\Insurance::all(array('after_id' => $insurance->id));
+$insurances2 = \EasyPost\Insurance::all(['after_id' => $insurance->id]);
 
 var_dump(count($insurances2["insurances"]));   // Should be 1
 var_dump($insurances2["has_more"]);            // Should be false

--- a/examples/intl_shipments.php
+++ b/examples/intl_shipments.php
@@ -6,7 +6,7 @@ require_once("../lib/easypost.php");
 \EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // create addresses
-$sf_address_params = array(
+$sf_address_params = [
     "name"    => "Jon Calhoun",
     "street1" => "388 Townsend St",
     "street2" => "Apt 20",
@@ -14,8 +14,8 @@ $sf_address_params = array(
     "state"   => "CA",
     "zip"     => "94107-8273",
     "phone"   => "415-456-7890"
-);
-$sf2_address_params = array(
+];
+$sf2_address_params = [
     "name"    => "Dirk Diggler",
     "street1" => "63 Ellis Street",
     // "street2" => "Suite 1290",
@@ -23,8 +23,8 @@ $sf2_address_params = array(
     "state"   => "CA",
     "zip"     => "94102",
     "phone"   => "415-482-2937"
-);
-$canada_address_params = array(
+];
+$canada_address_params = [
     "name"    => "Sawyer Bateman",
     "street1" => "1A Larkspur Cres",
     "city"    => "St. Albert",
@@ -32,49 +32,49 @@ $canada_address_params = array(
     "zip"     => "t8n2m4",
     "country" => "CA",
     "phone"   => "780-252-8464"
-);
-$china_address_params = array(
+];
+$china_address_params = [
     "name"    => "姚明",
     "street1" => "香港东路6号，5号楼，8号室",
     "city"    => "青岛市",
     "zip"     => "201900",
     "phone"   => "21-7283-8264",
     "country" => "CN"
-);
-$uk_address_params = array(
+];
+$uk_address_params = [
     "name" => "Queen Elizabeth",
     "street1" => "Buckingham Palace",
     "phone" => "+44 20 7930 4832",
     "city" => "London",
     "zip" => "SW1A 1AA",
     "country" => "GB"
-);
+];
 
 $from_address = \EasyPost\Address::create($sf_address_params);
 $to_address = \EasyPost\Address::create($canada_address_params);
 
 // create parcel
-$parcel_params = array(
+$parcel_params = [
     "length" => 20.2,
     "width" => 10.9,
     "height" => 5,
     "weight" => 14.8
-);
+];
 $parcel = \EasyPost\Parcel::create($parcel_params);
 
 
 // customs info form
-$customs_item_params = array(
+$customs_item_params = [
     "description"      => "Many, many EasyPost stickers.",
     "hs_tariff_number" => 123456,
     "origin_country"   => "US",
     "quantity"         => 1,
     "value"            => 879.47,
     "weight"           => 14
-);
+];
 $customs_item = \EasyPost\CustomsItem::create($customs_item_params);
 
-$customs_info_params = array(
+$customs_info_params = [
     "customs_certify"      => true,
     "customs_signer"       => "Borat Sagdiyev",
     "contents_type"        => "gift",
@@ -83,28 +83,33 @@ $customs_info_params = array(
     "non_delivery_option"  => "abandon",
     "restriction_type"     => "none",
     "restriction_comments" => "",
-    "customs_items"        => array($customs_item)
-);
+    "customs_items"        => [$customs_item]
+];
 $customs_info = \EasyPost\CustomsInfo::create($customs_info_params);
 
 // create shipment
-$shipment_params = array(
+$shipment_params = [
     "from_address" => $from_address,
     "to_address"   => $to_address,
     "parcel"       => $parcel,
     "customs_info" => $customs_info
-);
+];
 $shipment = \EasyPost\Shipment::create($shipment_params);
 
-$shipment->buy(array('rate' => $shipment->lowest_rate('usps'), 'insurance' => 249.99));
-// $shipment->buy(array('rate' => $shipment->lowest_rate(array('ups', 'fedex'))));
+$shipment->buy([
+    'rate' => $shipment->lowest_rate('usps'),
+    'insurance' => 249.99
+]);
+// $shipment->buy([
+//     'rate' => $shipment->lowest_rate(['ups', 'fedex'])
+// ]);
 // $shipment->buy($shipment->lowest_rate(null, 'PriorityMailInternational'));
 
 // Refund specific shipment example
 // $shipment = \EasyPost\Shipment::retrieve('shp_fX5JFpdF');
 // $shipment->refund();
 
-$shipment->insure(array('amount' => 100));
+$shipment->insure(['amount' => 100]);
 
 print_r($shipment);
 

--- a/examples/order_international.php
+++ b/examples/order_international.php
@@ -4,7 +4,7 @@ require_once("../lib/easypost.php");
 
 \EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
-$sf = array(
+$sf = [
     "name"    => "EasyPost.com",
     "street1" => "164 Townsend St #1",
     "street2" => "",
@@ -12,9 +12,9 @@ $sf = array(
     "state"   => "CA ",
     "zip"     => "94107",
     "phone"   => "415-456-7890"
-);
+];
 
-$maryland = array(
+$maryland = [
     "name" => "Maryland",
     "street1" => "8308 Fenway Rd",
     "city" => "Bethesda",
@@ -22,20 +22,20 @@ $maryland = array(
     "zip" => "20817",
     "phone"   => "415-482-2937",
     "email" => "sawyer@example.com"
-);
+];
 
 // overall customs info form
-$overall_customs_item_params = array(
+$overall_customs_item_params = [
     "description"      => "Many, many EasyPost stickers.",
     "hs_tariff_number" => 123456,
     "origin_country"   => "US",
     "quantity"         => 1,
     "value"            => 879.47,
     "weight"           => 14
-);
+];
 $overall_customs_item = \EasyPost\CustomsItem::create($overall_customs_item_params);
 
-$overall_customs_info_params = array(
+$overall_customs_info_params = [
     "customs_certify"      => true,
     "customs_signer"       => "Borat Sagdiyev",
     "contents_type"        => "gift",
@@ -44,22 +44,22 @@ $overall_customs_info_params = array(
     "non_delivery_option"  => "abandon",
     "restriction_type"     => "none",
     "restriction_comments" => "",
-    "customs_items"        => array($overall_customs_item)
-);
+    "customs_items"        => [$overall_customs_item]
+];
 $overall_customs_info = \EasyPost\CustomsInfo::create($overall_customs_info_params);
 
 // specific customs info form
-$specific_customs_item_params = array(
+$specific_customs_item_params = [
     "description"      => "Many, many EasyPost stickers.",
     "hs_tariff_number" => 123456,
     "origin_country"   => "US",
     "quantity"         => 1,
     "value"            => 879.47,
     "weight"           => 14
-);
+];
 $specific_customs_item = \EasyPost\CustomsItem::create($specific_customs_item_params);
 
-$specific_customs_info_params = array(
+$specific_customs_info_params = [
     "customs_certify"      => true,
     "customs_signer"       => "Borat Sagdiyev",
     "contents_type"        => "gift",
@@ -68,28 +68,28 @@ $specific_customs_info_params = array(
     "non_delivery_option"  => "abandon",
     "restriction_type"     => "none",
     "restriction_comments" => "",
-    "customs_items"        => array($specific_customs_item)
-);
+    "customs_items"        => [$specific_customs_item]
+];
 $specific_customs_info = \EasyPost\CustomsInfo::create($specific_customs_info_params);
 
-$order = \EasyPost\Order::create(array(
+$order = \EasyPost\Order::create([
     "from_address" => $sf,
     "to_address" => $maryland,
     "customs_info" => $overall_customs_info, // Customs info on the order should reflect the total of all packages
-    "shipments" => array(
-        array(
-            "parcel" => array("length" => 12.0, "width" => 10.5, "height" => 6.8, "weight" => 12),
-            "options" => array("cod_amount" => 14.99),
+    "shipments" => [
+        [
+            "parcel" => ["length" => 12.0, "width" => 10.5, "height" => 6.8, "weight" => 12],
+            "options" => ["cod_amount" => 14.99],
             "customs_info" => $specific_customs_info // Customs info on each shipment should reflect the contents of that shipment
-        ),
-        array(
-            "parcel" => array("length" => 11.9, "width" => 10.0, "height" => 7.3, "weight" => 18),
-            "options" => array("cod_amount" => 9.56),
+        ],
+        [
+            "parcel" => ["length" => 11.9, "width" => 10.0, "height" => 7.3, "weight" => 18],
+            "options" => ["cod_amount" => 9.56],
             "customs_info" => $specific_customs_info // Customs info on each shipment should reflect the contents of that shipment
-        ),
-    ),
-));
+        ],
+    ],
+]);
 
-$order->buy(array("carrier" => "UPS", "service" => "Ground"));
+$order->buy(["carrier" => "UPS", "service" => "Ground"]);
 
 print_r($order->id);

--- a/examples/orders.php
+++ b/examples/orders.php
@@ -4,7 +4,7 @@ require_once("../lib/easypost.php");
 
 \EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
-$sf = array(
+$sf = [
     "name"    => "EasyPost.com",
     "street1" => "164 Townsend St #1",
     "street2" => "",
@@ -12,8 +12,8 @@ $sf = array(
     "state"   => "CA ",
     "zip"     => "94107",
     "phone"   => "415-456-7890"
-);
-$maryland = array(
+];
+$maryland = [
     "name" => "Maryland",
     "street1" => "8308 Fenway Rd",
     "city" => "Bethesda",
@@ -21,27 +21,27 @@ $maryland = array(
     "zip" => "20817",
     "phone"   => "415-482-2937",
     "email" => "sawyer@example.com"
-);
+];
 
-$order = \EasyPost\Order::create(array(
+$order = \EasyPost\Order::create([
     "from_address" => $sf,
     "to_address" => $maryland,
-    "shipments" => array(
-        array(
-            "parcel" => array("length" => 12.0, "width" => 10.5, "height" => 6.8, "weight" => 12),
-            "options" => array("cod_amount" => 14.99)
-        ),
-        array(
-            "parcel" => array("length" => 11.9, "width" => 10.0, "height" => 7.3, "weight" => 18),
-            "options" => array("cod_amount" => 9.56)
-        ),
-    ),
-));
+    "shipments" => [
+        [
+            "parcel" => ["length" => 12.0, "width" => 10.5, "height" => 6.8, "weight" => 12],
+            "options" => ["cod_amount" => 14.99]
+        ],
+        [
+            "parcel" => ["length" => 11.9, "width" => 10.0, "height" => 7.3, "weight" => 18],
+            "options" => ["cod_amount" => 9.56]
+        ],
+    ],
+]);
 
-echo($order->shipments[0]->rates[0]->id . "\n");
+echo ($order->shipments[0]->rates[0]->id . "\n");
 $order->get_rates();
-echo($order->shipments[0]->rates[0]->id . "\n");
+echo ($order->shipments[0]->rates[0]->id . "\n");
 
-$order->buy(array("carrier" => "UPS", "service" => "Ground"));
+$order->buy(["carrier" => "UPS", "service" => "Ground"]);
 
-echo($order->id . "\n");
+echo ($order->id . "\n");

--- a/examples/parcels.php
+++ b/examples/parcels.php
@@ -4,17 +4,19 @@ require_once("../vendor/autoload.php");
 \EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // Parcel: create
-$params = array("length" => 20.2,
-                "width"  => 10.9,
-                "height" => 5,
-                //"predefined_package" => null,
-                "weight" => 14.8
-);
+$params = [
+    "length" => 20.2,
+    "width"  => 10.9,
+    "height" => 5,
+    //"predefined_package" => null,
+    "weight" => 14.8
+];
 $parcel = \EasyPost\Parcel::create($params);
 
-$params = array("predefined_package" => 'SmallFlatRateBox',
-                "weight"             => 38.1
-);
+$params = [
+    "predefined_package" => 'SmallFlatRateBox',
+    "weight"             => 38.1
+];
 $parcel = \EasyPost\Parcel::create($params);
 
 // retrieve

--- a/examples/pickups.php
+++ b/examples/pickups.php
@@ -4,58 +4,48 @@ require_once("../lib/easypost.php");
 
 \EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
-$to_address = \EasyPost\Address::create(
-    array(
-        "name"    => "Jeff Greenstein",
-        "street1" => "2 8th St",
-        "city"    => "Hermosa Beach",
-        "state"   => "CA",
-        "zip"     => "90254",
-        "phone"   => "310-456-7890"
-    )
-);
-$from_address = \EasyPost\Address::create(
-    array(
-        "company" => "EasyPost",
-        "street1" => "164 Townsend",
-        "street2" => "#1",
-        "city"    => "San Francisco",
-        "state"   => "CA",
-        "zip"     => "94107",
-        "phone"   => "415-379-7678"
-    )
-);
-$parcel = \EasyPost\Parcel::create(
-    array(
-        "height" => 10,
-        "length" => 15,
-        "width" => 5,
-        "weight" => 32
-    )
-);
-$shipment = \EasyPost\Shipment::create(
-    array(
-        "to_address"   => $to_address,
-        "from_address" => $from_address,
-        "parcel"       => $parcel
-    )
-);
-$shipment->buy($shipment->lowest_rate(array('UPS')));
-$shipment->insure(array('amount' => 100));
+$to_address = \EasyPost\Address::create([
+    "name"    => "Jeff Greenstein",
+    "street1" => "2 8th St",
+    "city"    => "Hermosa Beach",
+    "state"   => "CA",
+    "zip"     => "90254",
+    "phone"   => "310-456-7890"
+]);
+$from_address = \EasyPost\Address::create([
+    "company" => "EasyPost",
+    "street1" => "164 Townsend",
+    "street2" => "#1",
+    "city"    => "San Francisco",
+    "state"   => "CA",
+    "zip"     => "94107",
+    "phone"   => "415-379-7678"
+]);
+$parcel = \EasyPost\Parcel::create([
+    "height" => 10,
+    "length" => 15,
+    "width" => 5,
+    "weight" => 32
+]);
+$shipment = \EasyPost\Shipment::create([
+    "to_address"   => $to_address,
+    "from_address" => $from_address,
+    "parcel"       => $parcel
+]);
+$shipment->buy($shipment->lowest_rate(['UPS']));
+$shipment->insure(['amount' => 100]);
 
 echo $shipment->id . "\n";
 
-$pickup = \EasyPost\Pickup::create(
-    array(
-        "address" => $from_address,
-        "shipment" => $shipment,
-        "reference" => $shipment->id,
-        "min_datetime" => date("Y-m-d H:i:s", strtotime('+1 day')),
-        "max_datetime" => date("Y-m-d H:i:s", strtotime('+25 hours')),
-        "is_account_address" => false,
-        "instructions" => "Will be next to garage"
-    )
-);
+$pickup = \EasyPost\Pickup::create([
+    "address" => $from_address,
+    "shipment" => $shipment,
+    "reference" => $shipment->id,
+    "min_datetime" => date("Y-m-d H:i:s", strtotime('+1 day')),
+    "max_datetime" => date("Y-m-d H:i:s", strtotime('+25 hours')),
+    "is_account_address" => false,
+    "instructions" => "Will be next to garage"
+]);
 
-$pickup->buy(array('carrier' => 'UPS', 'service' => 'Future-day Pickup'));
+$pickup->buy(['carrier' => 'UPS', 'service' => 'Future-day Pickup']);
 echo "Confirmation: " . $pickup->confirmation . "\n";

--- a/examples/readme.php
+++ b/examples/readme.php
@@ -3,43 +3,37 @@
 require_once("../vendor/autoload.php");
 \EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
-$to_address = \EasyPost\Address::create(
-    array(
-        "name"    => "Dirk Diggler",
-        "street1" => "388 Townsend St",
-        "street2" => "Apt 20",
-        "city"    => "San Francisco",
-        "state"   => "CA",
-        "zip"     => "94107",
-        "phone"   => "415-456-7890"
-    )
-);
-$from_address = \EasyPost\Address::create(
-    array(
-        "company" => "Simpler Postage Inc",
-        "street1" => "764 Warehouse Ave",
-        "city"    => "Kansas City",
-        "state"   => "KS",
-        "zip"     => "66101",
-        "phone"   => "620-123-4567"
-    )
-);
-$parcel = \EasyPost\Parcel::create(
-    array(
-        "predefined_package" => "LargeFlatRateBox",
-        "weight" => 76.9
-    )
-);
-$shipment = \EasyPost\Shipment::create(
-    array(
-        "to_address"   => $to_address,
-        "from_address" => $from_address,
-        "parcel"       => $parcel
-    )
-);
+$to_address = \EasyPost\Address::create([
+    "name"    => "Dr. Steve Brule",
+    "street1" => "179 N Harbor Dr",
+    "city"    => "Redondo Beach",
+    "state"   => "CA",
+    "zip"     => "90277",
+    "phone"   => "310-808-5243",
+]);
+$from_address = \EasyPost\Address::create([
+    "company" => "EasyPost",
+    "street1" => "118 2nd Street",
+    "street2" => "4th Floor",
+    "city"    => "San Francisco",
+    "state"   => "CA",
+    "zip"     => "94105",
+    "phone"   => "415-456-7890",
+]);
+$parcel = \EasyPost\Parcel::create([
+    "predefined_package" => "LargeFlatRateBox",
+    "weight" => 76.9,
+]);
+$shipment = \EasyPost\Shipment::create([
+    "to_address"   => $to_address,
+    "from_address" => $from_address,
+    "parcel"       => $parcel,
+]);
 
 $shipment->buy($shipment->lowest_rate());
 
-$shipment->insure(array('amount' => 100));
+$shipment->insure([
+    'amount' => 100
+]);
 
 echo $shipment->postage_label->label_url;

--- a/examples/refunds.php
+++ b/examples/refunds.php
@@ -5,10 +5,10 @@ require_once("../vendor/autoload.php");
 
 try {
     // create refund
-    $refund = \EasyPost\Refund::create(array(
+    $refund = \EasyPost\Refund::create([
         "carrier" => "USPS",
         "tracking_codes" => "CJ123456789US,LN123456789US"
-    ));
+    ]);
     print_r($refund);
 
     // all

--- a/examples/reports.php
+++ b/examples/reports.php
@@ -5,7 +5,7 @@ require_once("../lib/easypost.php");
 
 
 // Create a shipment report
-$shipment_report = \EasyPost\Report::create(array("type" => "shipment"));
+$shipment_report = \EasyPost\Report::create(["type" => "shipment"]);
 var_dump($shipment_report->id);
 
 // Retrieve a shipment report
@@ -13,13 +13,13 @@ $shipment_report_2 = \EasyPost\Report::retrieve($shipment_report->id);
 var_dump($shipment_report_2->id);
 
 // Index shipment reports
-$shipment_reports = \EasyPost\Report::all(array("type" => "shipment", "page_size" => 4));
+$shipment_reports = \EasyPost\Report::all(["type" => "shipment", "page_size" => 4]);
 var_dump(count($shipment_reports["reports"]));
 var_dump($shipment_reports["has_more"]);
 
 
 // Create a tracker report
-$tracker_report = \EasyPost\Report::create(array("type" => "tracker"));
+$tracker_report = \EasyPost\Report::create(["type" => "tracker"]);
 var_dump($tracker_report->id);
 
 // Retrieve a tracker report
@@ -27,13 +27,13 @@ $tracker_report_2 = \EasyPost\Report::retrieve($tracker_report->id);
 var_dump($tracker_report_2->id);
 
 // Index tracker reports
-$tracker_reports = \EasyPost\Report::all(array("type" => "tracker", "page_size" => 4));
+$tracker_reports = \EasyPost\Report::all(["type" => "tracker", "page_size" => 4]);
 var_dump(count($tracker_reports["reports"]));
 var_dump($tracker_reports["has_more"]);
 
 
 // Create a payment log report
-$payment_log_report = \EasyPost\Report::create(array("type" => "payment_log"));
+$payment_log_report = \EasyPost\Report::create(["type" => "payment_log"]);
 var_dump($payment_log_report->id);
 
 // Retrieve a payment log report
@@ -41,6 +41,6 @@ $payment_log_report_2 = \EasyPost\Report::retrieve($payment_log_report->id);
 var_dump($payment_log_report_2->id);
 
 // Index payment log reports
-$payment_log_reports = \EasyPost\Report::all(array("type" => "payment_log", "page_size" => 4));
+$payment_log_reports = \EasyPost\Report::all(["type" => "payment_log", "page_size" => 4]);
 var_dump(count($payment_log_reports["reports"]));
 var_dump($payment_log_reports["has_more"]);

--- a/examples/scanforms.php
+++ b/examples/scanforms.php
@@ -4,40 +4,40 @@ require_once("../lib/easypost.php");
 \EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // create addresses
-$from_address = array(
+$from_address = [
     "company" => "EasyPost",
     "street1" => "388 Townsend St",
     "city"    => "San Francisco",
     "state"   => "CA",
     "zip"     => "94107-8273",
     "phone"   => "415-456-7890"
-);
-$to_address = array(
+];
+$to_address = [
     "name"    => "Ronald",
     "street1" => "6258 Amesbury St",
     "city"    => "San Diego",
     "state"   => "CA",
     "zip"     => "92114"
-);
-$parcel = array(
+];
+$parcel = [
     "predefined_package" => 'Parcel',
     "weight"             => 22.9
-);
+];
 
 // create shipment and buy
-$shipments = array();
-$shipment = \EasyPost\Shipment::create(array(
+$shipments = [];
+$shipment = \EasyPost\Shipment::create([
     "to_address"   => $to_address,
     "from_address" => $from_address,
     "parcel"       => $parcel,
-));
-$shipment->buy(array("rate" => $shipment->lowest_rate('usps')));
+]);
+$shipment->buy(["rate" => $shipment->lowest_rate('usps')]);
 $shipments[] = $shipment;
 
 // create a scan form
-$scan_form = \EasyPost\ScanForm::create(array(
+$scan_form = \EasyPost\ScanForm::create([
     "shipments" => $shipments
-));
+]);
 
 // inspect scanform
 var_dump($scan_form->id);
@@ -48,5 +48,5 @@ $scan_form2 = \EasyPost\ScanForm::retrieve($scan_form->id);
 var_dump($scan_form2->id);
 
 // index scan forms
-$scan_forms = \EasyPost\ScanForm::all(array("page_size" => 2));
+$scan_forms = \EasyPost\ScanForm::all(["page_size" => 2]);
 var_dump($scan_forms["scan_forms"][0]->id);

--- a/examples/shipment.php
+++ b/examples/shipment.php
@@ -4,34 +4,34 @@ require_once("../lib/easypost.php");
 
 \EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
-$shipment = \EasyPost\Shipment::create(array(
-  'to_address' => array(
-    "name"    => "Dr. Steve Brule",
-    "street1" => "179 N Harbor Dr",
-    "city"    => "Redondo Beach",
-    "state"   => "CA",
-    "zip"     => "90277",
-    "phone"   => "310-808-5243"
-  ),
-  'from_address' => array(
-    "company" => "EasyPost",
-    "street1" => "118 2nd Street",
-    "street2" => "4th Floor",
-    "city"    => "San Francisco",
-    "state"   => "CA",
-    "zip"     => "94105",
-    "phone"   => "415-456-7890"
-  ),
-  'parcel' => array(
-    'length' => 9,
-    'width' => 6,
-    'height' => 2,
-    'weight' => 10
-  )
-));
+$shipment = \EasyPost\Shipment::create([
+    'to_address' => [
+        "name"    => "Dr. Steve Brule",
+        "street1" => "179 N Harbor Dr",
+        "city"    => "Redondo Beach",
+        "state"   => "CA",
+        "zip"     => "90277",
+        "phone"   => "310-808-5243"
+    ],
+    'from_address' => [
+        "company" => "EasyPost",
+        "street1" => "118 2nd Street",
+        "street2" => "4th Floor",
+        "city"    => "San Francisco",
+        "state"   => "CA",
+        "zip"     => "94105",
+        "phone"   => "415-456-7890"
+    ],
+    'parcel' => [
+        'length' => 9,
+        'width' => 6,
+        'height' => 2,
+        'weight' => 10
+    ]
+]);
 
 echo $shipment->id;
 
 $shipment->buy($shipment->lowest_rate("USPS"));
 
-$shipment->insure(array('amount' => 100));
+$shipment->insure(['amount' => 100]);

--- a/examples/timeouts.php
+++ b/examples/timeouts.php
@@ -12,7 +12,7 @@ $carrier = "USPS";
 \EasyPost\EasyPost::setResponseTimeout(0);
 
 // Creation of test tracker should not timeout
-$tracker = \EasyPost\Tracker::create(array('tracking_code' => $tracking_code, 'carrier' => $carrier));
+$tracker = \EasyPost\Tracker::create(['tracking_code' => $tracking_code, 'carrier' => $carrier]);
 var_dump($tracker->id);                      // This is random
 
 // Set timeouts to 1ms
@@ -21,4 +21,4 @@ var_dump($tracker->id);                      // This is random
 
 // Creation of test tracker should timeout
 // This is expected to raise an EasyPost\Error
-$tracker = \EasyPost\Tracker::create(array('tracking_code' => $tracking_code, 'carrier' => $carrier));
+$tracker = \EasyPost\Tracker::create(['tracking_code' => $tracking_code, 'carrier' => $carrier]);

--- a/examples/tracker_batch_create.php
+++ b/examples/tracker_batch_create.php
@@ -4,10 +4,10 @@ require_once("../lib/easypost.php");
 
 \EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
-$trackers_rep = array();
+$trackers_rep = [];
 
 for ($i = 1; $i < 6; $i++) {
-    $tracker = array();
+    $tracker = [];
     $tracker["tracking_code"] = "EZ200000000$i";
     $tracker["carrier"] = "USPS";
     array_push($trackers_rep, $tracker);

--- a/examples/trackers.php
+++ b/examples/trackers.php
@@ -8,7 +8,7 @@ $tracking_code = "EZ2000000002";
 $carrier = "USPS";
 
 // create test tracker
-$tracker = \EasyPost\Tracker::create(array('tracking_code' => $tracking_code, 'carrier' => $carrier));
+$tracker = \EasyPost\Tracker::create(['tracking_code' => $tracking_code, 'carrier' => $carrier]);
 
 var_dump($tracker->id);                      // This is random
 
@@ -17,23 +17,23 @@ $tracker2 = \EasyPost\Tracker::retrieve($tracker->id);
 
 var_dump($tracker2->id);
 
-$params = array();                          // Should be the same as above
+$params = [];                          // Should be the same as above
 
 
 // retrieve all trackers by tracking_code
-$trackers = \EasyPost\Tracker::all(array('tracking_code' => $tracking_code));
+$trackers = \EasyPost\Tracker::all(['tracking_code' => $tracking_code]);
 
 var_dump(count($trackers["trackers"]));      // Should be 30
 var_dump($trackers["has_more"]);             // Should be true, unless the count() isn't 30
 var_dump($trackers["trackers"][0]->id);      // Should be the same as the ids above
 
 // create another test tracker
-$tracker3 = \EasyPost\Tracker::create(array('tracking_code' => $tracking_code, 'carrier' => $carrier));
+$tracker3 = \EasyPost\Tracker::create(['tracking_code' => $tracking_code, 'carrier' => $carrier]);
 
 var_dump($tracker3->id);                     // This is random
 
 // retrieve all created since 'tracker'
-$trackers2 = \EasyPost\Tracker::all(array('after_id' => $tracker->id));
+$trackers2 = \EasyPost\Tracker::all(['after_id' => $tracker->id]);
 
 var_dump(count($trackers2["trackers"]));     // Should be 1
 var_dump($trackers2["has_more"]);            // Should be false

--- a/examples/webhooks.php
+++ b/examples/webhooks.php
@@ -4,7 +4,7 @@ require_once("../lib/easypost.php");
 \EasyPost\EasyPost::setApiKey(getenv('API_KEY'));
 
 // Webhook: create
-$create_params = array("url" => "http://example.com");
+$create_params = ["url" => "http://example.com"];
 $webhook = \EasyPost\Webhook::create($create_params);
 var_dump($webhook->url);
 var_dump($webhook->id);

--- a/lib/EasyPost/EasyPostObject.php
+++ b/lib/EasyPost/EasyPostObject.php
@@ -50,13 +50,13 @@ class EasyPostObject implements \ArrayAccess, \Iterator
     public function __construct($id = null, $apiKey = null, $parent = null, $name = null)
     {
         $this->_apiKey = $apiKey;
-        $this->_values = array();
-        $this->_unsavedValues = array();
-        $this->_immutableValues = array('_apiKey', 'id');
+        $this->_values = [];
+        $this->_unsavedValues = [];
+        $this->_immutableValues = ['_apiKey', 'id'];
         $this->_parent = $parent;
         $this->_name = $name;
 
-        $this->_retrieveOptions = array();
+        $this->_retrieveOptions = [];
         if (is_array($id)) {
             foreach ($id as $key => $value) {
                 if ($key != 'id') {
@@ -83,11 +83,11 @@ class EasyPostObject implements \ArrayAccess, \Iterator
 
         $i = 0;
         $current = $this;
-        $param = array($k => $v);
+        $param = [$k => $v];
 
         while (true && $i < 99) {
             if (!is_null($current->_parent)) {
-                $param = array($current->_name => $param);
+                $param = [$current->_name => $param];
                 $current = $current->_parent;
             } else {
                 reset($param);
@@ -122,11 +122,11 @@ class EasyPostObject implements \ArrayAccess, \Iterator
 
             $i = 0;
             $current = $this;
-            $param = array($k => null);
+            $param = [$k => null];
 
             while (true && $i < 99) {
                 if (!is_null($current->_parent)) {
-                    $param = array($current->_name => $param);
+                    $param = [$current->_name => $param];
                     $current = $current->_parent;
                 } else {
                     reset($param);
@@ -191,7 +191,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
         $this->_apiKey = $apiKey;
 
         if ($partial) {
-            $removed = array();
+            $removed = [];
         } else {
             $removed = array_diff(array_keys($this->_values), array_keys($values));
         }
@@ -214,7 +214,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
 
             $this->_values[$k] = Util::convertToEasyPostObject($v, $apiKey, $this, $k);
         }
-        $this->_unsavedValues = array();
+        $this->_unsavedValues = [];
     }
 
     /**

--- a/lib/EasyPost/EasypostResource.php
+++ b/lib/EasyPost/EasypostResource.php
@@ -171,7 +171,7 @@ abstract class EasypostResource extends EasyPostObject
         if (count($this->_unsavedValues)) {
             $requestor = new Requestor($this->_apiKey);
             $url = $this->instanceUrl();
-            $params = array(self::className($class) => $this->_unsavedValues);
+            $params = [self::className($class) => $this->_unsavedValues];
             list($response, $apiKey) = $requestor->request('patch', $url, $params);
             $this->refreshFrom($response, $apiKey);
         }

--- a/lib/EasyPost/Requestor.php
+++ b/lib/EasyPost/Requestor.php
@@ -56,15 +56,15 @@ class Requestor
     private static function _encodeObjects($data)
     {
         if (is_null($data)) {
-            return array();
+            return [];
         } elseif ($data instanceof EasypostResource) {
-            return array("id" => self::utf8($data->id));
+            return ["id" => self::utf8($data->id)];
         } elseif ($data === true) {
             return 'true';
         } elseif ($data === false) {
             return 'false';
         } elseif (is_array($data)) {
-            $resource = array();
+            $resource = [];
             foreach ($data as $k => $v) {
                 if (!is_null($v) and ($v !== "") and (!is_array($v) or !empty($v))) {
                     $resource[$k] = self::_encodeObjects($v);
@@ -90,7 +90,7 @@ class Requestor
             return $arr;
         }
 
-        $r = array();
+        $r = [];
         foreach ($arr as $k => $v) {
             if (is_null($v)) {
                 continue;
@@ -126,7 +126,7 @@ class Requestor
         list($httpBody, $httpStatus, $myApiKey) = $this->_requestRaw($method, $url, $params, $apiKeyRequired);
         $response = $this->_interpretResponse($httpBody, $httpStatus);
 
-        return array($response, $myApiKey);
+        return [$response, $myApiKey];
     }
 
     /**
@@ -155,26 +155,26 @@ class Requestor
 
         $langVersion = phpversion();
         $uname = php_uname();
-        $ua = array(
+        $ua = [
             'bindings_version' => EasyPost::VERSION,
             'lang'             => 'php',
             'lang_version'     => $langVersion,
             'publisher'        => 'easypost',
             'uname'            => $uname
-        );
-        $headers = array(
+        ];
+        $headers = [
             'Accept: application/json',
             "Authorization: Bearer {$myApiKey}",
             'Content-Type: application/json',
             'User-Agent: EasyPost/v2 PhpClient/' . EasyPost::VERSION . ' PHP/' . phpversion(),
             'X-Client-User-Agent: ' . json_encode($ua),
-        );
+        ];
         if (EasyPost::$apiVersion) {
             $headers[] = 'EasyPost-Version: ' . EasyPost::$apiVersion;
         }
         list($httpBody, $httpStatus) = $this->_curlRequest($method, $absUrl, $headers, $params, $myApiKey);
 
-        return array($httpBody, $httpStatus, $myApiKey);
+        return [$httpBody, $httpStatus, $myApiKey];
     }
 
     /**
@@ -192,7 +192,7 @@ class Requestor
     {
         $curl = curl_init();
         $method = strtolower($method);
-        $curlOptions = array();
+        $curlOptions = [];
 
         // Setup the HTTP method and params to use on the request
         if ($method == 'get') {
@@ -255,7 +255,7 @@ class Requestor
         $httpStatus = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         curl_close($curl);
 
-        return array($httpBody, $httpStatus);
+        return [$httpBody, $httpStatus];
     }
 
     /**

--- a/lib/EasyPost/Shipment.php
+++ b/lib/EasyPost/Shipment.php
@@ -226,13 +226,13 @@ class Shipment extends EasypostResource
      * @return bool
      * @throws \EasyPost\Error
      */
-    public function lowest_rate($carriers = array(), $services = array())
+    public function lowest_rate($carriers = [], $services = [])
     {
         $lowest_rate = false;
-        $carriers_include = array();
-        $carriers_exclude = array();
-        $services_include = array();
-        $services_exclude = array();
+        $carriers_include = [];
+        $carriers_exclude = [];
+        $services_include = [];
+        $services_exclude = [];
 
         if (!is_array($carriers)) {
             $carriers = explode(',', $carriers);

--- a/lib/EasyPost/User.php
+++ b/lib/EasyPost/User.php
@@ -121,7 +121,7 @@ class User extends EasypostResource
         if (is_null($my_api_keys)) {
             return null;
         } else {
-            $response = array();
+            $response = [];
             foreach ($my_api_keys as $key) {
                 $response[$key->mode] = $key->key;
             }

--- a/lib/EasyPost/Util.php
+++ b/lib/EasyPost/Util.php
@@ -32,7 +32,7 @@ abstract class Util
      */
     public static function convertEasyPostObjectToArray($values)
     {
-        $results = array();
+        $results = [];
         foreach ($values as $k => $v) {
             if ($v instanceof EasyPostObject) {
                 $results[$k] = $v->__toArray(true);
@@ -57,7 +57,7 @@ abstract class Util
      */
     public static function convertToEasyPostObject($response, $apiKey, $parent = null, $name = null)
     {
-        $types = array(
+        $types = [
             'Address'               => '\EasyPost\Address',
             'Batch'                 => '\EasyPost\Batch',
             'CarrierAccount'        => '\EasyPost\CarrierAccount',
@@ -92,9 +92,9 @@ abstract class Util
             'VerificationDetails'   => '\EasyPost\VerificationDetails',
             'Verifictions'          => '\EasyPost\Verifications',
             'Webhook'               => '\EasyPost\Webhook',
-        );
+        ];
 
-        $prefixes = array(
+        $prefixes = [
             'adr'       => '\EasyPost\Address',
             'batch'     => '\EasyPost\Batch',
             'ca'        => '\EasyPost\CarrierAccount',
@@ -119,10 +119,10 @@ abstract class Util
             'trk'       => '\EasyPost\Tracker',
             'trkrep'    => '\EasyPost\Report',
             'user'      => '\EasyPost\User',
-        );
+        ];
 
         if (self::isList($response)) {
-            $mapped = array();
+            $mapped = [];
             foreach ($response as $object => $v) {
                 if (is_string($object) && isset($types[$object])) {
                     $v['object'] = $object;

--- a/test/EasyPost/Test/AddressTest.php
+++ b/test/EasyPost/Test/AddressTest.php
@@ -40,13 +40,13 @@ class AddressTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('addresses/create.yml');
 
-        $address = Address::create(array(
+        $address = Address::create([
             "street1" => "388 Townsend St",
             "street2" => "Apt 20",
             "city"    => "San Francisco",
             "state"   => "CA",
             "zip"     => "94107",
-        ));
+        ]);
 
         $this->assertInstanceOf('\EasyPost\Address', $address);
         $this->assertIsString($address->id);
@@ -85,8 +85,8 @@ class AddressTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('addresses/createVerify.yml');
 
-        $address = Address::create(array(
-            "verify"  => array(true),
+        $address = Address::create([
+            "verify"  => [true],
             "street1" => "417 montgomery streat",
             "street2" => "FL 5",
             "city"    => "San Francisco",
@@ -95,7 +95,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
             "country" => "US",
             "company" => "EasyPost",
             "phone"   => "415-123-4567"
-        ));
+        ]);
 
         $this->assertInstanceOf('\EasyPost\Address', $address);
         $this->assertIsString($address->id);

--- a/test/EasyPost/Test/ParcelTest.php
+++ b/test/EasyPost/Test/ParcelTest.php
@@ -40,12 +40,12 @@ class ParcelTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('parcels/create.yml');
 
-        $parcel = Parcel::create(array(
+        $parcel = Parcel::create([
             "length"    => "10",
             "width"     => "8",
             "height"    => "4",
             "weight"    => 15.4,
-        ));
+        ]);
 
         $this->assertInstanceOf('\EasyPost\Parcel', $parcel);
         $this->assertIsString($parcel->id);

--- a/test/EasyPost/Test/ReportTest.php
+++ b/test/EasyPost/Test/ReportTest.php
@@ -42,11 +42,11 @@ class ReportTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('reports/createPaymentLogReport.yml');
 
-        $payment_log_report = Report::create(array(
+        $payment_log_report = Report::create([
             "start_date" => REPORT_START_DATE,
             "end_date" => REPORT_END_DATE,
             "type" => "payment_log"
-        ));
+        ]);
 
         $this->assertInstanceOf('\EasyPost\Report', $payment_log_report);
         $this->assertIsString($payment_log_report->id);
@@ -65,11 +65,11 @@ class ReportTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('reports/createRefundReport.yml');
 
-        $refund_report = Report::create(array(
+        $refund_report = Report::create([
             "start_date" => REPORT_START_DATE,
             "end_date" => REPORT_END_DATE,
             "type" => "refund"
-        ));
+        ]);
 
         $this->assertInstanceOf('\EasyPost\Report', $refund_report);
         $this->assertIsString($refund_report->id);
@@ -88,11 +88,11 @@ class ReportTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('reports/createShipmentReport.yml');
 
-        $shipment_report = Report::create(array(
+        $shipment_report = Report::create([
             "start_date" => REPORT_START_DATE,
             "end_date" => REPORT_END_DATE,
             "type" => "shipment"
-        ));
+        ]);
 
         $this->assertInstanceOf('\EasyPost\Report', $shipment_report);
         $this->assertIsString($shipment_report->id);
@@ -111,11 +111,11 @@ class ReportTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('reports/createShipmentInvoiceReport.yml');
 
-        $shipment_invoice_report = Report::create(array(
+        $shipment_invoice_report = Report::create([
             "start_date" => REPORT_START_DATE,
             "end_date" => REPORT_END_DATE,
             "type" => "shipment_invoice"
-        ));
+        ]);
 
         $this->assertInstanceOf('\EasyPost\Report', $shipment_invoice_report);
         $this->assertIsString($shipment_invoice_report->id);
@@ -134,11 +134,11 @@ class ReportTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('reports/createTrackerReport.yml');
 
-        $tracker_report = Report::create(array(
+        $tracker_report = Report::create([
             "start_date" => REPORT_START_DATE,
             "end_date" => REPORT_END_DATE,
             "type" => "tracker"
-        ));
+        ]);
 
         $this->assertInstanceOf('\EasyPost\Report', $tracker_report);
         $this->assertIsString($tracker_report->id);

--- a/test/EasyPost/Test/ShipmentTest.php
+++ b/test/EasyPost/Test/ShipmentTest.php
@@ -40,28 +40,28 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('shipments/create.yml');
 
-        $shipment = Shipment::create(array(
-            "to_address" => array(
+        $shipment = Shipment::create([
+            "to_address" => [
                 "street1"   => "388 Townsend St",
                 "street2"   => "Apt 20",
                 "city"      => "San Francisco",
                 "state"     => "CA",
                 "zip"       => "94107",
-            ),
-            "from_address" => array(
+            ],
+            "from_address" => [
                 "street1"   => "388 Townsend St",
                 "street2"   => "Apt 20",
                 "city"      => "San Francisco",
                 "state"     => "CA",
                 "zip"       => "94107",
-            ),
-            "parcel" => array(
+            ],
+            "parcel" => [
                 "length"    => "10",
                 "width"     => "8",
                 "height"    => "4",
                 "weight"    => "15",
-            ),
-            "customs_info"  => array(
+            ],
+            "customs_info"  => [
                 "eel_pfc" => 'NOEEI 30.37(a)',
                 "customs_certify" => true,
                 "customs_signer" => 'Steve Brule',
@@ -69,23 +69,23 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
                 "contents_explanation" => '',
                 "restriction_type" => 'none',
                 "non_delivery_option" => 'return',
-                "customs_items" => array(
-                    array(
+                "customs_items" => [
+                    [
                         "description" => 'Sweet shirts',
                         "quantity" => 2,
                         "weight" => 11,
                         "value" => 23,
                         "hs_tariff_number" => '654321',
                         "origin_country" => 'US'
-                    ),
-                ),
-            ),
-            "options" => array(
+                    ],
+                ],
+            ],
+            "options" => [
                 "label_format"      => "PDF",
                 "invoice_number"    => 123 // Tests that we encode integers to strings where appropriate
-            ),
+            ],
             "reference" => 123 // Tests that we encode integers to strings where appropriate
-        ));
+        ]);
 
         $this->assertInstanceOf('\EasyPost\Shipment', $shipment);
         $this->assertIsString($shipment->id);
@@ -131,9 +131,9 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('shipments/buy.yml');
 
-        $shipment->buy(array(
+        $shipment->buy([
             'rate' => $shipment->lowest_rate(),
-        ));
+        ]);
 
         $this->assertNotNull($shipment->postage_label);
     }
@@ -147,28 +147,28 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('shipments/smartrates.yml');
 
-        $shipment = Shipment::create(array(
-            "to_address" => array(
+        $shipment = Shipment::create([
+            "to_address" => [
                 "street1"   => "388 Townsend St",
                 "street2"   => "Apt 20",
                 "city"      => "San Francisco",
                 "state"     => "CA",
                 "zip"       => "94107",
-            ),
-            "from_address" => array(
+            ],
+            "from_address" => [
                 "street1"   => "388 Townsend St",
                 "street2"   => "Apt 20",
                 "city"      => "San Francisco",
                 "state"     => "CA",
                 "zip"       => "94107",
-            ),
-            "parcel" => array(
+            ],
+            "parcel" => [
                 "length"    => "10",
                 "width"     => "8",
                 "height"    => "4",
                 "weight"    => "15",
-            )
-        ));
+            ],
+        ]);
 
         $this->assertNotNull($shipment->rates);
 
@@ -192,34 +192,34 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('shipments/createEmptyObjects.yml');
 
-        $shipment = Shipment::create(array(
-            "to_address" => array(
+        $shipment = Shipment::create([
+            "to_address" => [
                 "street1"   => "388 Townsend St",
                 "street2"   => "Apt 20",
                 "city"      => "San Francisco",
                 "state"     => "CA",
                 "zip"       => "94107",
-            ),
-            "from_address" => array(
+            ],
+            "from_address" => [
                 "street1"   => "388 Townsend St",
                 "street2"   => "Apt 20",
                 "city"      => "San Francisco",
                 "state"     => "CA",
                 "zip"       => "94107",
-            ),
-            "parcel" => array(
+            ],
+            "parcel" => [
                 "length"    => null,
                 "width"     => "",
                 "height"    => null,
                 "weight"    => "15",
-            ),
-            "customs_info" => array(
-                "customs_items" => array()
-            ),
+            ],
+            "customs_info" => [
+                "customs_items" => []
+            ],
             "options" => null,
             "tax_identifiers" => null,
             "reference" => "",
-        ));
+        ]);
 
         $this->assertInstanceOf('\EasyPost\Shipment', $shipment);
         $this->assertIsString($shipment->id);
@@ -238,36 +238,36 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('shipments/createTaxIdentifiers.yml');
 
-        $shipment = Shipment::create(array(
-            "to_address" => array(
+        $shipment = Shipment::create([
+            "to_address" => [
                 "street1"   => "388 Townsend St",
                 "street2"   => "Apt 20",
                 "city"      => "San Francisco",
                 "state"     => "CA",
                 "zip"       => "94107",
-            ),
-            "from_address" => array(
+            ],
+            "from_address" => [
                 "street1"   => "388 Townsend St",
                 "street2"   => "Apt 20",
                 "city"      => "San Francisco",
                 "state"     => "CA",
                 "zip"       => "94107",
-            ),
-            "parcel" => array(
+            ],
+            "parcel" => [
                 "length"    => "10",
                 "width"     => "8",
                 "height"    => "4",
                 "weight"    => "15",
-            ),
-            "tax_identifiers" => array(
-                array(
+            ],
+            "tax_identifiers" => [
+                [
                     "entity" => "SENDER",
                     "tax_id_type" => "IOSS",
                     "tax_id" => "12345",
                     "issuing_country" => "GB",
-                )
-            )
-        ));
+                ],
+            ],
+        ]);
 
         $this->assertInstanceOf('\EasyPost\Shipment', $shipment);
         $this->assertIsString($shipment->id);

--- a/test/EasyPost/Test/TrackerTest.php
+++ b/test/EasyPost/Test/TrackerTest.php
@@ -40,9 +40,9 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('trackers/create.yml');
 
-        $tracker = Tracker::create(array(
+        $tracker = Tracker::create([
             "tracking_code" => "EZ1000000001",
-        ));
+        ]);
 
         $this->assertInstanceOf('\EasyPost\Tracker', $tracker);
         $this->assertIsString($tracker->id);
@@ -82,9 +82,9 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
 
         $page_size = 5;
 
-        $trackers = Tracker::all(array(
+        $trackers = Tracker::all([
             'page_size' => $page_size,
-        ));
+        ]);
 
         $trackers_array = $trackers['trackers'];
         $first_tracker = $trackers['trackers'][0];
@@ -105,12 +105,12 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('trackers/createList.yml');
 
-        $tracker = Tracker::create_list(array(
-            array("tracking_code" => "EZ1000000001"),
-            array("tracking_code" => "EZ1000000002"),
-            array("tracking_code" => "EZ1000000003"),
-            array("tracking_code" => "EZ1000000004"),
-        ));
+        Tracker::create_list([
+            ["tracking_code" => "EZ1000000001"],
+            ["tracking_code" => "EZ1000000002"],
+            ["tracking_code" => "EZ1000000003"],
+            ["tracking_code" => "EZ1000000004"],
+        ]);
 
         // This endpoint/method does not return anything, just make sure the request doesn't fail
         $this->expectNotToPerformAssertions();

--- a/test/EasyPost/Test/WebhookTest.php
+++ b/test/EasyPost/Test/WebhookTest.php
@@ -40,9 +40,9 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('webhooks/create.yml');
 
-        $webhook = Webhook::create(array(
+        $webhook = Webhook::create([
             "url" => "http://example.com"
-        ));
+        ]);
 
         $this->assertInstanceOf('\EasyPost\Webhook', $webhook);
         $this->assertIsString($webhook->id);

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -11,12 +11,12 @@ VCR::configure()->setCassettePath('test/cassettes')
     ->setStorage('yaml')
     ->setMode('once');
 
-VCRCleaner::enable(array(
-    'request' => array(
-        'ignoreHeaders' => array(
+VCRCleaner::enable([
+    'request' => [
+        'ignoreHeaders' => [
             'Authorization',        // Ignore credentials
             'User-Agent',           // Ignore varying user agents across test runs
             'X-Client-User-Agent',  // Ignore varying user agents across test runs
-        ),
-    ),
-));
+        ],
+    ],
+]);


### PR DESCRIPTION
PHP has two different ways of creating an array - `array()` or `[]`. This PR updates all occurrences of the older `array()` syntax to the newer and more widely accepted `[]`. This is also just now possible because we no longer need to retain the older `array` for backwards compatibility with PHP 5 as we just dropped support.