### PR TITLE
Add bug report and feature request templates for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,95 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: [ "triage" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report an issue in this repository. Please fill out the form below.
+  - type: input
+    id: software-version
+    attributes:
+      label: Software Version
+      # change this description for the specific repo
+      description: |
+        What version of our software are you running?
+        TIP: [Available versions](https://github.com/EasyPost/easypost-php/releases)
+    validations:
+      required: true
+  - type: input
+    id: language-version
+    attributes:
+      label: Language Version
+      # change this description for the specific language of the repo
+      description: |
+        What language version and/or framework are you using?
+        TIP: [How to find your PHP version](https://www.php.net/manual/en/function.phpversion.php)
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: What operating system are you running the software on?
+    validations:
+      required: true
+  - type: textarea
+    id: behavior
+    attributes:
+      label: What happened?
+      description: Please describe what happened in reproducible steps.
+      value: |
+        1.
+        2.
+        3.
+        ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: What was expected?
+      description: Please describe what was expected to happen instead.
+    validations:
+      required: true
+  - type: input
+    id: frequency
+    attributes:
+      label: Frequency
+      description: How often does this occur?
+      placeholder: "Example: Every time, only once, only when X happens, etc."
+    validations:
+      required: true
+  - type: textarea
+    id: sample-code
+    attributes:
+      label: Sample Code
+      description: |
+        Please provide any sample code that demonstrates the behavior.
+        This will be automatically formatted into the appropriate language, so no need for backticks.
+        **Do not include any private information such as API keys or passwords.**
+      # change this render to the appropriate language: https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
+      render: inc
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        Please copy and paste any relevant log output.
+        This will be automatically formatted into shell output, so no need for backticks.
+        If you have screenshots instead, please paste them below.
+        **Do not include any private information such as API keys or passwords.**
+      render: sh
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,8 +39,8 @@ body:
     attributes:
       label: What happened?
       description: |
-      Please describe what happened in reproducible steps.
-      Include how often you see this issue, and any relevant links (i.e. GitHub issue, Stack Overflow, etc.).
+        Please describe what happened in reproducible steps.
+        Include how often you see this issue, and any relevant links (i.e. GitHub issue, Stack Overflow, etc.).
       value: |
         1.
         2.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,7 +38,9 @@ body:
     id: behavior
     attributes:
       label: What happened?
-      description: Please describe what happened in reproducible steps.
+      description: |
+      Please describe what happened in reproducible steps.
+      Include how often you see this issue, and any relevant links (i.e. GitHub issue, Stack Overflow, etc.).
       value: |
         1.
         2.
@@ -51,14 +53,6 @@ body:
     attributes:
       label: What was expected?
       description: Please describe what was expected to happen instead.
-    validations:
-      required: true
-  - type: input
-    id: frequency
-    attributes:
-      label: Frequency
-      description: How often does this occur?
-      placeholder: "Example: Every time, only once, only when X happens, etc."
     validations:
       required: true
   - type: textarea
@@ -85,11 +79,3 @@ body:
       render: sh
     validations:
       required: false
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our Code of Conduct
-      options:
-        - label: I agree to follow this project's Code of Conduct
-          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Request a new feature
+title: "[Feat]: "
+labels: [ "triage" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to request a new feature.
+        Please note, all feature requests are subject to review and approval.
+        We welcome all suggestions and ideas, but we cannot guarantee when or if we will implement them.
+        
+        We also welcome pull requests, if you would like to implement the feature yourself.
+        Doing so will likely accelaerate the process of implementing the requested feature.
+  - type: checkboxes
+    id: searched
+    attributes:
+      label: Feature Request Is New
+      description: |
+        Before we begin, please confirm that the requested feature does not already exist or has not already been requested.
+      options:
+        - label: I have verified that the requested feature does not already exist or has not already been requested.
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description of the feature
+      description: |
+        Please provide a detailed description of the feature, including:
+        - What the feature is
+        - What value it adds to the application
+        - How it should be implemented (i.e. pseudo-code, or a high-level description of the user experience)
+        - Any other relevant information
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,13 +11,14 @@ body:
         We welcome all suggestions and ideas, but we cannot guarantee when or if we will implement them.
         
         We also welcome pull requests, if you would like to implement the feature yourself.
-        Doing so will likely accelaerate the process of implementing the requested feature.
+        Doing so will likely accelerate the process of implementing the requested feature.
   - type: checkboxes
     id: searched
     attributes:
       label: Feature Request Is New
+      # change issue link below for the specific repo
       description: |
-        Before we begin, please confirm that the requested feature does not already exist or has not already been requested.
+        Before we begin, please confirm that the requested feature does not already exist or has not [already been requested](https://github.com/EasyPost/easypost-php/issues).
       options:
         - label: I have verified that the requested feature does not already exist or has not already been requested.
           required: true


### PR DESCRIPTION
We should standardize what information we collect from users reporting issues or requesting features to our client library repositories to streamline and enhance our ability to address issues.

This PR includes:
- Template for GitHub bug reports, collecting required information
- Template for GitHub feature requests

Preview the templates:
- Bug report: https://github.com/EasyPost/easypost-php/blob/issue_template/.github/ISSUE_TEMPLATE/bug_report.yml
- Feature request: https://github.com/EasyPost/easypost-php/blob/issue_template/.github/ISSUE_TEMPLATE/feature_request.yml

The templates includes some PHP-specific settings and repo-specific links. Once approved for this repository, this template will be altered accordingly and added to all other client library repositories.