### PR TITLE
fix: removes the params from the Address->verify method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## NEXT RELEASE
+
+* Removes the `params` from the `Address->verify()` method since it's non-static and unused
+* Various corrections made to the test suite
+
 ## v5.0.0 (2022-02-09)
 
 * Bumped minimum PHP version supported from `5.3` to `7.3`

--- a/lib/EasyPost/Address.php
+++ b/lib/EasyPost/Address.php
@@ -133,15 +133,15 @@ class Address extends EasypostResource
     /**
      * Verify an address.
      *
-     * @param mixed $params
      * @return mixed
      * @throws \EasyPost\Error
      */
-    public function verify($params = null)
+    public function verify()
     {
         $requestor = new Requestor($this->_apiKey);
         $url = $this->instanceUrl() . '/verify';
-        list($response, $apiKey) = $requestor->request('get', $url, $params);
+        list($response, $apiKey) = $requestor->request('get', $url, null);
+
         if (isset($response['address'])) {
             $verified_address = Util::convertToEasyPostObject($response['address'], $apiKey);
             if (!empty($response['message'])) {

--- a/test/EasyPost/AddressTest.php
+++ b/test/EasyPost/AddressTest.php
@@ -158,7 +158,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
     {
         VCR::insertCassette('addresses/verify.yml');
 
-        $address->verify(Fixture::incorrect_address_to_verify());
+        $address->verify();
 
         $this->assertInstanceOf('\EasyPost\Address', $address);
         $this->assertStringMatchesFormat('adr_%s', $address->id);

--- a/test/cassettes/addresses/verify.yml
+++ b/test/cassettes/addresses/verify.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/addresses/adr_b863a663883e11ec8b78ac1f6b0a0d1e/verify?verify%5B0%5D=true&street1=417+montgomery+streat&street2=FL+5&city=San+Francisco&state=CA&zip=94104&country=US&company=EasyPost&phone=415-123-4567'
+        url: 'https://api.easypost.com/v2/addresses/adr_b863a663883e11ec8b78ac1f6b0a0d1e/verify'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -23,57 +23,58 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 888f661162015c5ee7874dc4004b8692
+            x-ep-request-uuid: 4394cb02621002a5e788d943009ca5cb
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
-            location: /api/v2/addresses/adr_b8b32358883e11ecb620ac1f6bc72124
+            location: /api/v2/addresses/adr_0f292a6690fa11ecbfe1ac1f6bc7b362
             content-type: 'application/json; charset=utf-8'
             content-length: '650'
-            etag: 'W/"22f634d7328755b1ec2441d9fac7c584"'
-            x-request-id: eae06b69-14e0-4d6a-ba51-3179a7981dc7
-            x-runtime: '0.053665'
-            x-node: bigweb4nuq
-            x-version-label: easypost-202202042220-76f9648007-master
+            etag: 'W/"f425ef8e417da47fd4d7faabaeb378d1"'
+            x-request-id: 61465bae-7565-41bf-9fe2-6d8fe189ed9d
+            x-runtime: '0.170966'
+            x-node: bigweb7nuq
+            x-version-label: easypost-202202181927-fc9b702778-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 88c34981dc', 'extlb1nuq 88c34981dc']
+            x-canary: direct
+            x-proxied: ['intlb2nuq 88c34981dc', 'extlb1nuq 88c34981dc']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"address":{"id":"adr_b8b32358883e11ecb620ac1f6bc72124","object":"Address","created_at":"2022-02-07T17:52:30+00:00","updated_at":"2022-02-07T17:52:30+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}}}'
+        body: '{"address":{"id":"adr_0f292a6690fa11ecbfe1ac1f6bc7b362","object":"Address","created_at":"2022-02-18T20:33:41+00:00","updated_at":"2022-02-18T20:33:41+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}}}'
         curl_info:
-            url: 'https://api.easypost.com/v2/addresses/adr_b863a663883e11ec8b78ac1f6b0a0d1e/verify?verify%5B0%5D=true&street1=417+montgomery+streat&street2=FL+5&city=San+Francisco&state=CA&zip=94104&country=US&company=EasyPost&phone=415-123-4567'
+            url: 'https://api.easypost.com/v2/addresses/adr_b863a663883e11ec8b78ac1f6b0a0d1e/verify'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 836
-            request_size: 725
+            header_size: 854
+            request_size: 578
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.254103
-            namelookup_time: 0.0015
-            connect_time: 0.059703
-            pretransfer_time: 0.141262
+            total_time: 0.380498
+            namelookup_time: 0.010049
+            connect_time: 0.068127
+            pretransfer_time: 0.149393
             size_upload: 0.0
             size_download: 650.0
-            speed_download: 2558.0
+            speed_download: 1708.0
             speed_upload: 0.0
             download_content_length: 650.0
             upload_content_length: 0.0
-            starttransfer_time: 0.25408
+            starttransfer_time: 0.380434
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 51782
+            local_ip: 10.130.6.11
+            local_port: 54175
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 140997
-            connect_time_us: 59703
-            namelookup_time_us: 1500
-            pretransfer_time_us: 141262
+            appconnect_time_us: 149187
+            connect_time_us: 68127
+            namelookup_time_us: 10049
+            pretransfer_time_us: 149393
             redirect_time_us: 0
-            starttransfer_time_us: 254080
-            total_time_us: 254103
+            starttransfer_time_us: 380434
+            total_time_us: 380498


### PR DESCRIPTION
* Removes the `params` from the `Address->verify()` method since it's non-static and unused
