### PR TITLE
chore: assert against has_more key for pagination

### DIFF
--- a/test/EasyPost/AddressTest.php
+++ b/test/EasyPost/AddressTest.php
@@ -106,6 +106,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
         $addresses_array = $addresses['addresses'];
 
         $this->assertLessThanOrEqual($addresses_array, Fixture::page_size());
+        $this->assertNotNull($addresses['has_more']);
         foreach ($addresses_array as $address) {
             $this->assertInstanceOf('\EasyPost\Address', $address);
         }

--- a/test/EasyPost/BatchTest.php
+++ b/test/EasyPost/BatchTest.php
@@ -87,6 +87,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
         $batches_array = $batches['batches'];
 
         $this->assertLessThanOrEqual($batches_array, Fixture::page_size());
+        $this->assertNotNull($batches['has_more']);
         foreach ($batches_array as $batch) {
             $this->assertInstanceOf('\EasyPost\Batch', $batch);
         }

--- a/test/EasyPost/EventTest.php
+++ b/test/EasyPost/EventTest.php
@@ -48,6 +48,7 @@ class EventTest extends \PHPUnit\Framework\TestCase
         $events_array = $events['events'];
 
         $this->assertLessThanOrEqual($events_array, Fixture::page_size());
+        $this->assertNotNull($events['has_more']);
         foreach ($events_array as $event) {
             $this->assertInstanceOf('\EasyPost\Event', $event);
         }

--- a/test/EasyPost/InsuranceTest.php
+++ b/test/EasyPost/InsuranceTest.php
@@ -92,6 +92,7 @@ class InsuranceTest extends \PHPUnit\Framework\TestCase
         $insurance_array = $insurance['insurances'];
 
         $this->assertLessThanOrEqual($insurance_array, Fixture::page_size());
+        $this->assertNotNull($insurance['has_more']);
         foreach ($insurance_array as $insurance) {
             $this->assertInstanceOf('\EasyPost\Insurance', $insurance);
         }

--- a/test/EasyPost/RefundTest.php
+++ b/test/EasyPost/RefundTest.php
@@ -72,6 +72,7 @@ class RefundTest extends \PHPUnit\Framework\TestCase
         $refunds_array = $refunds['refunds'];
 
         $this->assertLessThanOrEqual($refunds_array, Fixture::page_size());
+        $this->assertNotNull($refunds['has_more']);
         foreach ($refunds_array as $address) {
             $this->assertInstanceOf('\EasyPost\Refund', $address);
         }

--- a/test/EasyPost/ReportTest.php
+++ b/test/EasyPost/ReportTest.php
@@ -249,6 +249,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         $reports_array = $reports['reports'];
 
         $this->assertLessThanOrEqual($reports_array, Fixture::page_size());
+        $this->assertNotNull($reports['has_more']);
         foreach ($reports_array as $report) {
             $this->assertInstanceOf('\EasyPost\Report', $report);
         }

--- a/test/EasyPost/ScanFormTest.php
+++ b/test/EasyPost/ScanFormTest.php
@@ -88,6 +88,7 @@ class ScanFormTest extends \PHPUnit\Framework\TestCase
         $scanforms_array = $scanforms['scan_forms'];
 
         $this->assertLessThanOrEqual($scanforms_array, Fixture::page_size());
+        $this->assertNotNull($scanforms['has_more']);
         foreach ($scanforms_array as $scanform) {
             $this->assertInstanceOf('\EasyPost\ScanForm', $scanform);
         }

--- a/test/EasyPost/ShipmentTest.php
+++ b/test/EasyPost/ShipmentTest.php
@@ -89,6 +89,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
         $shipments_array = $shipments['shipments'];
 
         $this->assertLessThanOrEqual($shipments_array, Fixture::page_size());
+        $this->assertNotNull($shipments['has_more']);
         foreach ($shipments_array as $address) {
             $this->assertInstanceOf('\EasyPost\Shipment', $address);
         }

--- a/test/EasyPost/TrackerTest.php
+++ b/test/EasyPost/TrackerTest.php
@@ -87,6 +87,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
         $trackers_array = $trackers['trackers'];
 
         $this->assertLessThanOrEqual($trackers_array, Fixture::page_size());
+        $this->assertNotNull($trackers['has_more']);
         foreach ($trackers_array as $tracker) {
             $this->assertInstanceOf('\EasyPost\Tracker', $tracker);
         }


### PR DESCRIPTION
Adds `has_more` assertions to retrieving `all` records to ensure users can paginate properly.