### PR TITLE
add assertion for tax_identifiers in shipment test.

### DIFF
--- a/test/EasyPost/ShipmentTest.php
+++ b/test/EasyPost/ShipmentTest.php
@@ -246,6 +246,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
         $this->assertNotEmpty($shipment->options); // The EasyPost API populates some default values here
         $this->assertEmpty($shipment->customs_info);
         $this->assertNull($shipment->reference);
+        $this->assertNull($shipment->tax_identifiers);
     }
 
     /**

--- a/test/cassettes/shipments/createEmptyObjects.yml
+++ b/test/cassettes/shipments/createEmptyObjects.yml
@@ -24,57 +24,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 888f660f62015c65e78750fb004b8835
+            x-ep-request-uuid: 03a9a2bd6241e9f0ff02f8230058c602
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
-            location: /api/v2/shipments/shp_fe8b7de6877d414083a3f520ac6778ab
+            location: /api/v2/shipments/shp_d74c0f7cab514138af2c2abafa0e6563
             content-type: 'application/json; charset=utf-8'
             content-length: '4729'
-            etag: 'W/"251f9deffff69a6481ec9fe60258c3e0"'
-            x-request-id: 39675d91-868b-4ae7-9aa5-cf6753a6876c
-            x-runtime: '0.307436'
+            etag: 'W/"4a5c5a888251872ed4fa453b2afff208"'
+            x-runtime: '0.264209'
             x-node: bigweb1nuq
-            x-version-label: easypost-202202042220-76f9648007-master
+            x-version-label: easypost-202203260046-01c741afa3-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 88c34981dc', 'extlb1nuq 88c34981dc']
+            x-proxied: ['intlb1nuq 3e97db20d4', 'intlb2wdc 3e97db20d4', 'extlb1wdc 3e97db20d4']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"created_at":"2022-02-07T17:52:37Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-02-07T17:52:37Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_bc8fdd25883e11eca9a0ac1f6bc7bdc6","object":"Address","created_at":"2022-02-07T17:52:37+00:00","updated_at":"2022-02-07T17:52:37+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_d6ee17c6493f4510a201251ee1dd9b79","object":"Parcel","created_at":"2022-02-07T17:52:37Z","updated_at":"2022-02-07T17:52:37Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_c327fae777544921a9780121a49a71a6","object":"Rate","created_at":"2022-02-07T17:52:37Z","updated_at":"2022-02-07T17:52:37Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_fe8b7de6877d414083a3f520ac6778ab","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_6562ec6e6cde471597c07277bcb1d76e","object":"Rate","created_at":"2022-02-07T17:52:37Z","updated_at":"2022-02-07T17:52:37Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_fe8b7de6877d414083a3f520ac6778ab","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_6ac712ee36c74238bc45a1d05f670c16","object":"Rate","created_at":"2022-02-07T17:52:37Z","updated_at":"2022-02-07T17:52:37Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_fe8b7de6877d414083a3f520ac6778ab","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_60207cd6468248ceb6390bb8ca9639f7","object":"Rate","created_at":"2022-02-07T17:52:37Z","updated_at":"2022-02-07T17:52:37Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_fe8b7de6877d414083a3f520ac6778ab","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_bc8daea9883e11ecb771ac1f6bc72124","object":"Address","created_at":"2022-02-07T17:52:37+00:00","updated_at":"2022-02-07T17:52:37+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_bc8fdd25883e11eca9a0ac1f6bc7bdc6","object":"Address","created_at":"2022-02-07T17:52:37+00:00","updated_at":"2022-02-07T17:52:37+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_bc8daea9883e11ecb771ac1f6bc72124","object":"Address","created_at":"2022-02-07T17:52:37+00:00","updated_at":"2022-02-07T17:52:37+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_fe8b7de6877d414083a3f520ac6778ab","object":"Shipment"}'
+        body: '{"created_at":"2022-03-28T17:01:36Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-03-28T17:01:36Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_ba76d335aeb811ecb08cac1f6bc7b362","object":"Address","created_at":"2022-03-28T17:01:36+00:00","updated_at":"2022-03-28T17:01:36+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_7c05ed1bf7a84f629c2119a7b32889a9","object":"Parcel","created_at":"2022-03-28T17:01:36Z","updated_at":"2022-03-28T17:01:36Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_8749c1d64fcb4d4d970472a09063a2ad","object":"Rate","created_at":"2022-03-28T17:01:36Z","updated_at":"2022-03-28T17:01:36Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_d74c0f7cab514138af2c2abafa0e6563","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_8485c1157ae64ba695ad6edfde370b14","object":"Rate","created_at":"2022-03-28T17:01:36Z","updated_at":"2022-03-28T17:01:36Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_d74c0f7cab514138af2c2abafa0e6563","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_02ba6367205a4aed9ad8a4eeb095ce1e","object":"Rate","created_at":"2022-03-28T17:01:36Z","updated_at":"2022-03-28T17:01:36Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_d74c0f7cab514138af2c2abafa0e6563","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_6e33d15ea51441f09e5d5e07997a47bb","object":"Rate","created_at":"2022-03-28T17:01:36Z","updated_at":"2022-03-28T17:01:36Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_d74c0f7cab514138af2c2abafa0e6563","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_ba7515c4aeb811ecb880ac1f6bc72124","object":"Address","created_at":"2022-03-28T17:01:36+00:00","updated_at":"2022-03-28T17:01:36+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_ba76d335aeb811ecb08cac1f6bc7b362","object":"Address","created_at":"2022-03-28T17:01:36+00:00","updated_at":"2022-03-28T17:01:36+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_ba7515c4aeb811ecb880ac1f6bc72124","object":"Address","created_at":"2022-03-28T17:01:36+00:00","updated_at":"2022-03-28T17:01:36+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_d74c0f7cab514138af2c2abafa0e6563","object":"Shipment"}'
         curl_info:
             url: 'https://api.easypost.com/v2/shipments'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 837
-            request_size: 556
+            header_size: 818
+            request_size: 539
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.506108
-            namelookup_time: 0.001473
-            connect_time: 0.059262
-            pretransfer_time: 0.13912
+            total_time: 0.596052
+            namelookup_time: 0.027098
+            connect_time: 0.040335
+            pretransfer_time: 0.075188
             size_upload: 452.0
             size_download: 4729.0
-            speed_download: 9343.0
-            speed_upload: 893.0
+            speed_download: 7933.0
+            speed_upload: 758.0
             download_content_length: 4729.0
             upload_content_length: 452.0
-            starttransfer_time: 0.139137
+            starttransfer_time: 0.075201
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.47.33.19
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 51800
+            local_ip: 192.168.1.156
+            local_port: 49563
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 138985
-            connect_time_us: 59262
-            namelookup_time_us: 1473
-            pretransfer_time_us: 139120
+            appconnect_time_us: 74940
+            connect_time_us: 40335
+            namelookup_time_us: 27098
+            pretransfer_time_us: 75188
             redirect_time_us: 0
-            starttransfer_time_us: 139137
-            total_time_us: 506108
+            starttransfer_time_us: 75201
+            total_time_us: 596052


### PR DESCRIPTION
This PR adds a missing assertion for `tax_identifiers`