### PR TITLE
[feat] Support for `columns` and `additional_columns` on Report creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## NEXT RELEASE
 
 * Removes the `params` from the `Address->verify()` method since it's non-static and unused
+* Add `columns` and `additional_columns` support to `Report->create()`
 
 ## v5.0.0 (2022-02-09)
 

--- a/lib/EasyPost/Report.php
+++ b/lib/EasyPost/Report.php
@@ -67,6 +67,34 @@ class Report extends EasypostResource
      */
     public static function create($params = null, $apiKey = null)
     {
+        if ((isset($params['columns']) && is_array($params['columns'])) || (isset($params['additional_columns']) && is_array($params['additional_columns']))) {
+            $columns = "";
+            if (isset($params['columns'])) {
+                $columns = $params['columns'];
+                unset($params['columns']);
+            }
+
+            $additional_columns = "";
+            if (isset($params['additional_columns'])) {
+                $additional_columns = $params['additional_columns'];
+                unset($params['additional_columns']);
+            }
+
+            $urlMod = "?";
+
+            if (is_array($columns)) {
+                foreach ($columns as $column) {
+                    $urlMod .= "columns[]=" . $column . "&";
+                }
+            }
+
+            if (is_array($additional_columns)) {
+                foreach ($additional_columns as $additional_column) {
+                    $urlMod .= "additional_columns[]=" . $additional_column . "&";
+                }
+            }
+        }
+
         if (!isset($params['type'])) {
             throw new Error('Undetermined Report Type');
         } else {

--- a/lib/EasyPost/Report.php
+++ b/lib/EasyPost/Report.php
@@ -67,47 +67,39 @@ class Report extends EasypostResource
      */
     public static function create($params = null, $apiKey = null)
     {
-        if ((isset($params['columns']) && is_array($params['columns'])) || (isset($params['additional_columns']) && is_array($params['additional_columns']))) {
-            $columns = "";
-            if (isset($params['columns'])) {
-                $columns = $params['columns'];
-                unset($params['columns']);
-            }
-
-            $additional_columns = "";
-            if (isset($params['additional_columns'])) {
-                $additional_columns = $params['additional_columns'];
-                unset($params['additional_columns']);
-            }
-
-            $urlMod = "?";
-
-            if (is_array($columns)) {
-                foreach ($columns as $column) {
-                    $urlMod .= "columns[]=" . $column . "&";
-                }
-            }
-
-            if (is_array($additional_columns)) {
-                foreach ($additional_columns as $additional_column) {
-                    $urlMod .= "additional_columns[]=" . $additional_column . "&";
-                }
-            }
-        }
-
         if (!isset($params['type'])) {
             throw new Error('Undetermined Report Type');
-        } else {
-            $type = $params['type'];
-
-            self::_validate($params, $apiKey);
-            $requestor = new Requestor($apiKey);
-
-            $url = self::reportUrl($type);
-
-            list($response, $apiKey) = $requestor->request('post', $url, $params, true);
-            return Util::convertToEasyPostObject($response, $apiKey);
         }
+
+        $url = self::reportUrl($params['type']);
+
+        $urlMod = "";
+
+        if ((isset($params['columns']) && is_array($params['columns']))) {
+            foreach ($params['columns'] as $column) {
+                $urlMod .= "columns[]=" . $column . "&";
+            }
+            // Removing from params since already used in query params
+            unset($params['columns']);
+        }
+
+        if ((isset($params['additional_columns']) && is_array($params['additional_columns']))) {
+            foreach ($params['additional_columns'] as $additional_column) {
+                $urlMod .= "additional_columns[]=" . $additional_column . "&";
+            }
+            // Removing from params since already used in query params
+            unset($params['additional_columns']);
+        }
+
+        if ($urlMod != "") {
+            $url .= "?" . $urlMod;
+        }
+
+        self::_validate($params, $apiKey);
+        $requestor = new Requestor($apiKey);
+
+        list($response, $apiKey) = $requestor->request('post', $url, $params, true);
+        return Util::convertToEasyPostObject($response, $apiKey);
     }
 
     /**

--- a/test/EasyPost/ReportTest.php
+++ b/test/EasyPost/ReportTest.php
@@ -158,10 +158,10 @@ class ReportTest extends \PHPUnit\Framework\TestCase
             'columns' => ['usps_zone']
         ]);
 
-        $this->assertInstanceOf('\EasyPost\Report', $report);
         // Reports are queued, so we can't retrieve it immediately.
         // Verifying columns would require parsing the CSV.
         // Verify parameters sent correctly by checking the URL in the cassette.
+        $this->assertInstanceOf('\EasyPost\Report', $report);
     }
 
     /**
@@ -180,10 +180,10 @@ class ReportTest extends \PHPUnit\Framework\TestCase
             'additional_columns' => ['from_name', 'from_company']
         ]);
 
-        $this->assertInstanceOf('\EasyPost\Report', $report);
         // Reports are queued, so we can't retrieve it immediately.
         // Verifying columns would require parsing the CSV.
         // Verify parameters sent correctly by checking the URL in the cassette.
+        $this->assertInstanceOf('\EasyPost\Report', $report);
     }
 
     /**

--- a/test/EasyPost/ReportTest.php
+++ b/test/EasyPost/ReportTest.php
@@ -143,6 +143,50 @@ class ReportTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test creating a report with custom columns
+     *
+     * @return void
+     */
+    public function testCreateCustomColumnReport()
+    {
+        VCR::insertCassette('reports/createCustomColumnReport.yml');
+
+        $report = Report::create([
+            'start_date' => Fixture::report_start_date(),
+            'end_date' => Fixture::report_end_date(),
+            'type' => 'shipment',
+            'columns' => ['usps_zone']
+        ]);
+
+        $this->assertInstanceOf('\EasyPost\Report', $report);
+        // Reports are queued, so we can't retrieve it immediately.
+        // Verifying columns would require parsing the CSV.
+        // Verify parameters sent correctly by checking the URL in the cassette.
+    }
+
+    /**
+     * Test creating a report with custom additional columns
+     *
+     * @return void
+     */
+    public function testCreateCustomAdditionalColumnReport()
+    {
+        VCR::insertCassette('reports/createCustomAdditionalColumnReport.yml');
+
+        $report = Report::create([
+            'start_date' => Fixture::report_start_date(),
+            'end_date' => Fixture::report_end_date(),
+            'type' => 'shipment',
+            'additional_columns' => ['from_name', 'from_company']
+        ]);
+
+        $this->assertInstanceOf('\EasyPost\Report', $report);
+        // Reports are queued, so we can't retrieve it immediately.
+        // Verifying columns would require parsing the CSV.
+        // Verify parameters sent correctly by checking the URL in the cassette.
+    }
+
+    /**
      * Test retrieving a Payment Log report.
      *
      * @param Report $report

--- a/test/cassettes/reports/all.yml
+++ b/test/cassettes/reports/all.yml
@@ -23,20 +23,20 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 4e82e4b7623a5de1e779a008001852ae
+            x-ep-request-uuid: 15978952623b6023f1fb7766001b1b33
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
-            content-length: '3469'
-            etag: 'W/"70f1b2f0256c8a9258822e701f9cab83"'
-            x-runtime: '0.035796'
+            content-length: '3065'
+            etag: 'W/"05535625b14de04974c50acd026b3e62"'
+            x-runtime: '0.045938'
             x-node: bigweb2nuq
             x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
             x-proxied: ['intlb1nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"reports":[{"id":"shprep_d21f5c32334a4a8e87b67b1109316f55","object":"ShipmentReport","created_at":"2022-03-22T23:38:08Z","updated_at":"2022-03-22T23:38:08Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220322/03c71773f60046ed91d29cfe10c9ad76.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233809Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=fed32fdfdc7c0b4f3f550b09ba60926cd95ca10527c57dc1c7f8e9bf99cbab04","url_expires_at":"2022-03-22T23:38:39Z","include_children":false},{"id":"shprep_34fe58eade354016abcd7db805a98a36","object":"ShipmentReport","created_at":"2022-03-22T23:38:08Z","updated_at":"2022-03-22T23:38:08Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220322/a3e57375aa83468e8d250aa54cce57aa.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233809Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=45e8862f541b1f7ee820f466fb89c599a525ccc6d21e1ffc974cc6383cfbd977","url_expires_at":"2022-03-22T23:38:39Z","include_children":false},{"id":"shprep_3288b84aff0d4dd5b96a7597c44553ad","object":"ShipmentReport","created_at":"2022-03-22T23:38:07Z","updated_at":"2022-03-22T23:38:08Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220322/45244ef89a3a41709adf0185e04159c4.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233809Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=2d59ee9b0a19c43dbd4bcf3ebbeeaccbe4ba394736fedcb48062bea8e9fab8b6","url_expires_at":"2022-03-22T23:38:39Z","include_children":false},{"id":"shprep_2a1170b363764ad88a4ded49c773714c","object":"ShipmentReport","created_at":"2022-03-22T23:30:39Z","updated_at":"2022-03-22T23:30:39Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220322/3c714400a9f64b348f22470246ad6639.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233809Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=3aee6f0a764206abf62ac1e596a6f485d3e807934e8ac17014ed2fe7ffe7dda5","url_expires_at":"2022-03-22T23:38:39Z","include_children":false},{"id":"shprep_c31c5acb77554034aa77c041c804f4c3","object":"ShipmentReport","created_at":"2022-03-22T23:30:38Z","updated_at":"2022-03-22T23:30:39Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220322/15eb94547c594557b64da7b17ae9fb38.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233809Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=012887c16fdcc39885a58573e33ec58eb2e7a48f5348bab4be5b03dc08553c9d","url_expires_at":"2022-03-22T23:38:39Z","include_children":false}],"has_more":true}'
+        body: '{"reports":[{"id":"shprep_08ac4b4736de41b9ade117e92a4ff15e","object":"ShipmentReport","created_at":"2022-03-23T18:00:03Z","updated_at":"2022-03-23T18:00:03Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false},{"id":"shprep_ca4c6b862125463199704b07a10afde4","object":"ShipmentReport","created_at":"2022-03-23T18:00:01Z","updated_at":"2022-03-23T18:00:01Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220323/7cb7c6f3674e467b931dff0d5f2755a4.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220323%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220323T180003Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=23387f7e061c5c900604b67124f419ed3568faf3fe3eecfb7d99e65b71abac93","url_expires_at":"2022-03-23T18:00:33Z","include_children":false},{"id":"shprep_cca848e778d94039ae4dbe0b6cf1fdd3","object":"ShipmentReport","created_at":"2022-03-23T18:00:01Z","updated_at":"2022-03-23T18:00:01Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220323/773930d6aceb461abdd0f5ea1a11c588.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220323%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220323T180003Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=ad81a64e5bb37e603bdec92b8a2c8e2f67947ebec638fb0fca7078e04f23d284","url_expires_at":"2022-03-23T18:00:33Z","include_children":false},{"id":"shprep_d21f5c32334a4a8e87b67b1109316f55","object":"ShipmentReport","created_at":"2022-03-22T23:38:08Z","updated_at":"2022-03-22T23:38:08Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220322/03c71773f60046ed91d29cfe10c9ad76.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220323%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220323T180003Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=22636e033f1afd27feb2c4b674bc028f67439621567206c38a8102df66c19721","url_expires_at":"2022-03-23T18:00:33Z","include_children":false},{"id":"shprep_34fe58eade354016abcd7db805a98a36","object":"ShipmentReport","created_at":"2022-03-22T23:38:08Z","updated_at":"2022-03-22T23:38:08Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220322/a3e57375aa83468e8d250aa54cce57aa.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220323%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220323T180003Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=c70de2918d19907026ee1b302a753945cad33e70385c65a74f5b9acb269a6f68","url_expires_at":"2022-03-23T18:00:33Z","include_children":false}],"has_more":true}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/shipment/?type=shipment&page_size=5'
             content_type: 'application/json; charset=utf-8'
@@ -46,32 +46,32 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.204239
-            namelookup_time: 0.001767
-            connect_time: 0.050787
-            pretransfer_time: 0.117433
+            total_time: 0.187165
+            namelookup_time: 0.001428
+            connect_time: 0.060758
+            pretransfer_time: 0.106446
             size_upload: 0.0
-            size_download: 3469.0
-            speed_download: 16985.0
+            size_download: 3065.0
+            speed_download: 16375.0
             speed_upload: 0.0
-            download_content_length: 3469.0
+            download_content_length: 3065.0
             upload_content_length: 0.0
-            starttransfer_time: 0.204209
+            starttransfer_time: 0.187128
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.32
-            local_port: 49923
+            local_ip: 172.168.1.123
+            local_port: 53905
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 117301
-            connect_time_us: 50787
-            namelookup_time_us: 1767
-            pretransfer_time_us: 117433
+            appconnect_time_us: 106299
+            connect_time_us: 60758
+            namelookup_time_us: 1428
+            pretransfer_time_us: 106446
             redirect_time_us: 0
-            starttransfer_time_us: 204209
-            total_time_us: 204239
+            starttransfer_time_us: 187128
+            total_time_us: 187165

--- a/test/cassettes/reports/all.yml
+++ b/test/cassettes/reports/all.yml
@@ -23,56 +23,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 888f660c62015c72e7875164004b8c1b
+            x-ep-request-uuid: 4e82e4b7623a5de1e779a008001852ae
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '3469'
-            etag: 'W/"607c7a4edb41135ea952758e17468a20"'
-            x-request-id: 377b8d30-7e83-494a-a3d4-f1ec72b91316
-            x-runtime: '0.061236'
-            x-node: bigweb1nuq
-            x-version-label: easypost-202202042220-76f9648007-master
+            etag: 'W/"70f1b2f0256c8a9258822e701f9cab83"'
+            x-runtime: '0.035796'
+            x-node: bigweb2nuq
+            x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 88c34981dc', 'extlb1nuq 88c34981dc']
+            x-proxied: ['intlb1nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"reports":[{"id":"shprep_3340200ca0ad402e9fea7fe2aede2306","object":"ShipmentReport","created_at":"2022-02-07T17:52:49Z","updated_at":"2022-02-07T17:52:50Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220207/1ea9ced7b7f04d2b83ed253d8f0e8397.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220207%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220207T175250Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=91e38ba61080e3b48561df9a0194a960dd5182a62a33e810c97f56cab39034b0","url_expires_at":"2022-02-07T17:53:20Z","include_children":false},{"id":"shprep_9f9d7c1b54964a22a73f721e22645a67","object":"ShipmentReport","created_at":"2022-02-07T17:51:49Z","updated_at":"2022-02-07T17:51:49Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220207/e845ffb403c84137ae4cf5e5ff6c92ca.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220207%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220207T175250Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=e3739b347de08e2dd399fde8cd32d43a513deeb9af7240e07fd71cb3e10a0ab3","url_expires_at":"2022-02-07T17:53:20Z","include_children":false},{"id":"shprep_19e0fdaf21cd415f836d2be5663ab8a7","object":"ShipmentReport","created_at":"2022-02-05T00:20:54Z","updated_at":"2022-02-05T00:20:54Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220205/7ef70c1feb1b4dc1a046f41bb91f13d7.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220207%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220207T175250Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=903728135cc44077c2c7e71ba3d686147a8b302d6d780441ba17e1ed277815a9","url_expires_at":"2022-02-07T17:53:20Z","include_children":false},{"id":"shprep_38efd7601c2245ad95a86afd37f3be41","object":"ShipmentReport","created_at":"2022-02-04T17:31:59Z","updated_at":"2022-02-04T17:31:59Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220204/3fe406f854c34880b39cae1652bdf8b0.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220207%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220207T175250Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=7e29ebb05b326ae9c1a6386ed71f5a1b3795f150f965c1d066494f25b0ab488f","url_expires_at":"2022-02-07T17:53:20Z","include_children":false},{"id":"shprep_2fa8c11362fc44adbfb73b65626d23a4","object":"ShipmentReport","created_at":"2022-02-04T16:29:54Z","updated_at":"2022-02-04T16:29:54Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220204/5c26ed4ce7c2490d8d85f69661013311.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220207%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220207T175250Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=26adf84568c15c964d7e864bf87f0ecead39e168d857bc9356c102b1928f6132","url_expires_at":"2022-02-07T17:53:20Z","include_children":false}],"has_more":true}'
+        body: '{"reports":[{"id":"shprep_d21f5c32334a4a8e87b67b1109316f55","object":"ShipmentReport","created_at":"2022-03-22T23:38:08Z","updated_at":"2022-03-22T23:38:08Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220322/03c71773f60046ed91d29cfe10c9ad76.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233809Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=fed32fdfdc7c0b4f3f550b09ba60926cd95ca10527c57dc1c7f8e9bf99cbab04","url_expires_at":"2022-03-22T23:38:39Z","include_children":false},{"id":"shprep_34fe58eade354016abcd7db805a98a36","object":"ShipmentReport","created_at":"2022-03-22T23:38:08Z","updated_at":"2022-03-22T23:38:08Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220322/a3e57375aa83468e8d250aa54cce57aa.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233809Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=45e8862f541b1f7ee820f466fb89c599a525ccc6d21e1ffc974cc6383cfbd977","url_expires_at":"2022-03-22T23:38:39Z","include_children":false},{"id":"shprep_3288b84aff0d4dd5b96a7597c44553ad","object":"ShipmentReport","created_at":"2022-03-22T23:38:07Z","updated_at":"2022-03-22T23:38:08Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220322/45244ef89a3a41709adf0185e04159c4.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233809Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=2d59ee9b0a19c43dbd4bcf3ebbeeaccbe4ba394736fedcb48062bea8e9fab8b6","url_expires_at":"2022-03-22T23:38:39Z","include_children":false},{"id":"shprep_2a1170b363764ad88a4ded49c773714c","object":"ShipmentReport","created_at":"2022-03-22T23:30:39Z","updated_at":"2022-03-22T23:30:39Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220322/3c714400a9f64b348f22470246ad6639.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233809Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=3aee6f0a764206abf62ac1e596a6f485d3e807934e8ac17014ed2fe7ffe7dda5","url_expires_at":"2022-03-22T23:38:39Z","include_children":false},{"id":"shprep_c31c5acb77554034aa77c041c804f4c3","object":"ShipmentReport","created_at":"2022-03-22T23:30:38Z","updated_at":"2022-03-22T23:30:39Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220322/15eb94547c594557b64da7b17ae9fb38.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233809Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=012887c16fdcc39885a58573e33ec58eb2e7a48f5348bab4be5b03dc08553c9d","url_expires_at":"2022-03-22T23:38:39Z","include_children":false}],"has_more":true}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/shipment/?type=shipment&page_size=5'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 771
-            request_size: 568
+            header_size: 719
+            request_size: 547
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.25555
-            namelookup_time: 0.001306
-            connect_time: 0.057823
-            pretransfer_time: 0.136087
+            total_time: 0.204239
+            namelookup_time: 0.001767
+            connect_time: 0.050787
+            pretransfer_time: 0.117433
             size_upload: 0.0
             size_download: 3469.0
-            speed_download: 13574.0
+            speed_download: 16985.0
             speed_upload: 0.0
             download_content_length: 3469.0
             upload_content_length: 0.0
-            starttransfer_time: 0.255486
+            starttransfer_time: 0.204209
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 51836
+            local_ip: 10.130.6.32
+            local_port: 49923
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 135956
-            connect_time_us: 57823
-            namelookup_time_us: 1306
-            pretransfer_time_us: 136087
+            appconnect_time_us: 117301
+            connect_time_us: 50787
+            namelookup_time_us: 1767
+            pretransfer_time_us: 117433
             redirect_time_us: 0
-            starttransfer_time_us: 255486
-            total_time_us: 255550
+            starttransfer_time_us: 204209
+            total_time_us: 204239

--- a/test/cassettes/reports/createCustomAdditionalColumnReport.yml
+++ b/test/cassettes/reports/createCustomAdditionalColumnReport.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: POST
-        url: 'https://api.easypost.com/v2/reports/shipment/'
+        url: 'https://api.easypost.com/v2/reports/shipment?additional_columns%5B0%5D=from_name&additional_columns%5B1%5D=from_company'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -24,55 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 4e82e4b6623a42bbe79a878a00103454
+            x-ep-request-uuid: 4e82e4b7623a5de0e7799fec00185281
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '283'
-            etag: 'W/"1cac57e2561db36fbe22b33a4f09901d"'
-            x-runtime: '0.069723'
-            x-node: bigweb5nuq
-            x-version-label: easypost-202203222036-024a84b010-master
+            etag: 'W/"d31cf126284ed994218edc67648e0f25"'
+            x-runtime: '0.036427'
+            x-node: bigweb8nuq
+            x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
+            x-proxied: ['intlb2nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_712ddb89a5eb424f95828669278adc5e","object":"ShipmentReport","created_at":"2022-03-22T21:42:19Z","updated_at":"2022-03-22T21:42:19Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shprep_d21f5c32334a4a8e87b67b1109316f55","object":"ShipmentReport","created_at":"2022-03-22T23:38:08Z","updated_at":"2022-03-22T23:38:08Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shipment/'
+            url: 'https://api.easypost.com/v2/reports/shipment?additional_columns%5B0%5D=from_name&additional_columns%5B1%5D=from_company'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
             header_size: 718
-            request_size: 542
+            request_size: 607
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.48474
-            namelookup_time: 0.240789
-            connect_time: 0.28989
-            pretransfer_time: 0.364771
+            total_time: 0.206322
+            namelookup_time: 0.001326
+            connect_time: 0.051445
+            pretransfer_time: 0.118137
             size_upload: 69.0
             size_download: 283.0
-            speed_download: 583.0
-            speed_upload: 142.0
+            speed_download: 1371.0
+            speed_upload: 334.0
             download_content_length: 283.0
             upload_content_length: 69.0
-            starttransfer_time: 0.364779
+            starttransfer_time: 0.118145
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
             local_ip: 10.130.6.32
-            local_port: 63983
+            local_port: 49918
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 364588
-            connect_time_us: 289890
-            namelookup_time_us: 240789
-            pretransfer_time_us: 364771
+            appconnect_time_us: 118004
+            connect_time_us: 51445
+            namelookup_time_us: 1326
+            pretransfer_time_us: 118137
             redirect_time_us: 0
-            starttransfer_time_us: 364779
-            total_time_us: 484740
+            starttransfer_time_us: 118145
+            total_time_us: 206322

--- a/test/cassettes/reports/createCustomAdditionalColumnReport.yml
+++ b/test/cassettes/reports/createCustomAdditionalColumnReport.yml
@@ -1,0 +1,78 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/reports/shipment/'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+            X-Client-User-Agent: ''
+            EasyPost-Version: '2'
+        body: '{"start_date":"2022-02-01","end_date":"2022-02-03","type":"shipment"}'
+    response:
+        status:
+            http_version: '2'
+            code: '201'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 4e82e4b6623a42bbe79a878a00103454
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '283'
+            etag: 'W/"1cac57e2561db36fbe22b33a4f09901d"'
+            x-runtime: '0.069723'
+            x-node: bigweb5nuq
+            x-version-label: easypost-202203222036-024a84b010-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"shprep_712ddb89a5eb424f95828669278adc5e","object":"ShipmentReport","created_at":"2022-03-22T21:42:19Z","updated_at":"2022-03-22T21:42:19Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/reports/shipment/'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 718
+            request_size: 542
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.48474
+            namelookup_time: 0.240789
+            connect_time: 0.28989
+            pretransfer_time: 0.364771
+            size_upload: 69.0
+            size_download: 283.0
+            speed_download: 583.0
+            speed_upload: 142.0
+            download_content_length: 283.0
+            upload_content_length: 69.0
+            starttransfer_time: 0.364779
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.130
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.32
+            local_port: 63983
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 364588
+            connect_time_us: 289890
+            namelookup_time_us: 240789
+            pretransfer_time_us: 364771
+            redirect_time_us: 0
+            starttransfer_time_us: 364779
+            total_time_us: 484740

--- a/test/cassettes/reports/createCustomAdditionalColumnReport.yml
+++ b/test/cassettes/reports/createCustomAdditionalColumnReport.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: POST
-        url: 'https://api.easypost.com/v2/reports/shipment?additional_columns%5B0%5D=from_name&additional_columns%5B1%5D=from_company'
+        url: 'https://api.easypost.com/v2/reports/shipment/?additional_columns%5B0%5D=from_name&additional_columns%5B1%5D=from_company'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -24,55 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 4e82e4b7623a5de0e7799fec00185281
+            x-ep-request-uuid: d6338b82623b6021f9c40ecb001851bc
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '283'
-            etag: 'W/"d31cf126284ed994218edc67648e0f25"'
-            x-runtime: '0.036427'
-            x-node: bigweb8nuq
+            etag: 'W/"6c94cad3df993e3f873dac307818cdc7"'
+            x-runtime: '0.041225'
+            x-node: bigweb2nuq
             x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
+            x-proxied: ['intlb1nuq 3e97db20d4', 'intlb1wdc 3e97db20d4', 'extlb1wdc 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_d21f5c32334a4a8e87b67b1109316f55","object":"ShipmentReport","created_at":"2022-03-22T23:38:08Z","updated_at":"2022-03-22T23:38:08Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shprep_ca4c6b862125463199704b07a10afde4","object":"ShipmentReport","created_at":"2022-03-23T18:00:01Z","updated_at":"2022-03-23T18:00:01Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shipment?additional_columns%5B0%5D=from_name&additional_columns%5B1%5D=from_company'
+            url: 'https://api.easypost.com/v2/reports/shipment/?additional_columns%5B0%5D=from_name&additional_columns%5B1%5D=from_company'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 718
-            request_size: 607
+            header_size: 751
+            request_size: 608
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.206322
-            namelookup_time: 0.001326
-            connect_time: 0.051445
-            pretransfer_time: 0.118137
+            total_time: 0.339235
+            namelookup_time: 0.001504
+            connect_time: 0.053013
+            pretransfer_time: 0.120282
             size_upload: 69.0
             size_download: 283.0
-            speed_download: 1371.0
-            speed_upload: 334.0
+            speed_download: 834.0
+            speed_upload: 203.0
             download_content_length: 283.0
             upload_content_length: 69.0
-            starttransfer_time: 0.118145
+            starttransfer_time: 0.120289
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.47.33.19
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.32
-            local_port: 49918
+            local_ip: 172.168.1.123
+            local_port: 53899
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 118004
-            connect_time_us: 51445
-            namelookup_time_us: 1326
-            pretransfer_time_us: 118137
+            appconnect_time_us: 120126
+            connect_time_us: 53013
+            namelookup_time_us: 1504
+            pretransfer_time_us: 120282
             redirect_time_us: 0
-            starttransfer_time_us: 118145
-            total_time_us: 206322
+            starttransfer_time_us: 120289
+            total_time_us: 339235

--- a/test/cassettes/reports/createCustomColumnReport.yml
+++ b/test/cassettes/reports/createCustomColumnReport.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: POST
-        url: 'https://api.easypost.com/v2/reports/shipment?columns%5B0%5D=usps_zone'
+        url: 'https://api.easypost.com/v2/reports/shipment/?columns%5B0%5D=usps_zone'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -24,55 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 4e82e4bb623a5ddfe7799fe90018525c
+            x-ep-request-uuid: 15978951623b6022f1ffd122001b1b1b
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '283'
-            etag: 'W/"7da893fafc24fccd0653f4af4ffd93dc"'
-            x-runtime: '0.054074'
+            etag: 'W/"9549ca31721e9298eed0428971798b4d"'
+            x-runtime: '0.096500'
             x-node: bigweb3nuq
             x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
+            x-proxied: ['intlb1nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_3288b84aff0d4dd5b96a7597c44553ad","object":"ShipmentReport","created_at":"2022-03-22T23:38:07Z","updated_at":"2022-03-22T23:38:07Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shprep_08ac4b4736de41b9ade117e92a4ff15e","object":"ShipmentReport","created_at":"2022-03-23T18:00:03Z","updated_at":"2022-03-23T18:00:03Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shipment?columns%5B0%5D=usps_zone'
+            url: 'https://api.easypost.com/v2/reports/shipment/?columns%5B0%5D=usps_zone'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
             header_size: 718
-            request_size: 562
+            request_size: 563
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.431781
-            namelookup_time: 0.195002
-            connect_time: 0.243959
-            pretransfer_time: 0.310746
+            total_time: 0.21054
+            namelookup_time: 0.001465
+            connect_time: 0.032504
+            pretransfer_time: 0.080365
             size_upload: 69.0
             size_download: 283.0
-            speed_download: 655.0
-            speed_upload: 159.0
+            speed_download: 1344.0
+            speed_upload: 327.0
             download_content_length: 283.0
             upload_content_length: 69.0
-            starttransfer_time: 0.310755
+            starttransfer_time: 0.080372
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.32
-            local_port: 49915
+            local_ip: 172.168.1.123
+            local_port: 53904
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 310580
-            connect_time_us: 243959
-            namelookup_time_us: 195002
-            pretransfer_time_us: 310746
+            appconnect_time_us: 80221
+            connect_time_us: 32504
+            namelookup_time_us: 1465
+            pretransfer_time_us: 80365
             redirect_time_us: 0
-            starttransfer_time_us: 310755
-            total_time_us: 431781
+            starttransfer_time_us: 80372
+            total_time_us: 210540

--- a/test/cassettes/reports/createCustomColumnReport.yml
+++ b/test/cassettes/reports/createCustomColumnReport.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: POST
-        url: 'https://api.easypost.com/v2/reports/shipment/'
+        url: 'https://api.easypost.com/v2/reports/shipment?columns%5B0%5D=usps_zone'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -24,55 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 4e82e4ba623a42bce79a878b00103462
+            x-ep-request-uuid: 4e82e4bb623a5ddfe7799fe90018525c
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '283'
-            etag: 'W/"4734a407b31bffe8f0e864a9e46574fe"'
-            x-runtime: '0.040065'
-            x-node: bigweb2nuq
-            x-version-label: easypost-202203222036-024a84b010-master
+            etag: 'W/"7da893fafc24fccd0653f4af4ffd93dc"'
+            x-runtime: '0.054074'
+            x-node: bigweb3nuq
+            x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
             x-proxied: ['intlb2nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_01356951204c48d0ab67613374cb271f","object":"ShipmentReport","created_at":"2022-03-22T21:42:20Z","updated_at":"2022-03-22T21:42:20Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shprep_3288b84aff0d4dd5b96a7597c44553ad","object":"ShipmentReport","created_at":"2022-03-22T23:38:07Z","updated_at":"2022-03-22T23:38:07Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shipment/'
+            url: 'https://api.easypost.com/v2/reports/shipment?columns%5B0%5D=usps_zone'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
             header_size: 718
-            request_size: 542
+            request_size: 562
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.218954
-            namelookup_time: 0.001425
-            connect_time: 0.063757
-            pretransfer_time: 0.12951
+            total_time: 0.431781
+            namelookup_time: 0.195002
+            connect_time: 0.243959
+            pretransfer_time: 0.310746
             size_upload: 69.0
             size_download: 283.0
-            speed_download: 1292.0
-            speed_upload: 315.0
+            speed_download: 655.0
+            speed_upload: 159.0
             download_content_length: 283.0
             upload_content_length: 69.0
-            starttransfer_time: 0.129518
+            starttransfer_time: 0.310755
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
             local_ip: 10.130.6.32
-            local_port: 63984
+            local_port: 49915
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 129364
-            connect_time_us: 63757
-            namelookup_time_us: 1425
-            pretransfer_time_us: 129510
+            appconnect_time_us: 310580
+            connect_time_us: 243959
+            namelookup_time_us: 195002
+            pretransfer_time_us: 310746
             redirect_time_us: 0
-            starttransfer_time_us: 129518
-            total_time_us: 218954
+            starttransfer_time_us: 310755
+            total_time_us: 431781

--- a/test/cassettes/reports/createCustomColumnReport.yml
+++ b/test/cassettes/reports/createCustomColumnReport.yml
@@ -1,0 +1,78 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/reports/shipment/'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+            X-Client-User-Agent: ''
+            EasyPost-Version: '2'
+        body: '{"start_date":"2022-02-01","end_date":"2022-02-03","type":"shipment"}'
+    response:
+        status:
+            http_version: '2'
+            code: '201'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 4e82e4ba623a42bce79a878b00103462
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '283'
+            etag: 'W/"4734a407b31bffe8f0e864a9e46574fe"'
+            x-runtime: '0.040065'
+            x-node: bigweb2nuq
+            x-version-label: easypost-202203222036-024a84b010-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"shprep_01356951204c48d0ab67613374cb271f","object":"ShipmentReport","created_at":"2022-03-22T21:42:20Z","updated_at":"2022-03-22T21:42:20Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/reports/shipment/'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 718
+            request_size: 542
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.218954
+            namelookup_time: 0.001425
+            connect_time: 0.063757
+            pretransfer_time: 0.12951
+            size_upload: 69.0
+            size_download: 283.0
+            speed_download: 1292.0
+            speed_upload: 315.0
+            download_content_length: 283.0
+            upload_content_length: 69.0
+            starttransfer_time: 0.129518
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.130
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.32
+            local_port: 63984
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 129364
+            connect_time_us: 63757
+            namelookup_time_us: 1425
+            pretransfer_time_us: 129510
+            redirect_time_us: 0
+            starttransfer_time_us: 129518
+            total_time_us: 218954

--- a/test/cassettes/reports/createPaymentLogReport.yml
+++ b/test/cassettes/reports/createPaymentLogReport.yml
@@ -24,55 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 4e82e4ba623a5de1e779a007001852a4
+            x-ep-request-uuid: 9845affe623b6022f1d9ea3f001a1d4c
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '259'
-            etag: 'W/"db19f9c0f8f0ed4e3f574985727b76d8"'
-            x-runtime: '0.034901'
-            x-node: bigweb2nuq
+            etag: 'W/"0a3f098fecab2d490045728c2d3a5bcd"'
+            x-runtime: '0.031926'
+            x-node: bigweb8nuq
             x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
+            x-proxied: ['intlb1nuq 3e97db20d4', 'intlb1wdc 3e97db20d4', 'extlb3wdc 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"plrep_7358a6296ea947df9416e1939920117d","object":"PaymentLogReport","created_at":"2022-03-22T23:38:09Z","updated_at":"2022-03-22T23:38:09Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null}'
+        body: '{"id":"plrep_16826a8073bb4ec685e6ff11f52e1292","object":"PaymentLogReport","created_at":"2022-03-23T18:00:02Z","updated_at":"2022-03-23T18:00:02Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/payment_log/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 718
+            header_size: 751
             request_size: 545
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.295883
-            namelookup_time: 0.001355
-            connect_time: 0.051837
-            pretransfer_time: 0.120384
+            total_time: 0.320238
+            namelookup_time: 0.001443
+            connect_time: 0.048879
+            pretransfer_time: 0.111876
             size_upload: 72.0
             size_download: 259.0
-            speed_download: 875.0
-            speed_upload: 243.0
+            speed_download: 808.0
+            speed_upload: 224.0
             download_content_length: 259.0
             upload_content_length: 72.0
-            starttransfer_time: 0.120393
+            starttransfer_time: 0.111885
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.47.33.18
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.32
-            local_port: 49922
+            local_ip: 172.168.1.123
+            local_port: 53903
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 120261
-            connect_time_us: 51837
-            namelookup_time_us: 1355
-            pretransfer_time_us: 120384
+            appconnect_time_us: 111719
+            connect_time_us: 48879
+            namelookup_time_us: 1443
+            pretransfer_time_us: 111876
             redirect_time_us: 0
-            starttransfer_time_us: 120393
-            total_time_us: 295883
+            starttransfer_time_us: 111885
+            total_time_us: 320238

--- a/test/cassettes/reports/createPaymentLogReport.yml
+++ b/test/cassettes/reports/createPaymentLogReport.yml
@@ -24,56 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 888f660c62015c73e7875165004b8c2f
+            x-ep-request-uuid: 4e82e4ba623a5de1e779a007001852a4
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '259'
-            etag: 'W/"399435012fb513b6afae7003075d57b2"'
-            x-request-id: 15eabf4b-e8b5-4b15-90b3-34d11f512e47
-            x-runtime: '0.045587'
-            x-node: bigweb1nuq
-            x-version-label: easypost-202202042220-76f9648007-master
+            etag: 'W/"db19f9c0f8f0ed4e3f574985727b76d8"'
+            x-runtime: '0.034901'
+            x-node: bigweb2nuq
+            x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 88c34981dc', 'extlb1nuq 88c34981dc']
+            x-proxied: ['intlb1nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"plrep_e26dd72d216c4b23a482df6f2187ab61","object":"PaymentLogReport","created_at":"2022-02-07T17:52:51Z","updated_at":"2022-02-07T17:52:51Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null}'
+        body: '{"id":"plrep_7358a6296ea947df9416e1939920117d","object":"PaymentLogReport","created_at":"2022-03-22T23:38:09Z","updated_at":"2022-03-22T23:38:09Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/payment_log/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 770
-            request_size: 566
+            header_size: 718
+            request_size: 545
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.245298
-            namelookup_time: 0.001385
-            connect_time: 0.059758
-            pretransfer_time: 0.139928
+            total_time: 0.295883
+            namelookup_time: 0.001355
+            connect_time: 0.051837
+            pretransfer_time: 0.120384
             size_upload: 72.0
             size_download: 259.0
-            speed_download: 1055.0
-            speed_upload: 293.0
+            speed_download: 875.0
+            speed_upload: 243.0
             download_content_length: 259.0
             upload_content_length: 72.0
-            starttransfer_time: 0.139947
+            starttransfer_time: 0.120393
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 51837
+            local_ip: 10.130.6.32
+            local_port: 49922
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 139791
-            connect_time_us: 59758
-            namelookup_time_us: 1385
-            pretransfer_time_us: 139928
+            appconnect_time_us: 120261
+            connect_time_us: 51837
+            namelookup_time_us: 1355
+            pretransfer_time_us: 120384
             redirect_time_us: 0
-            starttransfer_time_us: 139947
-            total_time_us: 245298
+            starttransfer_time_us: 120393
+            total_time_us: 295883

--- a/test/cassettes/reports/createRefundReport.yml
+++ b/test/cassettes/reports/createRefundReport.yml
@@ -24,55 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 4e82e4b4623a5de0e7799fed0018528c
+            x-ep-request-uuid: d6338b7f623b6021f1fd8279001851d1
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '256'
-            etag: 'W/"5ba52fed5fadb62165b0770fb2cf78e0"'
-            x-runtime: '0.050689'
-            x-node: bigweb9nuq
+            etag: 'W/"3c50178826939ece9d63adc614f43772"'
+            x-runtime: '0.044231'
+            x-node: bigweb8nuq
             x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
+            x-proxied: ['intlb2nuq 3e97db20d4', 'intlb2wdc 3e97db20d4', 'extlb1wdc 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"refrep_e236be05e8dd404cad45df7b4b5a9f2e","object":"RefundReport","created_at":"2022-03-22T23:38:08Z","updated_at":"2022-03-22T23:38:08Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null}'
+        body: '{"id":"refrep_26bdfe6a039a48d89e4610f3d0ee4367","object":"RefundReport","created_at":"2022-03-23T18:00:01Z","updated_at":"2022-03-23T18:00:01Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/refund/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 718
+            header_size: 751
             request_size: 540
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.238346
-            namelookup_time: 0.001353
-            connect_time: 0.053769
-            pretransfer_time: 0.121578
+            total_time: 0.32033
+            namelookup_time: 0.001795
+            connect_time: 0.045694
+            pretransfer_time: 0.106034
             size_upload: 67.0
             size_download: 256.0
-            speed_download: 1074.0
-            speed_upload: 281.0
+            speed_download: 799.0
+            speed_upload: 209.0
             download_content_length: 256.0
             upload_content_length: 67.0
-            starttransfer_time: 0.121586
+            starttransfer_time: 0.106043
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.47.33.19
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.32
-            local_port: 49919
+            local_ip: 172.168.1.123
+            local_port: 53900
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 121460
-            connect_time_us: 53769
-            namelookup_time_us: 1353
-            pretransfer_time_us: 121578
+            appconnect_time_us: 105779
+            connect_time_us: 45694
+            namelookup_time_us: 1795
+            pretransfer_time_us: 106034
             redirect_time_us: 0
-            starttransfer_time_us: 121586
-            total_time_us: 238346
+            starttransfer_time_us: 106043
+            total_time_us: 320330

--- a/test/cassettes/reports/createRefundReport.yml
+++ b/test/cassettes/reports/createRefundReport.yml
@@ -24,56 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 888f660d62015c72e7875162004b8bf9
+            x-ep-request-uuid: 4e82e4b4623a5de0e7799fed0018528c
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '256'
-            etag: 'W/"ac748132d3106014435b986ce11e9226"'
-            x-request-id: aacaae42-713e-4ffa-a258-fd230e25bc22
-            x-runtime: '0.041292'
+            etag: 'W/"5ba52fed5fadb62165b0770fb2cf78e0"'
+            x-runtime: '0.050689'
             x-node: bigweb9nuq
-            x-version-label: easypost-202202042220-76f9648007-master
+            x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 88c34981dc', 'extlb1nuq 88c34981dc']
+            x-proxied: ['intlb1nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"refrep_d3f9231714144fd0bd8042ff3cd713e0","object":"RefundReport","created_at":"2022-02-07T17:52:50Z","updated_at":"2022-02-07T17:52:50Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null}'
+        body: '{"id":"refrep_e236be05e8dd404cad45df7b4b5a9f2e","object":"RefundReport","created_at":"2022-03-22T23:38:08Z","updated_at":"2022-03-22T23:38:08Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/refund/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 770
-            request_size: 561
+            header_size: 718
+            request_size: 540
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.235588
-            namelookup_time: 0.001355
-            connect_time: 0.057639
-            pretransfer_time: 0.136378
+            total_time: 0.238346
+            namelookup_time: 0.001353
+            connect_time: 0.053769
+            pretransfer_time: 0.121578
             size_upload: 67.0
             size_download: 256.0
-            speed_download: 1086.0
-            speed_upload: 284.0
+            speed_download: 1074.0
+            speed_upload: 281.0
             download_content_length: 256.0
             upload_content_length: 67.0
-            starttransfer_time: 0.136395
+            starttransfer_time: 0.121586
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 51834
+            local_ip: 10.130.6.32
+            local_port: 49919
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 136224
-            connect_time_us: 57639
-            namelookup_time_us: 1355
-            pretransfer_time_us: 136378
+            appconnect_time_us: 121460
+            connect_time_us: 53769
+            namelookup_time_us: 1353
+            pretransfer_time_us: 121578
             redirect_time_us: 0
-            starttransfer_time_us: 136395
-            total_time_us: 235588
+            starttransfer_time_us: 121586
+            total_time_us: 238346

--- a/test/cassettes/reports/createShipmentInvoiceReport.yml
+++ b/test/cassettes/reports/createShipmentInvoiceReport.yml
@@ -24,56 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 888f661062015c72e7875161004b8bec
+            x-ep-request-uuid: 4e82e4bb623a5de1e779a00600185297
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '293'
-            etag: 'W/"152f091b3e6e7a0d812b49cd4b10ab84"'
-            x-request-id: 8f2d9adf-7488-4f52-99b6-d40cf3810d75
-            x-runtime: '0.046731'
-            x-node: bigweb2nuq
-            x-version-label: easypost-202202042220-76f9648007-master
+            etag: 'W/"29e95d438b57f75d08ab40987d9972a2"'
+            x-runtime: '0.033832'
+            x-node: bigweb5nuq
+            x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 88c34981dc', 'extlb1nuq 88c34981dc']
+            x-proxied: ['intlb2nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shpinvrep_38e751354a87433297242edcb9c62bc8","object":"ShipmentInvoiceReport","created_at":"2022-02-07T17:52:50Z","updated_at":"2022-02-07T17:52:50Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shpinvrep_7ba057cdf9d9481f8f26eb1598b1900c","object":"ShipmentInvoiceReport","created_at":"2022-03-22T23:38:09Z","updated_at":"2022-03-22T23:38:09Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/shipment_invoice/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 770
-            request_size: 571
+            header_size: 718
+            request_size: 550
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.241117
-            namelookup_time: 0.001377
-            connect_time: 0.059543
-            pretransfer_time: 0.134703
+            total_time: 0.244038
+            namelookup_time: 0.001533
+            connect_time: 0.052677
+            pretransfer_time: 0.146295
             size_upload: 77.0
             size_download: 293.0
-            speed_download: 1215.0
-            speed_upload: 319.0
+            speed_download: 1200.0
+            speed_upload: 315.0
             download_content_length: 293.0
             upload_content_length: 77.0
-            starttransfer_time: 0.134721
+            starttransfer_time: 0.146302
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 51833
+            local_ip: 10.130.6.32
+            local_port: 49921
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 134538
-            connect_time_us: 59543
-            namelookup_time_us: 1377
-            pretransfer_time_us: 134703
+            appconnect_time_us: 146193
+            connect_time_us: 52677
+            namelookup_time_us: 1533
+            pretransfer_time_us: 146295
             redirect_time_us: 0
-            starttransfer_time_us: 134721
-            total_time_us: 241117
+            starttransfer_time_us: 146302
+            total_time_us: 244038

--- a/test/cassettes/reports/createShipmentInvoiceReport.yml
+++ b/test/cassettes/reports/createShipmentInvoiceReport.yml
@@ -24,55 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 4e82e4bb623a5de1e779a00600185297
+            x-ep-request-uuid: 9845b002623b6021f1ea5034001a1d09
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '293'
-            etag: 'W/"29e95d438b57f75d08ab40987d9972a2"'
-            x-runtime: '0.033832'
-            x-node: bigweb5nuq
+            etag: 'W/"bce7ceba1c3478e890f03bf56b776bd6"'
+            x-runtime: '0.037662'
+            x-node: bigweb4nuq
             x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
+            x-proxied: ['intlb2nuq 3e97db20d4', 'intlb1wdc 3e97db20d4', 'extlb3wdc 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shpinvrep_7ba057cdf9d9481f8f26eb1598b1900c","object":"ShipmentInvoiceReport","created_at":"2022-03-22T23:38:09Z","updated_at":"2022-03-22T23:38:09Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shpinvrep_c84da1eb52b741bcac3754d240921340","object":"ShipmentInvoiceReport","created_at":"2022-03-23T18:00:02Z","updated_at":"2022-03-23T18:00:02Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/shipment_invoice/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 718
+            header_size: 751
             request_size: 550
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.244038
-            namelookup_time: 0.001533
-            connect_time: 0.052677
-            pretransfer_time: 0.146295
+            total_time: 0.379785
+            namelookup_time: 0.001629
+            connect_time: 0.096979
+            pretransfer_time: 0.171348
             size_upload: 77.0
             size_download: 293.0
-            speed_download: 1200.0
-            speed_upload: 315.0
+            speed_download: 771.0
+            speed_upload: 202.0
             download_content_length: 293.0
             upload_content_length: 77.0
-            starttransfer_time: 0.146302
+            starttransfer_time: 0.171359
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.47.33.18
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.32
-            local_port: 49921
+            local_ip: 172.168.1.123
+            local_port: 53901
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 146193
-            connect_time_us: 52677
-            namelookup_time_us: 1533
-            pretransfer_time_us: 146295
+            appconnect_time_us: 171178
+            connect_time_us: 96979
+            namelookup_time_us: 1629
+            pretransfer_time_us: 171348
             redirect_time_us: 0
-            starttransfer_time_us: 146302
-            total_time_us: 244038
+            starttransfer_time_us: 171359
+            total_time_us: 379785

--- a/test/cassettes/reports/createShipmentReport.yml
+++ b/test/cassettes/reports/createShipmentReport.yml
@@ -24,56 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 888f660c62015c71e7875160004b8bd2
+            x-ep-request-uuid: 4e82e4bb623a5de0e7799fea00185268
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '283'
-            etag: 'W/"0aefe2ec1681ee068e00882f7acf9732"'
-            x-request-id: 3407d59f-b147-4e9d-a1b0-dbbcd698544a
-            x-runtime: '0.069982'
-            x-node: bigweb2nuq
-            x-version-label: easypost-202202042220-76f9648007-master
+            etag: 'W/"13540bc0a878e924f4d5480d82fa37fb"'
+            x-runtime: '0.036734'
+            x-node: bigweb9nuq
+            x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 88c34981dc', 'extlb1nuq 88c34981dc']
+            x-proxied: ['intlb1nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_3340200ca0ad402e9fea7fe2aede2306","object":"ShipmentReport","created_at":"2022-02-07T17:52:49Z","updated_at":"2022-02-07T17:52:49Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shprep_34fe58eade354016abcd7db805a98a36","object":"ShipmentReport","created_at":"2022-03-22T23:38:08Z","updated_at":"2022-03-22T23:38:08Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/shipment/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 770
-            request_size: 563
+            header_size: 718
+            request_size: 542
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.271361
-            namelookup_time: 0.00114
-            connect_time: 0.057854
-            pretransfer_time: 0.142976
+            total_time: 0.204628
+            namelookup_time: 0.001397
+            connect_time: 0.050545
+            pretransfer_time: 0.117005
             size_upload: 69.0
             size_download: 283.0
-            speed_download: 1042.0
-            speed_upload: 254.0
+            speed_download: 1382.0
+            speed_upload: 337.0
             download_content_length: 283.0
             upload_content_length: 69.0
-            starttransfer_time: 0.142991
+            starttransfer_time: 0.117015
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 51832
+            local_ip: 10.130.6.32
+            local_port: 49916
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 142760
-            connect_time_us: 57854
-            namelookup_time_us: 1140
-            pretransfer_time_us: 142976
+            appconnect_time_us: 116878
+            connect_time_us: 50545
+            namelookup_time_us: 1397
+            pretransfer_time_us: 117005
             redirect_time_us: 0
-            starttransfer_time_us: 142991
-            total_time_us: 271361
+            starttransfer_time_us: 117015
+            total_time_us: 204628

--- a/test/cassettes/reports/createShipmentReport.yml
+++ b/test/cassettes/reports/createShipmentReport.yml
@@ -24,55 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 4e82e4bb623a5de0e7799fea00185268
+            x-ep-request-uuid: d6338b80623b6020f9c4a3cd00185195
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '283'
-            etag: 'W/"13540bc0a878e924f4d5480d82fa37fb"'
-            x-runtime: '0.036734'
-            x-node: bigweb9nuq
+            etag: 'W/"d6df3c8ff273b14621e797594ca02c66"'
+            x-runtime: '0.101523'
+            x-node: bigweb3nuq
             x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
+            x-proxied: ['intlb2nuq 3e97db20d4', 'intlb2wdc 3e97db20d4', 'extlb1wdc 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_34fe58eade354016abcd7db805a98a36","object":"ShipmentReport","created_at":"2022-03-22T23:38:08Z","updated_at":"2022-03-22T23:38:08Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shprep_cca848e778d94039ae4dbe0b6cf1fdd3","object":"ShipmentReport","created_at":"2022-03-23T18:00:01Z","updated_at":"2022-03-23T18:00:01Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/shipment/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 718
+            header_size: 751
             request_size: 542
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.204628
-            namelookup_time: 0.001397
-            connect_time: 0.050545
-            pretransfer_time: 0.117005
+            total_time: 0.561721
+            namelookup_time: 0.143456
+            connect_time: 0.199518
+            pretransfer_time: 0.287062
             size_upload: 69.0
             size_download: 283.0
-            speed_download: 1382.0
-            speed_upload: 337.0
+            speed_download: 503.0
+            speed_upload: 122.0
             download_content_length: 283.0
             upload_content_length: 69.0
-            starttransfer_time: 0.117015
+            starttransfer_time: 0.287075
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.47.33.19
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.32
-            local_port: 49916
+            local_ip: 172.168.1.123
+            local_port: 53898
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 116878
-            connect_time_us: 50545
-            namelookup_time_us: 1397
-            pretransfer_time_us: 117005
+            appconnect_time_us: 286779
+            connect_time_us: 199518
+            namelookup_time_us: 143456
+            pretransfer_time_us: 287062
             redirect_time_us: 0
-            starttransfer_time_us: 117015
-            total_time_us: 204628
+            starttransfer_time_us: 287075
+            total_time_us: 561721

--- a/test/cassettes/reports/createTrackerReport.yml
+++ b/test/cassettes/reports/createTrackerReport.yml
@@ -24,55 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 4e82e4bb623a5de0e7799feb00185271
+            x-ep-request-uuid: 9845affd623b6022f1ec02fd001a1d2a
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '685'
-            etag: 'W/"ef0dae0efbd07f35dcc36a8c999d9043"'
-            x-runtime: '0.088237'
-            x-node: bigweb8nuq
+            etag: 'W/"902b76726c90eb0d7e441a1908837e82"'
+            x-runtime: '0.047042'
+            x-node: bigweb3nuq
             x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
+            x-proxied: ['intlb1nuq 3e97db20d4', 'intlb2wdc 3e97db20d4', 'extlb3wdc 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"trkrep_f8c2664fc490481980ab8ff1f6ac297d","object":"TrackerReport","created_at":"2022-02-03T16:56:09Z","updated_at":"2022-03-22T23:30:40Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20220322/3370161985ee4dee8f529649fe3a2839.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233808Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=1165f252c407e8edff57c837c22f0e9430b3df3593faa52efeddc08c6f3e12c7","url_expires_at":"2022-03-22T23:38:38Z","include_children":false}'
+        body: '{"id":"trkrep_f8c2664fc490481980ab8ff1f6ac297d","object":"TrackerReport","created_at":"2022-02-03T16:56:09Z","updated_at":"2022-03-22T23:38:09Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20220322/14f3ed87e50d4719a814552c6c98075c.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220323%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220323T180002Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=cd33330bdcc7b271226e4456b56f120be3e4ccf60f8d81700c420834d073f5c6","url_expires_at":"2022-03-23T18:00:32Z","include_children":false}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/tracker/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 718
+            header_size: 751
             request_size: 541
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.279021
-            namelookup_time: 0.00139
-            connect_time: 0.052094
-            pretransfer_time: 0.131793
+            total_time: 0.314719
+            namelookup_time: 0.001515
+            connect_time: 0.041976
+            pretransfer_time: 0.099609
             size_upload: 68.0
             size_download: 685.0
-            speed_download: 2455.0
-            speed_upload: 243.0
+            speed_download: 2176.0
+            speed_upload: 216.0
             download_content_length: 685.0
             upload_content_length: 68.0
-            starttransfer_time: 0.131801
+            starttransfer_time: 0.099616
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.47.33.18
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.32
-            local_port: 49917
+            local_ip: 172.168.1.123
+            local_port: 53902
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 131653
-            connect_time_us: 52094
-            namelookup_time_us: 1390
-            pretransfer_time_us: 131793
+            appconnect_time_us: 99444
+            connect_time_us: 41976
+            namelookup_time_us: 1515
+            pretransfer_time_us: 99609
             redirect_time_us: 0
-            starttransfer_time_us: 131801
-            total_time_us: 279021
+            starttransfer_time_us: 99616
+            total_time_us: 314719

--- a/test/cassettes/reports/createTrackerReport.yml
+++ b/test/cassettes/reports/createTrackerReport.yml
@@ -24,56 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 888f660c62015c72e7875163004b8c06
+            x-ep-request-uuid: 4e82e4bb623a5de0e7799feb00185271
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '685'
-            etag: 'W/"4f462b007092480ebd714bf719d41c46"'
-            x-request-id: 87390903-65c6-46e0-8a4a-4a311d614762
-            x-runtime: '0.049933'
-            x-node: bigweb1nuq
-            x-version-label: easypost-202202042220-76f9648007-master
+            etag: 'W/"ef0dae0efbd07f35dcc36a8c999d9043"'
+            x-runtime: '0.088237'
+            x-node: bigweb8nuq
+            x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 88c34981dc', 'extlb1nuq 88c34981dc']
+            x-proxied: ['intlb2nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"trkrep_f8c2664fc490481980ab8ff1f6ac297d","object":"TrackerReport","created_at":"2022-02-03T16:56:09Z","updated_at":"2022-02-07T17:51:50Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20220207/abb81d0b50434f3cb18d180fbb80626e.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220207%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220207T175250Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=e48046b84f68a37efc54c938066844d0aef585d4febd29504ee51f2cca7be6e6","url_expires_at":"2022-02-07T17:53:20Z","include_children":false}'
+        body: '{"id":"trkrep_f8c2664fc490481980ab8ff1f6ac297d","object":"TrackerReport","created_at":"2022-02-03T16:56:09Z","updated_at":"2022-03-22T23:30:40Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20220322/3370161985ee4dee8f529649fe3a2839.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233808Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=1165f252c407e8edff57c837c22f0e9430b3df3593faa52efeddc08c6f3e12c7","url_expires_at":"2022-03-22T23:38:38Z","include_children":false}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/tracker/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 770
-            request_size: 562
+            header_size: 718
+            request_size: 541
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.250068
-            namelookup_time: 0.001325
-            connect_time: 0.059357
-            pretransfer_time: 0.141342
+            total_time: 0.279021
+            namelookup_time: 0.00139
+            connect_time: 0.052094
+            pretransfer_time: 0.131793
             size_upload: 68.0
             size_download: 685.0
-            speed_download: 2739.0
-            speed_upload: 271.0
+            speed_download: 2455.0
+            speed_upload: 243.0
             download_content_length: 685.0
             upload_content_length: 68.0
-            starttransfer_time: 0.141359
+            starttransfer_time: 0.131801
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 51835
+            local_ip: 10.130.6.32
+            local_port: 49917
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 141159
-            connect_time_us: 59357
-            namelookup_time_us: 1325
-            pretransfer_time_us: 141342
+            appconnect_time_us: 131653
+            connect_time_us: 52094
+            namelookup_time_us: 1390
+            pretransfer_time_us: 131793
             redirect_time_us: 0
-            starttransfer_time_us: 141359
-            total_time_us: 250068
+            starttransfer_time_us: 131801
+            total_time_us: 279021

--- a/test/cassettes/reports/retrievePaymentLogReport.yml
+++ b/test/cassettes/reports/retrievePaymentLogReport.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/reports/plrep_7358a6296ea947df9416e1939920117d'
+        url: 'https://api.easypost.com/v2/reports/plrep_16826a8073bb4ec685e6ff11f52e1292'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -23,22 +23,22 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 4e82e4b9623a5de2e779a00c001852d8
+            x-ep-request-uuid: 15978957623b6023f1d95916001b1b92
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '261'
-            etag: 'W/"a0429f5d950c6463f8172caae160114a"'
-            x-runtime: '0.028059'
-            x-node: bigweb4nuq
+            etag: 'W/"ff772aedb90ab8b0a01b11060e6fc610"'
+            x-runtime: '0.026770'
+            x-node: bigweb3nuq
             x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
             x-proxied: ['intlb2nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"plrep_7358a6296ea947df9416e1939920117d","object":"PaymentLogReport","created_at":"2022-03-22T23:38:09Z","updated_at":"2022-03-22T23:38:09Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"empty","url":null,"url_expires_at":null}'
+        body: '{"id":"plrep_16826a8073bb4ec685e6ff11f52e1292","object":"PaymentLogReport","created_at":"2022-03-23T18:00:02Z","updated_at":"2022-03-23T18:00:02Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"empty","url":null,"url_expires_at":null}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/plrep_7358a6296ea947df9416e1939920117d'
+            url: 'https://api.easypost.com/v2/reports/plrep_16826a8073bb4ec685e6ff11f52e1292'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 718
@@ -46,32 +46,32 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.233024
-            namelookup_time: 0.001438
-            connect_time: 0.05424
-            pretransfer_time: 0.141073
+            total_time: 0.143163
+            namelookup_time: 0.001638
+            connect_time: 0.041289
+            pretransfer_time: 0.085271
             size_upload: 0.0
             size_download: 261.0
-            speed_download: 1120.0
+            speed_download: 1823.0
             speed_upload: 0.0
             download_content_length: 261.0
             upload_content_length: 0.0
-            starttransfer_time: 0.232982
+            starttransfer_time: 0.143139
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.32
-            local_port: 49927
+            local_ip: 172.168.1.123
+            local_port: 53909
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 140958
-            connect_time_us: 54240
-            namelookup_time_us: 1438
-            pretransfer_time_us: 141073
+            appconnect_time_us: 85138
+            connect_time_us: 41289
+            namelookup_time_us: 1638
+            pretransfer_time_us: 85271
             redirect_time_us: 0
-            starttransfer_time_us: 232982
-            total_time_us: 233024
+            starttransfer_time_us: 143139
+            total_time_us: 143163

--- a/test/cassettes/reports/retrievePaymentLogReport.yml
+++ b/test/cassettes/reports/retrievePaymentLogReport.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/reports/plrep_e26dd72d216c4b23a482df6f2187ab61'
+        url: 'https://api.easypost.com/v2/reports/plrep_7358a6296ea947df9416e1939920117d'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -23,56 +23,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 888f660d62015c73e7875167004b8c59
+            x-ep-request-uuid: 4e82e4b9623a5de2e779a00c001852d8
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '261'
-            etag: 'W/"f050fa9e1bc941a8baedaf08dc1954e1"'
-            x-request-id: 90527b85-4f66-4bd0-860e-18b481897d64
-            x-runtime: '0.032814'
-            x-node: bigweb8nuq
-            x-version-label: easypost-202202042220-76f9648007-master
+            etag: 'W/"a0429f5d950c6463f8172caae160114a"'
+            x-runtime: '0.028059'
+            x-node: bigweb4nuq
+            x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 88c34981dc', 'extlb1nuq 88c34981dc']
+            x-proxied: ['intlb2nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"plrep_e26dd72d216c4b23a482df6f2187ab61","object":"PaymentLogReport","created_at":"2022-02-07T17:52:51Z","updated_at":"2022-02-07T17:52:51Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"empty","url":null,"url_expires_at":null}'
+        body: '{"id":"plrep_7358a6296ea947df9416e1939920117d","object":"PaymentLogReport","created_at":"2022-03-22T23:38:09Z","updated_at":"2022-03-22T23:38:09Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"empty","url":null,"url_expires_at":null}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/plrep_e26dd72d216c4b23a482df6f2187ab61'
+            url: 'https://api.easypost.com/v2/reports/plrep_7358a6296ea947df9416e1939920117d'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 770
-            request_size: 571
+            header_size: 718
+            request_size: 550
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.239732
-            namelookup_time: 0.001301
-            connect_time: 0.058749
-            pretransfer_time: 0.145694
+            total_time: 0.233024
+            namelookup_time: 0.001438
+            connect_time: 0.05424
+            pretransfer_time: 0.141073
             size_upload: 0.0
             size_download: 261.0
-            speed_download: 1088.0
+            speed_download: 1120.0
             speed_upload: 0.0
             download_content_length: 261.0
             upload_content_length: 0.0
-            starttransfer_time: 0.239684
+            starttransfer_time: 0.232982
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 51839
+            local_ip: 10.130.6.32
+            local_port: 49927
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 145496
-            connect_time_us: 58749
-            namelookup_time_us: 1301
-            pretransfer_time_us: 145694
+            appconnect_time_us: 140958
+            connect_time_us: 54240
+            namelookup_time_us: 1438
+            pretransfer_time_us: 141073
             redirect_time_us: 0
-            starttransfer_time_us: 239684
-            total_time_us: 239732
+            starttransfer_time_us: 232982
+            total_time_us: 233024

--- a/test/cassettes/reports/retrieveRefundReport.yml
+++ b/test/cassettes/reports/retrieveRefundReport.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/reports/refrep_e236be05e8dd404cad45df7b4b5a9f2e'
+        url: 'https://api.easypost.com/v2/reports/refrep_26bdfe6a039a48d89e4610f3d0ee4367'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -23,56 +23,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 4e82e4b9623a5de1e779a009001852b8
+            x-ep-request-uuid: c18aa493623b6024f1fea363001a81a5
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '658'
-            etag: 'W/"c5769230e7139aec5653199bc5947662"'
-            x-runtime: '0.031782'
-            x-node: bigweb7nuq
+            etag: 'W/"d3929ba7dfdacf03a160ce5d5eda13eb"'
+            x-runtime: '0.029319'
+            x-node: bigweb3nuq
             x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-canary: direct
-            x-proxied: ['intlb1nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
+            x-proxied: ['intlb1nuq 3e97db20d4', 'extlb1nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"refrep_e236be05e8dd404cad45df7b4b5a9f2e","object":"RefundReport","created_at":"2022-03-22T23:38:08Z","updated_at":"2022-03-22T23:38:09Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/refund_report/20220322/f6207c8000b7416eb2789237f24bcd90.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233809Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=8624bf60606209882ce40a5622a40bf7a2149bd8cf4d8470b15be92e616164f8","url_expires_at":"2022-03-22T23:38:39Z"}'
+        body: '{"id":"refrep_26bdfe6a039a48d89e4610f3d0ee4367","object":"RefundReport","created_at":"2022-03-23T18:00:01Z","updated_at":"2022-03-23T18:00:02Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/refund_report/20220323/71a18e9899bb46548bf6a9a8eb61c0ea.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220323%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220323T180004Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=4e952dc126beebc9368c1e1073c2f474420f79337643ce988ac29f7a346ece17","url_expires_at":"2022-03-23T18:00:34Z"}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/refrep_e236be05e8dd404cad45df7b4b5a9f2e'
+            url: 'https://api.easypost.com/v2/reports/refrep_26bdfe6a039a48d89e4610f3d0ee4367'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 736
+            header_size: 718
             request_size: 551
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.233044
-            namelookup_time: 0.001431
-            connect_time: 0.052975
-            pretransfer_time: 0.137139
+            total_time: 0.140032
+            namelookup_time: 0.001503
+            connect_time: 0.031497
+            pretransfer_time: 0.078154
             size_upload: 0.0
             size_download: 658.0
-            speed_download: 2823.0
+            speed_download: 4698.0
             speed_upload: 0.0
             download_content_length: 658.0
             upload_content_length: 0.0
-            starttransfer_time: 0.233005
+            starttransfer_time: 0.140004
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.32
-            local_port: 49924
+            local_ip: 172.168.1.123
+            local_port: 53910
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 137020
-            connect_time_us: 52975
-            namelookup_time_us: 1431
-            pretransfer_time_us: 137139
+            appconnect_time_us: 78001
+            connect_time_us: 31497
+            namelookup_time_us: 1503
+            pretransfer_time_us: 78154
             redirect_time_us: 0
-            starttransfer_time_us: 233005
-            total_time_us: 233044
+            starttransfer_time_us: 140004
+            total_time_us: 140032

--- a/test/cassettes/reports/retrieveRefundReport.yml
+++ b/test/cassettes/reports/retrieveRefundReport.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/reports/refrep_d3f9231714144fd0bd8042ff3cd713e0'
+        url: 'https://api.easypost.com/v2/reports/refrep_e236be05e8dd404cad45df7b4b5a9f2e'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -23,56 +23,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 888f661162015c73e7875166004b8c40
+            x-ep-request-uuid: 4e82e4b9623a5de1e779a009001852b8
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '658'
-            etag: 'W/"5b0cab32a3d005e318f8ff45b389784e"'
-            x-request-id: 7c3969b6-19bf-4be8-93ab-0aaab5a95276
-            x-runtime: '0.036462'
-            x-node: bigweb2nuq
-            x-version-label: easypost-202202042220-76f9648007-master
+            etag: 'W/"c5769230e7139aec5653199bc5947662"'
+            x-runtime: '0.031782'
+            x-node: bigweb7nuq
+            x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 88c34981dc', 'extlb1nuq 88c34981dc']
+            x-canary: direct
+            x-proxied: ['intlb1nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"refrep_d3f9231714144fd0bd8042ff3cd713e0","object":"RefundReport","created_at":"2022-02-07T17:52:50Z","updated_at":"2022-02-07T17:52:50Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/refund_report/20220207/b5f059bd5086413285ab350ab6dc21c6.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220207%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220207T175251Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=accca6eb9215a2caa461212d52428420a787d5774e4751a579702bbd19db5037","url_expires_at":"2022-02-07T17:53:21Z"}'
+        body: '{"id":"refrep_e236be05e8dd404cad45df7b4b5a9f2e","object":"RefundReport","created_at":"2022-03-22T23:38:08Z","updated_at":"2022-03-22T23:38:09Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/refund_report/20220322/f6207c8000b7416eb2789237f24bcd90.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233809Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=8624bf60606209882ce40a5622a40bf7a2149bd8cf4d8470b15be92e616164f8","url_expires_at":"2022-03-22T23:38:39Z"}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/refrep_d3f9231714144fd0bd8042ff3cd713e0'
+            url: 'https://api.easypost.com/v2/reports/refrep_e236be05e8dd404cad45df7b4b5a9f2e'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 770
-            request_size: 572
+            header_size: 736
+            request_size: 551
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.238805
-            namelookup_time: 0.001346
-            connect_time: 0.060619
-            pretransfer_time: 0.142247
+            total_time: 0.233044
+            namelookup_time: 0.001431
+            connect_time: 0.052975
+            pretransfer_time: 0.137139
             size_upload: 0.0
             size_download: 658.0
-            speed_download: 2755.0
+            speed_download: 2823.0
             speed_upload: 0.0
             download_content_length: 658.0
             upload_content_length: 0.0
-            starttransfer_time: 0.238758
+            starttransfer_time: 0.233005
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 51838
+            local_ip: 10.130.6.32
+            local_port: 49924
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 142064
-            connect_time_us: 60619
-            namelookup_time_us: 1346
-            pretransfer_time_us: 142247
+            appconnect_time_us: 137020
+            connect_time_us: 52975
+            namelookup_time_us: 1431
+            pretransfer_time_us: 137139
             redirect_time_us: 0
-            starttransfer_time_us: 238758
-            total_time_us: 238805
+            starttransfer_time_us: 233005
+            total_time_us: 233044

--- a/test/cassettes/reports/retrieveShipmentReport.yml
+++ b/test/cassettes/reports/retrieveShipmentReport.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/reports/shpinvrep_38e751354a87433297242edcb9c62bc8'
+        url: 'https://api.easypost.com/v2/reports/shpinvrep_7ba057cdf9d9481f8f26eb1598b1900c'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -23,64 +23,62 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 888f661162015c73e787517f004b8c6b
+            x-ep-request-uuid: 4e82e4ba623a5de2e779a00a001852c4
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '295'
-            etag: 'W/"e14e13846ef4a57922b898650ce67966"'
-            x-request-id: 1b3f4887-494c-4f1b-bc34-56010a53a98c
-            x-runtime: '0.033262'
-            x-node: bigweb7nuq
-            x-version-label: easypost-202202042220-76f9648007-master
+            etag: 'W/"1c4bdb975c0f7a3e0a3612000bc972ee"'
+            x-runtime: '0.027112'
+            x-node: bigweb5nuq
+            x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-canary: direct
-            x-proxied: ['intlb2nuq 88c34981dc', 'extlb1nuq 88c34981dc']
+            x-proxied: ['intlb1nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shpinvrep_38e751354a87433297242edcb9c62bc8","object":"ShipmentInvoiceReport","created_at":"2022-02-07T17:52:50Z","updated_at":"2022-02-07T17:52:50Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shpinvrep_7ba057cdf9d9481f8f26eb1598b1900c","object":"ShipmentInvoiceReport","created_at":"2022-03-22T23:38:09Z","updated_at":"2022-03-22T23:38:09Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shpinvrep_38e751354a87433297242edcb9c62bc8'
+            url: 'https://api.easypost.com/v2/reports/shpinvrep_7ba057cdf9d9481f8f26eb1598b1900c'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 788
-            request_size: 575
+            header_size: 718
+            request_size: 554
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.234795
-            namelookup_time: 0.001354
-            connect_time: 0.059938
-            pretransfer_time: 0.142047
+            total_time: 0.196057
+            namelookup_time: 0.00133
+            connect_time: 0.049954
+            pretransfer_time: 0.116036
             size_upload: 0.0
             size_download: 295.0
-            speed_download: 1256.0
+            speed_download: 1504.0
             speed_upload: 0.0
             download_content_length: 295.0
             upload_content_length: 0.0
-            starttransfer_time: 0.23476
+            starttransfer_time: 0.196015
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 51840
+            local_ip: 10.130.6.32
+            local_port: 49925
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 141842
-            connect_time_us: 59938
-            namelookup_time_us: 1354
-            pretransfer_time_us: 142047
+            appconnect_time_us: 115918
+            connect_time_us: 49954
+            namelookup_time_us: 1330
+            pretransfer_time_us: 116036
             redirect_time_us: 0
-            starttransfer_time_us: 234760
-            total_time_us: 234795
+            starttransfer_time_us: 196015
+            total_time_us: 196057
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/reports/shprep_3340200ca0ad402e9fea7fe2aede2306'
+        url: 'https://api.easypost.com/v2/reports/shprep_34fe58eade354016abcd7db805a98a36'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -101,56 +99,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 888f661262015c74e7875181004b8c90
+            x-ep-request-uuid: 4e82e4b4623a5de2e779a00b001852ce
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '687'
-            etag: 'W/"e139d54dd692508aa6d92c6c918015d9"'
-            x-request-id: 765fb809-e932-467f-965e-7919d34acd00
-            x-runtime: '0.045559'
-            x-node: bigweb2nuq
-            x-version-label: easypost-202202042220-76f9648007-master
+            etag: 'W/"a44ec463192f07f4af457a49825af1bf"'
+            x-runtime: '0.033312'
+            x-node: bigweb7nuq
+            x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 88c34981dc', 'extlb1nuq 88c34981dc']
+            x-canary: direct
+            x-proxied: ['intlb2nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_3340200ca0ad402e9fea7fe2aede2306","object":"ShipmentReport","created_at":"2022-02-07T17:52:49Z","updated_at":"2022-02-07T17:52:50Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220207/1ea9ced7b7f04d2b83ed253d8f0e8397.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220207%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220207T175252Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=41e2fd1a4b591ac7a207e9dc2a9241be97b14868d41d2e4903cca254f49440ae","url_expires_at":"2022-02-07T17:53:22Z","include_children":false}'
+        body: '{"id":"shprep_34fe58eade354016abcd7db805a98a36","object":"ShipmentReport","created_at":"2022-03-22T23:38:08Z","updated_at":"2022-03-22T23:38:08Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220322/a3e57375aa83468e8d250aa54cce57aa.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233810Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=8db76446ebb7f7c31d574641c83327dd2156c9a70f4509cde43c81d3c523396b","url_expires_at":"2022-03-22T23:38:40Z","include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shprep_3340200ca0ad402e9fea7fe2aede2306'
+            url: 'https://api.easypost.com/v2/reports/shprep_34fe58eade354016abcd7db805a98a36'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 770
-            request_size: 572
+            header_size: 736
+            request_size: 551
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.244938
-            namelookup_time: 0.001257
-            connect_time: 0.05886
-            pretransfer_time: 0.140134
+            total_time: 0.205138
+            namelookup_time: 0.00131
+            connect_time: 0.051507
+            pretransfer_time: 0.119475
             size_upload: 0.0
             size_download: 687.0
-            speed_download: 2804.0
+            speed_download: 3348.0
             speed_upload: 0.0
             download_content_length: 687.0
             upload_content_length: 0.0
-            starttransfer_time: 0.244903
+            starttransfer_time: 0.205076
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 51842
+            local_ip: 10.130.6.32
+            local_port: 49926
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 140005
-            connect_time_us: 58860
-            namelookup_time_us: 1257
-            pretransfer_time_us: 140134
+            appconnect_time_us: 119346
+            connect_time_us: 51507
+            namelookup_time_us: 1310
+            pretransfer_time_us: 119475
             redirect_time_us: 0
-            starttransfer_time_us: 244903
-            total_time_us: 244938
+            starttransfer_time_us: 205076
+            total_time_us: 205138

--- a/test/cassettes/reports/retrieveShipmentReport.yml
+++ b/test/cassettes/reports/retrieveShipmentReport.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/reports/shpinvrep_7ba057cdf9d9481f8f26eb1598b1900c'
+        url: 'https://api.easypost.com/v2/reports/shpinvrep_c84da1eb52b741bcac3754d240921340'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -23,22 +23,22 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 4e82e4ba623a5de2e779a00a001852c4
+            x-ep-request-uuid: 15978954623b6023f1e9e23a001b1b42
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '295'
-            etag: 'W/"1c4bdb975c0f7a3e0a3612000bc972ee"'
-            x-runtime: '0.027112'
-            x-node: bigweb5nuq
+            etag: 'W/"54d358d1936159ef28b26c18844e9ee5"'
+            x-runtime: '0.027033'
+            x-node: bigweb9nuq
             x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
+            x-proxied: ['intlb2nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shpinvrep_7ba057cdf9d9481f8f26eb1598b1900c","object":"ShipmentInvoiceReport","created_at":"2022-03-22T23:38:09Z","updated_at":"2022-03-22T23:38:09Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shpinvrep_c84da1eb52b741bcac3754d240921340","object":"ShipmentInvoiceReport","created_at":"2022-03-23T18:00:02Z","updated_at":"2022-03-23T18:00:02Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shpinvrep_7ba057cdf9d9481f8f26eb1598b1900c'
+            url: 'https://api.easypost.com/v2/reports/shpinvrep_c84da1eb52b741bcac3754d240921340'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 718
@@ -46,39 +46,39 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.196057
-            namelookup_time: 0.00133
-            connect_time: 0.049954
-            pretransfer_time: 0.116036
+            total_time: 0.143775
+            namelookup_time: 0.00163
+            connect_time: 0.033371
+            pretransfer_time: 0.080907
             size_upload: 0.0
             size_download: 295.0
-            speed_download: 1504.0
+            speed_download: 2051.0
             speed_upload: 0.0
             download_content_length: 295.0
             upload_content_length: 0.0
-            starttransfer_time: 0.196015
+            starttransfer_time: 0.143749
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.32
-            local_port: 49925
+            local_ip: 172.168.1.123
+            local_port: 53906
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 115918
-            connect_time_us: 49954
-            namelookup_time_us: 1330
-            pretransfer_time_us: 116036
+            appconnect_time_us: 80775
+            connect_time_us: 33371
+            namelookup_time_us: 1630
+            pretransfer_time_us: 80907
             redirect_time_us: 0
-            starttransfer_time_us: 196015
-            total_time_us: 196057
+            starttransfer_time_us: 143749
+            total_time_us: 143775
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/reports/shprep_34fe58eade354016abcd7db805a98a36'
+        url: 'https://api.easypost.com/v2/reports/shprep_cca848e778d94039ae4dbe0b6cf1fdd3'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -99,23 +99,23 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 4e82e4b4623a5de2e779a00b001852ce
+            x-ep-request-uuid: 15978957623b6023f22033fc001b1b7a
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '687'
-            etag: 'W/"a44ec463192f07f4af457a49825af1bf"'
-            x-runtime: '0.033312'
+            etag: 'W/"9783e42a1afd815e2b403f133de96084"'
+            x-runtime: '0.051953'
             x-node: bigweb7nuq
             x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
             x-canary: direct
             x-proxied: ['intlb2nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_34fe58eade354016abcd7db805a98a36","object":"ShipmentReport","created_at":"2022-03-22T23:38:08Z","updated_at":"2022-03-22T23:38:08Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220322/a3e57375aa83468e8d250aa54cce57aa.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233810Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=8db76446ebb7f7c31d574641c83327dd2156c9a70f4509cde43c81d3c523396b","url_expires_at":"2022-03-22T23:38:40Z","include_children":false}'
+        body: '{"id":"shprep_cca848e778d94039ae4dbe0b6cf1fdd3","object":"ShipmentReport","created_at":"2022-03-23T18:00:01Z","updated_at":"2022-03-23T18:00:01Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220323/773930d6aceb461abdd0f5ea1a11c588.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220323%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220323T180003Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=ad81a64e5bb37e603bdec92b8a2c8e2f67947ebec638fb0fca7078e04f23d284","url_expires_at":"2022-03-23T18:00:33Z","include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shprep_34fe58eade354016abcd7db805a98a36'
+            url: 'https://api.easypost.com/v2/reports/shprep_cca848e778d94039ae4dbe0b6cf1fdd3'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 736
@@ -123,32 +123,32 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.205138
-            namelookup_time: 0.00131
-            connect_time: 0.051507
-            pretransfer_time: 0.119475
+            total_time: 0.204759
+            namelookup_time: 0.001367
+            connect_time: 0.072709
+            pretransfer_time: 0.119201
             size_upload: 0.0
             size_download: 687.0
-            speed_download: 3348.0
+            speed_download: 3355.0
             speed_upload: 0.0
             download_content_length: 687.0
             upload_content_length: 0.0
-            starttransfer_time: 0.205076
+            starttransfer_time: 0.204727
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.32
-            local_port: 49926
+            local_ip: 172.168.1.123
+            local_port: 53908
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 119346
-            connect_time_us: 51507
-            namelookup_time_us: 1310
-            pretransfer_time_us: 119475
+            appconnect_time_us: 119055
+            connect_time_us: 72709
+            namelookup_time_us: 1367
+            pretransfer_time_us: 119201
             redirect_time_us: 0
-            starttransfer_time_us: 205076
-            total_time_us: 205138
+            starttransfer_time_us: 204727
+            total_time_us: 204759

--- a/test/cassettes/reports/retrieveTrackerReport.yml
+++ b/test/cassettes/reports/retrieveTrackerReport.yml
@@ -23,20 +23,20 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 4e82e4b4623a5de2e779a00d001852e1
+            x-ep-request-uuid: 15978954623b6023f1e9d938001b1b62
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '685'
-            etag: 'W/"46e7d20d21489de0329157ca52ef4ca3"'
-            x-runtime: '0.032672'
-            x-node: bigweb8nuq
+            etag: 'W/"ef1344a30fc3de5d0eb86c459230eb9f"'
+            x-runtime: '0.042019'
+            x-node: bigweb6nuq
             x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
             x-proxied: ['intlb2nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"trkrep_f8c2664fc490481980ab8ff1f6ac297d","object":"TrackerReport","created_at":"2022-02-03T16:56:09Z","updated_at":"2022-03-22T23:38:09Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20220322/14f3ed87e50d4719a814552c6c98075c.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233810Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=f491eb917dedd44a9309f765e52ad68eeb3a9ad298a50cbb098039288df702e2","url_expires_at":"2022-03-22T23:38:40Z","include_children":false}'
+        body: '{"id":"trkrep_f8c2664fc490481980ab8ff1f6ac297d","object":"TrackerReport","created_at":"2022-02-03T16:56:09Z","updated_at":"2022-03-23T18:00:03Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20220323/b1a50f4228734fcfa4d8f6f63897a4c4.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220323%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220323T180003Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=c85b6df55e949363a8a9cd287a982a6f7b2c96b6f420f99e8888d963a417b547","url_expires_at":"2022-03-23T18:00:33Z","include_children":false}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/trkrep_f8c2664fc490481980ab8ff1f6ac297d'
             content_type: 'application/json; charset=utf-8'
@@ -46,32 +46,32 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.199802
-            namelookup_time: 0.001429
-            connect_time: 0.049847
-            pretransfer_time: 0.116582
+            total_time: 0.1978
+            namelookup_time: 0.019419
+            connect_time: 0.064492
+            pretransfer_time: 0.114088
             size_upload: 0.0
             size_download: 685.0
-            speed_download: 3428.0
+            speed_download: 3463.0
             speed_upload: 0.0
             download_content_length: 685.0
             upload_content_length: 0.0
-            starttransfer_time: 0.199759
+            starttransfer_time: 0.197773
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.32
-            local_port: 49928
+            local_ip: 172.168.1.123
+            local_port: 53907
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 116464
-            connect_time_us: 49847
-            namelookup_time_us: 1429
-            pretransfer_time_us: 116582
+            appconnect_time_us: 113950
+            connect_time_us: 64492
+            namelookup_time_us: 19419
+            pretransfer_time_us: 114088
             redirect_time_us: 0
-            starttransfer_time_us: 199759
-            total_time_us: 199802
+            starttransfer_time_us: 197773
+            total_time_us: 197800

--- a/test/cassettes/reports/retrieveTrackerReport.yml
+++ b/test/cassettes/reports/retrieveTrackerReport.yml
@@ -23,56 +23,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 888f661262015c74e7875180004b8c7f
+            x-ep-request-uuid: 4e82e4b4623a5de2e779a00d001852e1
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '685'
-            etag: 'W/"10d029aad4477ded10f45c6b181c181d"'
-            x-request-id: 43e53abc-7c5b-4414-bd46-c6c3fb7f29ee
-            x-runtime: '0.032768'
-            x-node: bigweb3nuq
-            x-version-label: easypost-202202042220-76f9648007-master
+            etag: 'W/"46e7d20d21489de0329157ca52ef4ca3"'
+            x-runtime: '0.032672'
+            x-node: bigweb8nuq
+            x-version-label: easypost-202203222149-4f3b000452-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 88c34981dc', 'extlb1nuq 88c34981dc']
+            x-proxied: ['intlb2nuq 3e97db20d4', 'extlb2nuq 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"trkrep_f8c2664fc490481980ab8ff1f6ac297d","object":"TrackerReport","created_at":"2022-02-03T16:56:09Z","updated_at":"2022-02-07T17:52:51Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20220207/7a39eb89e189450b9b5d53f4ed4ea32e.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220207%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220207T175252Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=7a3408a73a74efce043c6e9c6683a7b08d993a8d70a259ce16d4dc90365f7885","url_expires_at":"2022-02-07T17:53:22Z","include_children":false}'
+        body: '{"id":"trkrep_f8c2664fc490481980ab8ff1f6ac297d","object":"TrackerReport","created_at":"2022-02-03T16:56:09Z","updated_at":"2022-03-22T23:38:09Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20220322/14f3ed87e50d4719a814552c6c98075c.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220322%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220322T233810Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=f491eb917dedd44a9309f765e52ad68eeb3a9ad298a50cbb098039288df702e2","url_expires_at":"2022-03-22T23:38:40Z","include_children":false}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/trkrep_f8c2664fc490481980ab8ff1f6ac297d'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 770
-            request_size: 572
+            header_size: 718
+            request_size: 551
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.234709
-            namelookup_time: 0.001383
-            connect_time: 0.059604
-            pretransfer_time: 0.141772
+            total_time: 0.199802
+            namelookup_time: 0.001429
+            connect_time: 0.049847
+            pretransfer_time: 0.116582
             size_upload: 0.0
             size_download: 685.0
-            speed_download: 2918.0
+            speed_download: 3428.0
             speed_upload: 0.0
             download_content_length: 685.0
             upload_content_length: 0.0
-            starttransfer_time: 0.234663
+            starttransfer_time: 0.199759
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 51841
+            local_ip: 10.130.6.32
+            local_port: 49928
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 141641
-            connect_time_us: 59604
-            namelookup_time_us: 1383
-            pretransfer_time_us: 141772
+            appconnect_time_us: 116464
+            connect_time_us: 49847
+            namelookup_time_us: 1429
+            pretransfer_time_us: 116582
             redirect_time_us: 0
-            starttransfer_time_us: 234663
-            total_time_us: 234709
+            starttransfer_time_us: 199759
+            total_time_us: 199802


### PR DESCRIPTION
This PR:
- Adds support for specifying `columns` and `additional_columns` (both lists of strings) in the parameters dictionary passed into the `Report->create()` function.

Unfortunately, since the API response does not indicate the columns used for a report, the only way to ensure the report actually includes the columns requested would be to make a live API call, download the generated CSV report and parse its column headers. That is a complex unit test with many points of failure and prevents us from using VCR.

Instead, we simply assume that if no error is thrown during the API call to generate and retrieve the report, that the report contains the correct columns. If it doesn't, that constitutes a server-side error that is out of our control.