### PR TITLE
fix: test assertEquals order

### DIFF
--- a/test/EasyPost/AddressTest.php
+++ b/test/EasyPost/AddressTest.php
@@ -45,7 +45,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('\EasyPost\Address', $address);
         $this->assertStringMatchesFormat('adr_%s', $address->id);
-        $this->assertEquals($address->street1, '388 Townsend St');
+        $this->assertEquals('388 Townsend St', $address->street1);
 
         // Return so other tests can reuse this object
         return $address;
@@ -67,7 +67,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('\EasyPost\Address', $address);
         $this->assertStringMatchesFormat('adr_%s', $address->id);
-        $this->assertEquals($address->street1, '388 TOWNSEND ST APT 20');
+        $this->assertEquals('388 TOWNSEND ST APT 20', $address->street1);
 
         // Return so other tests can reuse this object
         return $address;
@@ -87,7 +87,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
         $retrieved_address = Address::retrieve($address->id);
 
         $this->assertInstanceOf('\EasyPost\Address', $retrieved_address);
-        $this->assertEquals($retrieved_address, $address);
+        $this->assertEquals($address, $retrieved_address);
     }
 
     /**
@@ -126,7 +126,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('\EasyPost\Address', $address);
         $this->assertStringMatchesFormat('adr_%s', $address->id);
-        $this->assertEquals($address->street1, '417 MONTGOMERY ST STE 500');
+        $this->assertEquals('417 MONTGOMERY ST STE 500', $address->street1);
     }
 
     /**
@@ -144,7 +144,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('\EasyPost\Address', $address);
         $this->assertStringMatchesFormat('adr_%s', $address->id);
-        $this->assertEquals($address->street1, '417 MONTGOMERY ST STE 500');
+        $this->assertEquals('417 MONTGOMERY ST STE 500', $address->street1);
     }
 
     /**
@@ -162,6 +162,6 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('\EasyPost\Address', $address);
         $this->assertStringMatchesFormat('adr_%s', $address->id);
-        $this->assertEquals($address->street1, '388 Townsend St');
+        $this->assertEquals('388 Townsend St', $address->street1);
     }
 }

--- a/test/EasyPost/BatchTest.php
+++ b/test/EasyPost/BatchTest.php
@@ -68,7 +68,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
         $retrieved_batch = Batch::retrieve($batch->id);
 
         $this->assertInstanceOf('\EasyPost\Batch', $retrieved_batch);
-        $this->assertEquals($retrieved_batch->id, $batch->id);
+        $this->assertEquals($batch->id, $retrieved_batch->id);
     }
 
     /**
@@ -108,7 +108,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('\EasyPost\Batch', $batch);
         $this->assertStringMatchesFormat('batch_%s', $batch->id);
-        $this->assertEquals($batch->num_shipments, 2);
+        $this->assertEquals(2, $batch->num_shipments);
     }
 
     /**
@@ -129,7 +129,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
         $batch->buy();
 
         $this->assertInstanceOf('\EasyPost\Batch', $batch);
-        $this->assertEquals($batch->num_shipments, 1);
+        $this->assertEquals(1, $batch->num_shipments);
 
         // Return so other tests can reuse this object
         return $batch;
@@ -168,12 +168,12 @@ class BatchTest extends \PHPUnit\Framework\TestCase
         $batch->add_shipments([
             'shipments' => [$shipment]
         ]);
-        $this->assertEquals($batch->num_shipments, 1);
+        $this->assertEquals(1, $batch->num_shipments);
 
         $batch->remove_shipments([
             'shipments' => [$shipment]
         ]);
-        $this->assertEquals($batch->num_shipments, 0);
+        $this->assertEquals(0, $batch->num_shipments);
     }
 
     /**

--- a/test/EasyPost/CarrierAccountTest.php
+++ b/test/EasyPost/CarrierAccountTest.php
@@ -109,7 +109,7 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('\EasyPost\CarrierAccount', $carrier_account);
         $this->assertStringMatchesFormat('ca_%s', $carrier_account->id);
-        $this->assertEquals($carrier_account->description, $test_description);
+        $this->assertEquals($test_description, $carrier_account->description);
     }
 
     /**

--- a/test/EasyPost/CustomsInfoTest.php
+++ b/test/EasyPost/CustomsInfoTest.php
@@ -45,7 +45,7 @@ class CustomsInfoTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('\EasyPost\CustomsInfo', $customs_item);
         $this->assertStringMatchesFormat('cstinfo_%s', $customs_item->id);
-        $this->assertEquals($customs_item->eel_pfc, 'NOEEI 30.37(a)');
+        $this->assertEquals('NOEEI 30.37(a)', $customs_item->eel_pfc);
 
         // Return so other tests can reuse this object
         return $customs_item;
@@ -65,6 +65,6 @@ class CustomsInfoTest extends \PHPUnit\Framework\TestCase
         $retrieved_customs_item = CustomsInfo::retrieve($customs_item->id);
 
         $this->assertInstanceOf('\EasyPost\CustomsInfo', $retrieved_customs_item);
-        $this->assertEquals($retrieved_customs_item, $customs_item);
+        $this->assertEquals($customs_item, $retrieved_customs_item);
     }
 }

--- a/test/EasyPost/CustomsItemTest.php
+++ b/test/EasyPost/CustomsItemTest.php
@@ -45,7 +45,7 @@ class CustomsItemTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('\EasyPost\CustomsItem', $customs_item);
         $this->assertStringMatchesFormat('cstitem_%s', $customs_item->id);
-        $this->assertEquals($customs_item->value, '23.0');
+        $this->assertEquals('23.0', $customs_item->value);
 
         // Return so other tests can reuse this object
         return $customs_item;
@@ -65,6 +65,6 @@ class CustomsItemTest extends \PHPUnit\Framework\TestCase
         $retrieved_customs_item = CustomsItem::retrieve($customs_item->id);
 
         $this->assertInstanceOf('\EasyPost\CustomsItem', $retrieved_customs_item);
-        $this->assertEquals($retrieved_customs_item, $customs_item);
+        $this->assertEquals($customs_item, $retrieved_customs_item);
     }
 }

--- a/test/EasyPost/EasyPostTest.php
+++ b/test/EasyPost/EasyPostTest.php
@@ -45,7 +45,7 @@ class EasyPostTest extends \PHPUnit\Framework\TestCase
         EasyPost::setApiBase($test_base);
         $api_base = EasyPost::getApiBase();
 
-        $this->assertEquals($api_base, $test_base);
+        $this->assertEquals($test_base, $api_base);
     }
 
     /**
@@ -60,7 +60,7 @@ class EasyPostTest extends \PHPUnit\Framework\TestCase
         EasyPost::setApiVersion($test_version);
         $api_version = EasyPost::getApiVersion();
 
-        $this->assertEquals($api_version, $test_version);
+        $this->assertEquals($test_version, $api_version);
     }
 
     /**
@@ -75,7 +75,7 @@ class EasyPostTest extends \PHPUnit\Framework\TestCase
         EasyPost::setConnectTimeout($test_timeout);
         $connection_timeout = EasyPost::getConnectTimeout();
 
-        $this->assertEquals($connection_timeout, $test_timeout);
+        $this->assertEquals($test_timeout, $connection_timeout);
     }
 
     /**
@@ -90,6 +90,6 @@ class EasyPostTest extends \PHPUnit\Framework\TestCase
         EasyPost::setResponseTimeout($test_timeout);
         $connection_timeout = EasyPost::getResponseTimeout();
 
-        $this->assertEquals($connection_timeout, $test_timeout);
+        $this->assertEquals($test_timeout, $connection_timeout);
     }
 }

--- a/test/EasyPost/ErrorTest.php
+++ b/test/EasyPost/ErrorTest.php
@@ -45,8 +45,8 @@ class ErrorTest extends \PHPUnit\Framework\TestCase
         try {
             $_ = Shipment::create();
         } catch (Error $error) {
-            $this->assertEquals($error->getHttpStatus(), 422);
-            $this->assertEquals($error->getHttpBody(), '{"error":{"code":"SHIPMENT.INVALID_PARAMS","message":"Unable to create shipment, one or more parameters were invalid.","errors":[{"to_address":"Required and missing."},{"from_address":"Required and missing."}]}}');
+            $this->assertEquals(422, $error->getHttpStatus());
+            $this->assertEquals('{"error":{"code":"SHIPMENT.INVALID_PARAMS","message":"Unable to create shipment, one or more parameters were invalid.","errors":[{"to_address":"Required and missing."},{"from_address":"Required and missing."}]}}', $error->getHttpBody());
 
             // We check that the printed output is the same here, leave the odd formatting as it is here and do not auto-format the next few lines
             $error->prettyPrint();

--- a/test/EasyPost/OrderTest.php
+++ b/test/EasyPost/OrderTest.php
@@ -69,7 +69,7 @@ class OrderTest extends \PHPUnit\Framework\TestCase
         $retrieved_order = Order::retrieve($order->id);
 
         $this->assertInstanceOf('\EasyPost\Order', $retrieved_order);
-        $this->assertEquals($retrieved_order->id, $order->id);
+        $this->assertEquals($order->id, $retrieved_order->id);
     }
 
     /**

--- a/test/EasyPost/ParcelTest.php
+++ b/test/EasyPost/ParcelTest.php
@@ -45,7 +45,7 @@ class ParcelTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('\EasyPost\Parcel', $parcel);
         $this->assertStringMatchesFormat('prcl_%s', $parcel->id);
-        $this->assertEquals($parcel->weight, 15.4);
+        $this->assertEquals(15.4, $parcel->weight);
 
         // Return so other tests can reuse this object
         return $parcel;
@@ -65,6 +65,6 @@ class ParcelTest extends \PHPUnit\Framework\TestCase
         $retrieved_parcel = Parcel::retrieve($parcel->id);
 
         $this->assertInstanceOf('\EasyPost\Parcel', $retrieved_parcel);
-        $this->assertEquals($retrieved_parcel, $parcel);
+        $this->assertEquals($parcel, $retrieved_parcel);
     }
 }

--- a/test/EasyPost/PickupTest.php
+++ b/test/EasyPost/PickupTest.php
@@ -93,7 +93,7 @@ class PickupTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('\EasyPost\Pickup', $bought_pickup);
         $this->assertStringMatchesFormat('pickup_%s', $bought_pickup->id);
         $this->assertNotNull($bought_pickup->confirmation);
-        $this->assertEquals($bought_pickup->status, 'scheduled');
+        $this->assertEquals('scheduled', $bought_pickup->status);
 
         // Return so other tests can reuse this object
         return $pickup;
@@ -114,6 +114,6 @@ class PickupTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('\EasyPost\Pickup', $cancelled_pickup);
         $this->assertStringMatchesFormat('pickup_%s', $cancelled_pickup->id);
-        $this->assertNotNull($cancelled_pickup->status, 'canceled');
+        $this->assertEquals('canceled', $cancelled_pickup->status);
     }
 }

--- a/test/EasyPost/RefundTest.php
+++ b/test/EasyPost/RefundTest.php
@@ -53,7 +53,7 @@ class RefundTest extends \PHPUnit\Framework\TestCase
         ]);
 
         $this->assertStringMatchesFormat('rfnd_%s', $refund[0]->id);
-        $this->assertEquals($refund[0]->status, 'submitted');
+        $this->assertEquals('submitted', $refund[0]->status);
     }
 
     /**

--- a/test/EasyPost/ReportTest.php
+++ b/test/EasyPost/ReportTest.php
@@ -156,8 +156,8 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         $retrieved_payment_log_report = Report::retrieve($payment_log_report->id);
 
         $this->assertInstanceOf('\EasyPost\Report', $retrieved_payment_log_report);
-        $this->assertEquals($retrieved_payment_log_report->start_date, $payment_log_report->start_date);
-        $this->assertEquals($retrieved_payment_log_report->end_date, $payment_log_report->end_date);
+        $this->assertEquals($payment_log_report->start_date, $retrieved_payment_log_report->start_date);
+        $this->assertEquals($payment_log_report->end_date, $retrieved_payment_log_report->end_date);
     }
 
     /**
@@ -174,8 +174,8 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         $retrieved_refund_report = Report::retrieve($refund_report->id);
 
         $this->assertInstanceOf('\EasyPost\Report', $retrieved_refund_report);
-        $this->assertEquals($retrieved_refund_report->start_date, $refund_report->start_date);
-        $this->assertEquals($retrieved_refund_report->end_date, $refund_report->end_date);
+        $this->assertEquals($refund_report->start_date, $retrieved_refund_report->start_date);
+        $this->assertEquals($refund_report->end_date, $retrieved_refund_report->end_date);
     }
 
     /**
@@ -192,8 +192,8 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         $retrieved_shipment_report = Report::retrieve($shipment_report->id);
 
         $this->assertInstanceOf('\EasyPost\Report', $retrieved_shipment_report);
-        $this->assertEquals($retrieved_shipment_report->start_date, $shipment_report->start_date);
-        $this->assertEquals($retrieved_shipment_report->end_date, $shipment_report->end_date);
+        $this->assertEquals($shipment_report->start_date, $retrieved_shipment_report->start_date);
+        $this->assertEquals($shipment_report->end_date, $retrieved_shipment_report->end_date);
     }
 
     /**
@@ -210,8 +210,8 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         $retrieved_shipment_invoice_report = Report::retrieve($shipment_invoice_report->id);
 
         $this->assertInstanceOf('\EasyPost\Report', $retrieved_shipment_invoice_report);
-        $this->assertEquals($retrieved_shipment_invoice_report->start_date, $shipment_invoice_report->start_date);
-        $this->assertEquals($retrieved_shipment_invoice_report->end_date, $shipment_invoice_report->end_date);
+        $this->assertEquals($shipment_invoice_report->start_date, $retrieved_shipment_invoice_report->start_date);
+        $this->assertEquals($shipment_invoice_report->end_date, $retrieved_shipment_invoice_report->end_date);
     }
 
     /**
@@ -228,8 +228,8 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         $retrieved_tracker_report = Report::retrieve($tracker_report->id);
 
         $this->assertInstanceOf('\EasyPost\Report', $retrieved_tracker_report);
-        $this->assertEquals($retrieved_tracker_report->start_date, $tracker_report->start_date);
-        $this->assertEquals($retrieved_tracker_report->end_date, $tracker_report->end_date);
+        $this->assertEquals($tracker_report->start_date, $retrieved_tracker_report->start_date);
+        $this->assertEquals($tracker_report->end_date, $retrieved_tracker_report->end_date);
     }
 
     /**

--- a/test/EasyPost/ShipmentTest.php
+++ b/test/EasyPost/ShipmentTest.php
@@ -48,9 +48,9 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('\EasyPost\Shipment', $shipment);
         $this->assertStringMatchesFormat('shp_%s', $shipment->id);
         $this->assertNotNull($shipment->rates);
-        $this->assertEquals($shipment->options->label_format, 'PNG');
-        $this->assertEquals($shipment->options->invoice_number, '123');
-        $this->assertEquals($shipment->reference, '123');
+        $this->assertEquals('PNG', $shipment->options->label_format);
+        $this->assertEquals('123', $shipment->options->invoice_number);
+        $this->assertEquals('123', $shipment->reference);
 
         // Return so other tests can reuse this object
         return $shipment;
@@ -70,7 +70,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
         $retrieved_shipment = Shipment::retrieve($shipment->id);
 
         $this->assertInstanceOf('\EasyPost\Shipment', $retrieved_shipment);
-        $this->assertEquals($retrieved_shipment->id, $shipment->id);
+        $this->assertEquals($shipment->id, $retrieved_shipment->id);
     }
 
     /**
@@ -173,7 +173,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
             'amount' => '100',
         ]);
 
-        $this->assertEquals($shipment->insurance, '100.00');
+        $this->assertEquals('100.00', $shipment->insurance);
     }
 
     /**
@@ -193,7 +193,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
         $shipment->refund();
 
-        $this->assertEquals($shipment->refund_status, 'submitted');
+        $this->assertEquals('submitted', $shipment->refund_status);
     }
 
     /**
@@ -260,6 +260,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('\EasyPost\Shipment', $shipment);
         $this->assertStringMatchesFormat('shp_%s', $shipment->id);
-        $this->assertEquals($shipment->tax_identifiers[0]['tax_id_type'], 'IOSS');
+        $this->assertEquals('IOSS', $shipment->tax_identifiers[0]['tax_id_type']);
     }
 }

--- a/test/EasyPost/TrackerTest.php
+++ b/test/EasyPost/TrackerTest.php
@@ -47,7 +47,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('\EasyPost\Tracker', $tracker);
         $this->assertStringMatchesFormat('trk_%s', $tracker->id);
-        $this->assertEquals($tracker->status, 'pre_transit');
+        $this->assertEquals('pre_transit', $tracker->status);
 
         // Return so other tests can reuse this object
         return $tracker;
@@ -68,7 +68,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
         $retrieved_tracker = Tracker::retrieve($tracker->id);
 
         $this->assertInstanceOf('\EasyPost\Tracker', $retrieved_tracker);
-        $this->assertEquals($retrieved_tracker->id, $tracker->id);
+        $this->assertEquals($tracker->id, $retrieved_tracker->id);
     }
 
     /**

--- a/test/EasyPost/UserTest.php
+++ b/test/EasyPost/UserTest.php
@@ -102,7 +102,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('\EasyPost\User', $user);
         $this->assertStringMatchesFormat('user_%s', $user->id);
-        $this->assertEquals($user->phone, $test_phone);
+        $this->assertEquals($test_phone, $user->phone);
     }
 
     /**
@@ -172,6 +172,6 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('\EasyPost\Brand', $brand);
         $this->assertStringMatchesFormat('brd_%s', $brand->id);
-        $this->assertEquals($brand->color, $color);
+        $this->assertEquals($color, $brand->color);
     }
 }

--- a/test/EasyPost/WebhookTest.php
+++ b/test/EasyPost/WebhookTest.php
@@ -47,7 +47,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('\EasyPost\Webhook', $webhook);
         $this->assertStringMatchesFormat('hook_%s', $webhook->id);
-        $this->assertEquals($webhook->url, 'http://example.com');
+        $this->assertEquals('http://example.com', $webhook->url);
 
         // Return so other tests can reuse this object
         return $webhook;
@@ -67,7 +67,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         $retrieved_webhook = Webhook::retrieve($webhook->id);
 
         $this->assertInstanceOf('\EasyPost\Webhook', $retrieved_webhook);
-        $this->assertEquals($retrieved_webhook, $webhook);
+        $this->assertEquals($webhook, $retrieved_webhook);
 
         // Return so the `delete` test can reuse this object
         return $webhook;


### PR DESCRIPTION
Swaps the order of all `assertEquals` tests to be `expected`, then `actual` like it should be.

Also found one `assertNotNull` that should have actually been an `assertEquals`.