### PR TITLE
fix: don't iterate all tests, use containsonlyinstanceof

### DIFF
--- a/test/EasyPost/AddressTest.php
+++ b/test/EasyPost/AddressTest.php
@@ -107,9 +107,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($addresses_array, Fixture::page_size());
         $this->assertNotNull($addresses['has_more']);
-        foreach ($addresses_array as $address) {
-            $this->assertInstanceOf('\EasyPost\Address', $address);
-        }
+        $this->assertContainsOnlyInstancesOf('\EasyPost\Address', $addresses_array);
     }
 
     /**

--- a/test/EasyPost/BatchTest.php
+++ b/test/EasyPost/BatchTest.php
@@ -88,9 +88,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($batches_array, Fixture::page_size());
         $this->assertNotNull($batches['has_more']);
-        foreach ($batches_array as $batch) {
-            $this->assertInstanceOf('\EasyPost\Batch', $batch);
-        }
+        $this->assertContainsOnlyInstancesOf('\EasyPost\Batch', $batches_array);
     }
 
     /**

--- a/test/EasyPost/CarrierAccountTest.php
+++ b/test/EasyPost/CarrierAccountTest.php
@@ -86,9 +86,7 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
 
         $carrier_accounts = CarrierAccount::all();
 
-        foreach ($carrier_accounts as $carrier_account) {
-            $this->assertInstanceOf('\EasyPost\CarrierAccount', $carrier_account);
-        }
+        $this->assertContainsOnlyInstancesOf('\EasyPost\CarrierAccount', $carrier_accounts);
     }
 
     /**

--- a/test/EasyPost/EventTest.php
+++ b/test/EasyPost/EventTest.php
@@ -49,9 +49,7 @@ class EventTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($events_array, Fixture::page_size());
         $this->assertNotNull($events['has_more']);
-        foreach ($events_array as $event) {
-            $this->assertInstanceOf('\EasyPost\Event', $event);
-        }
+        $this->assertContainsOnlyInstancesOf('\EasyPost\Event', $events_array);
 
         // Return so other tests can reuse these objects
         return $events;

--- a/test/EasyPost/InsuranceTest.php
+++ b/test/EasyPost/InsuranceTest.php
@@ -94,8 +94,6 @@ class InsuranceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($insurance_array, Fixture::page_size());
         $this->assertNotNull($insurance['has_more']);
-        foreach ($insurance_array as $insurance) {
-            $this->assertInstanceOf('\EasyPost\Insurance', $insurance);
-        }
+        $this->assertContainsOnlyInstancesOf('\EasyPost\Insurance', $insurance_array);
     }
 }

--- a/test/EasyPost/OrderTest.php
+++ b/test/EasyPost/OrderTest.php
@@ -88,9 +88,7 @@ class OrderTest extends \PHPUnit\Framework\TestCase
         $rates_array = $rates['rates'];
 
         $this->assertIsArray($rates_array);
-        foreach ($rates_array as $rate) {
-            $this->assertInstanceOf('\EasyPost\Rate', $rate);
-        }
+        $this->assertContainsOnlyInstancesOf('\EasyPost\Rate', $rates_array);
     }
 
     /**

--- a/test/EasyPost/RefundTest.php
+++ b/test/EasyPost/RefundTest.php
@@ -71,9 +71,7 @@ class RefundTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($refunds_array, Fixture::page_size());
         $this->assertNotNull($refunds['has_more']);
-        foreach ($refunds_array as $address) {
-            $this->assertInstanceOf('\EasyPost\Refund', $address);
-        }
+        $this->assertContainsOnlyInstancesOf('\EasyPost\Refund', $refunds_array);
 
         // Return so other tests can reuse these objects
         return $refunds;

--- a/test/EasyPost/ReportTest.php
+++ b/test/EasyPost/ReportTest.php
@@ -250,9 +250,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($reports_array, Fixture::page_size());
         $this->assertNotNull($reports['has_more']);
-        foreach ($reports_array as $report) {
-            $this->assertInstanceOf('\EasyPost\Report', $report);
-        }
+        $this->assertContainsOnlyInstancesOf('\EasyPost\Report', $reports_array);
     }
 
     /**

--- a/test/EasyPost/ScanFormTest.php
+++ b/test/EasyPost/ScanFormTest.php
@@ -89,9 +89,7 @@ class ScanFormTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($scanforms_array, Fixture::page_size());
         $this->assertNotNull($scanforms['has_more']);
-        foreach ($scanforms_array as $scanform) {
-            $this->assertInstanceOf('\EasyPost\ScanForm', $scanform);
-        }
+        $this->assertContainsOnlyInstancesOf('\EasyPost\ScanForm', $scanforms_array);
 
         // Return so other tests can reuse these objects
         return $scanforms;

--- a/test/EasyPost/ShipmentTest.php
+++ b/test/EasyPost/ShipmentTest.php
@@ -90,9 +90,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($shipments_array, Fixture::page_size());
         $this->assertNotNull($shipments['has_more']);
-        foreach ($shipments_array as $address) {
-            $this->assertInstanceOf('\EasyPost\Shipment', $address);
-        }
+        $this->assertContainsOnlyInstancesOf('\EasyPost\Shipment', $shipments_array);
     }
 
     /**

--- a/test/EasyPost/TrackerTest.php
+++ b/test/EasyPost/TrackerTest.php
@@ -88,9 +88,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($trackers_array, Fixture::page_size());
         $this->assertNotNull($trackers['has_more']);
-        foreach ($trackers_array as $tracker) {
-            $this->assertInstanceOf('\EasyPost\Tracker', $tracker);
-        }
+        $this->assertContainsOnlyInstancesOf('\EasyPost\Tracker', $trackers_array);
     }
 
     /**

--- a/test/EasyPost/WebhookTest.php
+++ b/test/EasyPost/WebhookTest.php
@@ -89,9 +89,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         $webhook_array = $webhooks['webhooks'];
 
         $this->assertLessThanOrEqual($webhook_array, Fixture::page_size());
-        foreach ($webhook_array as $webhook) {
-            $this->assertInstanceOf('\EasyPost\Webhook', $webhook);
-        }
+        $this->assertContainsOnlyInstancesOf('\EasyPost\Webhook', $webhook_array);
     }
 
     /**


### PR DESCRIPTION
Simplify the `all` tests by using `assertContainsOnlyInstancesOf` instead of iterating each record to assert the instance. This was also done in the Ruby lib. Has the added benefit of correcting a few bad variable names from copy/pasta.