### PR TITLE
fix: test dates by hardcoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,6 @@ If you make an addition to this project, the request/response will get recorded 
 
 The test suite has been populated with various helpful fixtures that are available for use, each completely independent from a particular user **with the exception of the USPS carrier account ID** which has a fallback value to our internal testing user's ID. If you are a non-EasyPost employee and are re-recording cassettes, you may need to provide the `USPS_CARRIER_ACCOUNT_ID` environment variable with the ID associated with your USPS account (which will be associated with your API keys in use) for tests that use this fixture.
 
+**Note on dates:** Some fixtures use hard-coded dates that may need to be incremented if cassettes get re-recorded (such as reports or pickups).
+
 **Note on test order:** This project uses a special test ordering which follows a `create -> retrieve -> update -> delete` pattern. The create test will return the created object so that other tests such as retrieving, updating, and deleting tests can reuse that object for their own tests in an effort to cut down on object creation during testing. You'll see this denoted with a `@depends` decorator on tests where you can link the test order as needed.

--- a/test/EasyPost/Fixture.php
+++ b/test/EasyPost/Fixture.php
@@ -13,8 +13,9 @@ class Fixture
     // This is the USPS carrier account ID that comes with your EasyPost account by default and should be used for all tests
     public static function usps_carrier_account_id()
     {
-        // Fallback to the EasyPost Ruby Client Library Test User USPS carrier account ID
+        // Fallback to the EasyPost PHP Client Library Test User USPS carrier account ID
         $usps_carrier_account_id = getenv('USPS_CARRIER_ACCOUNT_ID') !== false ? getenv('USPS_CARRIER_ACCOUNT_ID') : 'ca_8dc116debcdb49b5a66a2ddee4612600';
+
         return $usps_carrier_account_id;
     }
 
@@ -38,14 +39,15 @@ class Fixture
         return 'shipment';
     }
 
-    public static function report_start_date()
+    // If you need to re-record cassettes, increment this date by 1
+    public static function report_date()
     {
-        return date('Y/m/d', strtotime('-2 day'));
+        return '2022-04-09';
     }
 
-    public static function report_end_date()
+    public static function webhook_url()
     {
-        return date('Y/m/d');
+        return 'http://example.com';
     }
 
     public static function basic_address()
@@ -175,12 +177,11 @@ class Fixture
     }
 
     // This fixture will require you to add a `shipment` key with a Shipment object from a test.
+    // If you need to re-record cassettes, increment the date below and ensure it is one day in the future,
     // USPS only does "next-day" pickups including Saturday but not Sunday or Holidays.
     public static function basic_pickup()
     {
-        $weekday_number = date('N');
-        $weekday_offset = ($weekday_number == 5) ? 3 : 2; // Push our pickup date to the "next day" based on the day of the week
-        $pickup_date = date('Y/m/d', strtotime("+$weekday_offset days"));
+        $pickup_date = '2022-04-12';
 
         return [
             'address' => self::basic_address(),

--- a/test/EasyPost/PickupTest.php
+++ b/test/EasyPost/PickupTest.php
@@ -87,7 +87,7 @@ class PickupTest extends \PHPUnit\Framework\TestCase
 
         $bought_pickup = $pickup->buy([
             'carrier' => Fixture::usps(),
-            'service' => 'NextDay',
+            'service' => Fixture::pickup_service(),
         ]);
 
         $this->assertInstanceOf('\EasyPost\Pickup', $bought_pickup);

--- a/test/EasyPost/ReportTest.php
+++ b/test/EasyPost/ReportTest.php
@@ -42,8 +42,8 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('reports/createReport.yml');
 
         $report = Report::create([
-            'start_date' => Fixture::report_start_date(),
-            'end_date' => Fixture::report_end_date(),
+            'start_date' => Fixture::report_date(),
+            'end_date' => Fixture::report_date(),
             'type' => Fixture::report_type(),
         ]);
 
@@ -64,8 +64,8 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('reports/createCustomColumnReport.yml');
 
         $report = Report::create([
-            'start_date' => Fixture::report_start_date(),
-            'end_date' => Fixture::report_end_date(),
+            'start_date' => Fixture::report_date(),
+            'end_date' => Fixture::report_date(),
             'type' => Fixture::report_type(),
             'columns' => ['usps_zone']
         ]);
@@ -86,8 +86,8 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('reports/createCustomAdditionalColumnReport.yml');
 
         $report = Report::create([
-            'start_date' => Fixture::report_start_date(),
-            'end_date' => Fixture::report_end_date(),
+            'start_date' => Fixture::report_date(),
+            'end_date' => Fixture::report_date(),
             'type' => Fixture::report_type(),
             'additional_columns' => ['from_name', 'from_company']
         ]);

--- a/test/EasyPost/WebhookTest.php
+++ b/test/EasyPost/WebhookTest.php
@@ -42,12 +42,12 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('webhooks/create.yml');
 
         $webhook = Webhook::create([
-            "url" => "http://example.com"
+            "url" => Fixture::webhook_url(),
         ]);
 
         $this->assertInstanceOf('\EasyPost\Webhook', $webhook);
         $this->assertStringMatchesFormat('hook_%s', $webhook->id);
-        $this->assertEquals('http://example.com', $webhook->url);
+        $this->assertEquals(Fixture::webhook_url(), $webhook->url);
 
         // Return so other tests can reuse this object
         return $webhook;

--- a/test/cassettes/pickups/buy.yml
+++ b/test/cassettes/pickups/buy.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: POST
-        url: 'https://api.easypost.com/v2/pickups/pickup_7070dd414b7246c0b12aec71c3013485/buy'
+        url: 'https://api.easypost.com/v2/pickups/pickup_5451ee8718904b5f9d7faf67aa7c24a2/buy'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -24,22 +24,22 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 6583cdf86250864de2b7e338004c8325
+            x-ep-request-uuid: df63cd0b62547161e786af5900239903
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '1160'
-            etag: 'W/"dd575512cf0667c3d7d5affe34bf603b"'
-            x-runtime: '1.796734'
+            etag: 'W/"bc510864f81206504f676fad9d7d6c15"'
+            x-runtime: '1.288440'
             x-node: bigweb5nuq
-            x-version-label: easypost-202204071939-d894f5743c-master
+            x-version-label: easypost-202204082123-da17cc1ac2-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq fde591f008', 'extlb2nuq fde591f008']
+            x-proxied: ['intlb1nuq fde591f008', 'extlb1nuq fde591f008']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"pickup_7070dd414b7246c0b12aec71c3013485","object":"Pickup","created_at":"2022-04-08T19:00:28Z","updated_at":"2022-04-08T19:00:31Z","mode":"test","status":"scheduled","reference":null,"min_datetime":"2022-04-11T00:00:00Z","max_datetime":"2022-04-11T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":"WTC61774598","address":{"id":"adr_27dd58e7b76e11eca07cac1f6b0a0d1e","object":"Address","created_at":"2022-04-08T19:00:28+00:00","updated_at":"2022-04-08T19:00:28+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-08T19:00:29Z","updated_at":"2022-04-08T19:00:29Z","carrier":"USPS","pickup_id":"pickup_7070dd414b7246c0b12aec71c3013485","id":"pickuprate_637cccd602ec4d098e8c66c8980be4dc","object":"PickupRate"}]}'
+        body: '{"id":"pickup_5451ee8718904b5f9d7faf67aa7c24a2","object":"Pickup","created_at":"2022-04-11T18:20:15Z","updated_at":"2022-04-11T18:20:18Z","mode":"test","status":"scheduled","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":"WTC61774794","address":{"id":"adr_08f58c9bb9c411ec9a46ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:20:15+00:00","updated_at":"2022-04-11T18:20:15+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:20:17Z","updated_at":"2022-04-11T18:20:17Z","carrier":"USPS","pickup_id":"pickup_5451ee8718904b5f9d7faf67aa7c24a2","id":"pickuprate_2f9d75ab8de44ab9a77d36332752e442","object":"PickupRate"}]}'
         curl_info:
-            url: 'https://api.easypost.com/v2/pickups/pickup_7070dd414b7246c0b12aec71c3013485/buy'
+            url: 'https://api.easypost.com/v2/pickups/pickup_5451ee8718904b5f9d7faf67aa7c24a2/buy'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 719
@@ -47,32 +47,32 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 1.90773
-            namelookup_time: 0.002486
-            connect_time: 0.033747
-            pretransfer_time: 0.078061
+            total_time: 1.48443
+            namelookup_time: 0.003191
+            connect_time: 0.061123
+            pretransfer_time: 0.133179
             size_upload: 38.0
             size_download: 1160.0
-            speed_download: 608.0
-            speed_upload: 19.0
+            speed_download: 781.0
+            speed_upload: 25.0
             download_content_length: 1160.0
             upload_content_length: 38.0
-            starttransfer_time: 0.078065
+            starttransfer_time: 0.133183
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 192.168.1.201
-            local_port: 50685
+            local_ip: 10.130.6.21
+            local_port: 50304
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 77929
-            connect_time_us: 33747
-            namelookup_time_us: 2486
-            pretransfer_time_us: 78061
+            appconnect_time_us: 133077
+            connect_time_us: 61123
+            namelookup_time_us: 3191
+            pretransfer_time_us: 133179
             redirect_time_us: 0
-            starttransfer_time_us: 78065
-            total_time_us: 1907730
+            starttransfer_time_us: 133183
+            total_time_us: 1484430

--- a/test/cassettes/pickups/cancel.yml
+++ b/test/cassettes/pickups/cancel.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: POST
-        url: 'https://api.easypost.com/v2/pickups/pickup_7070dd414b7246c0b12aec71c3013485/cancel'
+        url: 'https://api.easypost.com/v2/pickups/pickup_5451ee8718904b5f9d7faf67aa7c24a2/cancel'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -24,55 +24,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 6583cdf96250864fe2b7e339004c8433
+            x-ep-request-uuid: df63cd0b62547163e786af5b002399bb
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '1159'
-            etag: 'W/"863524dbc548c0b89b78fbe3019500d3"'
-            x-runtime: '1.102182'
-            x-node: bigweb8nuq
-            x-version-label: easypost-202204071939-d894f5743c-master
+            etag: 'W/"3822d44fbf7574e5135f35db727fd094"'
+            x-runtime: '0.977849'
+            x-node: bigweb7nuq
+            x-version-label: easypost-202204082123-da17cc1ac2-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq fde591f008', 'extlb2nuq fde591f008']
+            x-canary: direct
+            x-proxied: ['intlb1nuq fde591f008', 'extlb1nuq fde591f008']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"pickup_7070dd414b7246c0b12aec71c3013485","object":"Pickup","created_at":"2022-04-08T19:00:28Z","updated_at":"2022-04-08T19:00:32Z","mode":"test","status":"canceled","reference":null,"min_datetime":"2022-04-11T00:00:00Z","max_datetime":"2022-04-11T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":"WTC61774598","address":{"id":"adr_27dd58e7b76e11eca07cac1f6b0a0d1e","object":"Address","created_at":"2022-04-08T19:00:28+00:00","updated_at":"2022-04-08T19:00:28+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-08T19:00:29Z","updated_at":"2022-04-08T19:00:29Z","carrier":"USPS","pickup_id":"pickup_7070dd414b7246c0b12aec71c3013485","id":"pickuprate_637cccd602ec4d098e8c66c8980be4dc","object":"PickupRate"}]}'
+        body: '{"id":"pickup_5451ee8718904b5f9d7faf67aa7c24a2","object":"Pickup","created_at":"2022-04-11T18:20:15Z","updated_at":"2022-04-11T18:20:20Z","mode":"test","status":"canceled","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":"WTC61774794","address":{"id":"adr_08f58c9bb9c411ec9a46ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:20:15+00:00","updated_at":"2022-04-11T18:20:15+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:20:17Z","updated_at":"2022-04-11T18:20:17Z","carrier":"USPS","pickup_id":"pickup_5451ee8718904b5f9d7faf67aa7c24a2","id":"pickuprate_2f9d75ab8de44ab9a77d36332752e442","object":"PickupRate"}]}'
         curl_info:
-            url: 'https://api.easypost.com/v2/pickups/pickup_7070dd414b7246c0b12aec71c3013485/cancel'
+            url: 'https://api.easypost.com/v2/pickups/pickup_5451ee8718904b5f9d7faf67aa7c24a2/cancel'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 719
+            header_size: 737
             request_size: 603
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 1.212934
-            namelookup_time: 0.002305
-            connect_time: 0.032932
-            pretransfer_time: 0.078026
+            total_time: 1.171937
+            namelookup_time: 0.002186
+            connect_time: 0.0614
+            pretransfer_time: 0.129852
             size_upload: 2.0
             size_download: 1159.0
-            speed_download: 955.0
+            speed_download: 988.0
             speed_upload: 1.0
             download_content_length: 1159.0
             upload_content_length: 2.0
-            starttransfer_time: 0.078031
+            starttransfer_time: 0.129855
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 192.168.1.201
-            local_port: 50686
+            local_ip: 10.130.6.21
+            local_port: 50306
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 77894
-            connect_time_us: 32932
-            namelookup_time_us: 2305
-            pretransfer_time_us: 78026
+            appconnect_time_us: 129798
+            connect_time_us: 61400
+            namelookup_time_us: 2186
+            pretransfer_time_us: 129852
             redirect_time_us: 0
-            starttransfer_time_us: 78031
-            total_time_us: 1212934
+            starttransfer_time_us: 129855
+            total_time_us: 1171937

--- a/test/cassettes/pickups/create.yml
+++ b/test/cassettes/pickups/create.yml
@@ -24,21 +24,21 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 6583cdf86250864be2b7e335004c81a6
+            x-ep-request-uuid: df63cd086254715ee786af5600239756
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
-            location: /api/v2/shipments/shp_74698991044d40e698c96b6d3ed323a1
+            location: /api/v2/shipments/shp_07da9df174de4643ba0e949e40ef1a97
             content-type: 'application/json; charset=utf-8'
             content-length: '6919'
-            etag: 'W/"8f58a5fdf0d198bd0c436d0290615950"'
-            x-runtime: '1.137208'
-            x-node: bigweb5nuq
-            x-version-label: easypost-202204071939-d894f5743c-master
+            etag: 'W/"61a56462bd4c0c704ca131dc0049d856"'
+            x-runtime: '1.036456'
+            x-node: bigweb1nuq
+            x-version-label: easypost-202204082123-da17cc1ac2-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq fde591f008', 'extlb2nuq fde591f008']
+            x-proxied: ['intlb2nuq fde591f008', 'extlb1nuq fde591f008']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"created_at":"2022-04-08T19:00:27Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361114224796","updated_at":"2022-04-08T19:00:28Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_271ff507b76e11ecb137ac1f6bc72124","object":"Address","created_at":"2022-04-08T19:00:27+00:00","updated_at":"2022-04-08T19:00:27+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":"50.00","order_id":null,"parcel":{"id":"prcl_28567fb5600c4369ad1ae89582024a42","object":"Parcel","created_at":"2022-04-08T19:00:27Z","updated_at":"2022-04-08T19:00:27Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_0815270ba5fb43e8a3cb55ccb291f0e6","created_at":"2022-04-08T19:00:27Z","updated_at":"2022-04-08T19:00:28Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-08T19:00:27Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220408/76f516d6feaf41c1ab5d62f5208ad014.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_fc12d5f304f14a2fb77448eae79c2002","object":"Rate","created_at":"2022-04-08T19:00:27Z","updated_at":"2022-04-08T19:00:27Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_74698991044d40e698c96b6d3ed323a1","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_c61806a985404b008d1edb8076b866dc","object":"Rate","created_at":"2022-04-08T19:00:27Z","updated_at":"2022-04-08T19:00:27Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_74698991044d40e698c96b6d3ed323a1","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_3de121a413ea482587a66b2e06c6126a","object":"Rate","created_at":"2022-04-08T19:00:27Z","updated_at":"2022-04-08T19:00:27Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_74698991044d40e698c96b6d3ed323a1","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_d0cd48e802084b11b13fbceab917fce6","object":"Rate","created_at":"2022-04-08T19:00:27Z","updated_at":"2022-04-08T19:00:27Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_74698991044d40e698c96b6d3ed323a1","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_fc12d5f304f14a2fb77448eae79c2002","object":"Rate","created_at":"2022-04-08T19:00:27Z","updated_at":"2022-04-08T19:00:27Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_74698991044d40e698c96b6d3ed323a1","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},"tracker":{"id":"trk_e4a933ddda6a48a49791975cb0242ac9","object":"Tracker","mode":"test","tracking_code":"9400100109361114224796","status":"unknown","status_detail":"unknown","created_at":"2022-04-08T19:00:28Z","updated_at":"2022-04-08T19:00:28Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_74698991044d40e698c96b6d3ed323a1","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2U0YTkzM2RkZGE2YTQ4YTQ5NzkxOTc1Y2IwMjQyYWM5"},"to_address":{"id":"adr_271ddbdbb76e11eca047ac1f6b0a0d1e","object":"Address","created_at":"2022-04-08T19:00:27+00:00","updated_at":"2022-04-08T19:00:27+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_271ff507b76e11ecb137ac1f6bc72124","object":"Address","created_at":"2022-04-08T19:00:27+00:00","updated_at":"2022-04-08T19:00:27+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_271ddbdbb76e11eca047ac1f6b0a0d1e","object":"Address","created_at":"2022-04-08T19:00:27+00:00","updated_at":"2022-04-08T19:00:27+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false},{"object":"Fee","type":"InsuranceFee","amount":"0.25000","charged":true,"refunded":false}],"id":"shp_74698991044d40e698c96b6d3ed323a1","object":"Shipment"}'
+        body: '{"created_at":"2022-04-11T18:20:14Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361114520515","updated_at":"2022-04-11T18:20:15Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_083b082bb9c411ec99f6ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:20:14+00:00","updated_at":"2022-04-11T18:20:14+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":"50.00","order_id":null,"parcel":{"id":"prcl_600df1bd858a497b828f210ec3341235","object":"Parcel","created_at":"2022-04-11T18:20:14Z","updated_at":"2022-04-11T18:20:14Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_4490bcc05f0143e99ec0380a28ed288e","created_at":"2022-04-11T18:20:14Z","updated_at":"2022-04-11T18:20:15Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-11T18:20:14Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220411/4591311d29094dd4b9eada19ecc12baf.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_f8b7589aea2e49e9b5cf90a7d1a0fc20","object":"Rate","created_at":"2022-04-11T18:20:14Z","updated_at":"2022-04-11T18:20:14Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_07da9df174de4643ba0e949e40ef1a97","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_7e46460891504d69b9134ec5f84e6f15","object":"Rate","created_at":"2022-04-11T18:20:14Z","updated_at":"2022-04-11T18:20:14Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_07da9df174de4643ba0e949e40ef1a97","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_ee477b076fe84ef794c7f9677756f414","object":"Rate","created_at":"2022-04-11T18:20:14Z","updated_at":"2022-04-11T18:20:14Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_07da9df174de4643ba0e949e40ef1a97","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_eca3c53642004f549a208ec3b281751b","object":"Rate","created_at":"2022-04-11T18:20:14Z","updated_at":"2022-04-11T18:20:14Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_07da9df174de4643ba0e949e40ef1a97","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_f8b7589aea2e49e9b5cf90a7d1a0fc20","object":"Rate","created_at":"2022-04-11T18:20:15Z","updated_at":"2022-04-11T18:20:15Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_07da9df174de4643ba0e949e40ef1a97","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},"tracker":{"id":"trk_b7abc8ae947642b5a17a7d7f0beda627","object":"Tracker","mode":"test","tracking_code":"9400100109361114520515","status":"unknown","status_detail":"unknown","created_at":"2022-04-11T18:20:15Z","updated_at":"2022-04-11T18:20:15Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_07da9df174de4643ba0e949e40ef1a97","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2I3YWJjOGFlOTQ3NjQyYjVhMTdhN2Q3ZjBiZWRhNjI3"},"to_address":{"id":"adr_08392fb4b9c411ec9457ac1f6bc7bdc6","object":"Address","created_at":"2022-04-11T18:20:14+00:00","updated_at":"2022-04-11T18:20:14+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_083b082bb9c411ec99f6ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:20:14+00:00","updated_at":"2022-04-11T18:20:14+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_08392fb4b9c411ec9457ac1f6bc7bdc6","object":"Address","created_at":"2022-04-11T18:20:14+00:00","updated_at":"2022-04-11T18:20:14+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false},{"object":"Fee","type":"InsuranceFee","amount":"0.25000","charged":true,"refunded":false}],"id":"shp_07da9df174de4643ba0e949e40ef1a97","object":"Shipment"}'
         curl_info:
             url: 'https://api.easypost.com/v2/shipments'
             content_type: 'application/json; charset=utf-8'
@@ -48,35 +48,35 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 1.244617
-            namelookup_time: 0.004511
-            connect_time: 0.035623
-            pretransfer_time: 0.074378
+            total_time: 1.230213
+            namelookup_time: 0.010138
+            connect_time: 0.068448
+            pretransfer_time: 0.13446
             size_upload: 528.0
             size_download: 6919.0
-            speed_download: 5559.0
-            speed_upload: 424.0
+            speed_download: 5624.0
+            speed_upload: 429.0
             download_content_length: 6919.0
             upload_content_length: 528.0
-            starttransfer_time: 0.07438
+            starttransfer_time: 0.134463
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 192.168.1.201
-            local_port: 50682
+            local_ip: 10.130.6.21
+            local_port: 50301
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 74303
-            connect_time_us: 35623
-            namelookup_time_us: 4511
-            pretransfer_time_us: 74378
+            appconnect_time_us: 134328
+            connect_time_us: 68448
+            namelookup_time_us: 10138
+            pretransfer_time_us: 134460
             redirect_time_us: 0
-            starttransfer_time_us: 74380
-            total_time_us: 1244617
+            starttransfer_time_us: 134463
+            total_time_us: 1230213
 -
     request:
         method: POST
@@ -89,7 +89,7 @@
             User-Agent: ''
             X-Client-User-Agent: ''
             EasyPost-Version: '2'
-        body: '{"pickup":{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022\/04\/11","max_datetime":"2022\/04\/11","instructions":"Pickup at front door","shipment":{"id":"shp_74698991044d40e698c96b6d3ed323a1"}}}'
+        body: '{"pickup":{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-04-12","max_datetime":"2022-04-12","instructions":"Pickup at front door","shipment":{"id":"shp_07da9df174de4643ba0e949e40ef1a97"}}}'
     response:
         status:
             http_version: '2'
@@ -102,20 +102,20 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 6583cdf86250864ce2b7e336004c825a
+            x-ep-request-uuid: df63cd096254715fe786af5700239807
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '1149'
-            etag: 'W/"88a7565d486534fede7cdf2e6b65640e"'
-            x-runtime: '1.093645'
-            x-node: bigweb1nuq
-            x-version-label: easypost-202204071939-d894f5743c-master
+            etag: 'W/"fb34023f4887501ea84c2959d881b235"'
+            x-runtime: '1.531368'
+            x-node: bigweb3nuq
+            x-version-label: easypost-202204082123-da17cc1ac2-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq fde591f008', 'extlb2nuq fde591f008']
+            x-proxied: ['intlb2nuq fde591f008', 'extlb1nuq fde591f008']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"pickup_7070dd414b7246c0b12aec71c3013485","object":"Pickup","created_at":"2022-04-08T19:00:28Z","updated_at":"2022-04-08T19:00:28Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-11T00:00:00Z","max_datetime":"2022-04-11T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":null,"address":{"id":"adr_27dd58e7b76e11eca07cac1f6b0a0d1e","object":"Address","created_at":"2022-04-08T19:00:28+00:00","updated_at":"2022-04-08T19:00:28+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-08T19:00:29Z","updated_at":"2022-04-08T19:00:29Z","carrier":"USPS","pickup_id":"pickup_7070dd414b7246c0b12aec71c3013485","id":"pickuprate_637cccd602ec4d098e8c66c8980be4dc","object":"PickupRate"}]}'
+        body: '{"id":"pickup_5451ee8718904b5f9d7faf67aa7c24a2","object":"Pickup","created_at":"2022-04-11T18:20:15Z","updated_at":"2022-04-11T18:20:15Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":null,"address":{"id":"adr_08f58c9bb9c411ec9a46ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:20:15+00:00","updated_at":"2022-04-11T18:20:15+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:20:17Z","updated_at":"2022-04-11T18:20:17Z","carrier":"USPS","pickup_id":"pickup_5451ee8718904b5f9d7faf67aa7c24a2","id":"pickuprate_2f9d75ab8de44ab9a77d36332752e442","object":"PickupRate"}]}'
         curl_info:
             url: 'https://api.easypost.com/v2/pickups'
             content_type: 'application/json; charset=utf-8'
@@ -125,32 +125,32 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 1.200047
-            namelookup_time: 0.003241
-            connect_time: 0.034053
-            pretransfer_time: 0.074155
-            size_upload: 340.0
+            total_time: 1.723392
+            namelookup_time: 0.002243
+            connect_time: 0.061149
+            pretransfer_time: 0.131815
+            size_upload: 336.0
             size_download: 1149.0
-            speed_download: 957.0
-            speed_upload: 283.0
+            speed_download: 666.0
+            speed_upload: 194.0
             download_content_length: 1149.0
-            upload_content_length: 340.0
-            starttransfer_time: 0.074157
+            upload_content_length: 336.0
+            starttransfer_time: 0.131819
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 192.168.1.201
-            local_port: 50683
+            local_ip: 10.130.6.21
+            local_port: 50302
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 74079
-            connect_time_us: 34053
-            namelookup_time_us: 3241
-            pretransfer_time_us: 74155
+            appconnect_time_us: 131719
+            connect_time_us: 61149
+            namelookup_time_us: 2243
+            pretransfer_time_us: 131815
             redirect_time_us: 0
-            starttransfer_time_us: 74157
-            total_time_us: 1200047
+            starttransfer_time_us: 131819
+            total_time_us: 1723392

--- a/test/cassettes/pickups/retrieve.yml
+++ b/test/cassettes/pickups/retrieve.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/pickups/pickup_7070dd414b7246c0b12aec71c3013485'
+        url: 'https://api.easypost.com/v2/pickups/pickup_5451ee8718904b5f9d7faf67aa7c24a2'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -23,22 +23,22 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 6583cdf86250864de2b7e337004c8307
+            x-ep-request-uuid: df63cd0962547161e786af58002398da
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '1149'
-            etag: 'W/"88a7565d486534fede7cdf2e6b65640e"'
-            x-runtime: '0.070233'
-            x-node: bigweb6nuq
-            x-version-label: easypost-202204071939-d894f5743c-master
+            etag: 'W/"fb34023f4887501ea84c2959d881b235"'
+            x-runtime: '0.069650'
+            x-node: bigweb2nuq
+            x-version-label: easypost-202204082123-da17cc1ac2-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq fde591f008', 'extlb2nuq fde591f008']
+            x-proxied: ['intlb2nuq fde591f008', 'extlb1nuq fde591f008']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"pickup_7070dd414b7246c0b12aec71c3013485","object":"Pickup","created_at":"2022-04-08T19:00:28Z","updated_at":"2022-04-08T19:00:28Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-11T00:00:00Z","max_datetime":"2022-04-11T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":null,"address":{"id":"adr_27dd58e7b76e11eca07cac1f6b0a0d1e","object":"Address","created_at":"2022-04-08T19:00:28+00:00","updated_at":"2022-04-08T19:00:28+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-08T19:00:29Z","updated_at":"2022-04-08T19:00:29Z","carrier":"USPS","pickup_id":"pickup_7070dd414b7246c0b12aec71c3013485","id":"pickuprate_637cccd602ec4d098e8c66c8980be4dc","object":"PickupRate"}]}'
+        body: '{"id":"pickup_5451ee8718904b5f9d7faf67aa7c24a2","object":"Pickup","created_at":"2022-04-11T18:20:15Z","updated_at":"2022-04-11T18:20:15Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":null,"address":{"id":"adr_08f58c9bb9c411ec9a46ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:20:15+00:00","updated_at":"2022-04-11T18:20:15+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:20:17Z","updated_at":"2022-04-11T18:20:17Z","carrier":"USPS","pickup_id":"pickup_5451ee8718904b5f9d7faf67aa7c24a2","id":"pickuprate_2f9d75ab8de44ab9a77d36332752e442","object":"PickupRate"}]}'
         curl_info:
-            url: 'https://api.easypost.com/v2/pickups/pickup_7070dd414b7246c0b12aec71c3013485'
+            url: 'https://api.easypost.com/v2/pickups/pickup_5451ee8718904b5f9d7faf67aa7c24a2'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 719
@@ -46,32 +46,32 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.181909
-            namelookup_time: 0.002651
-            connect_time: 0.033804
-            pretransfer_time: 0.078714
+            total_time: 0.267987
+            namelookup_time: 0.001743
+            connect_time: 0.061457
+            pretransfer_time: 0.132788
             size_upload: 0.0
             size_download: 1149.0
-            speed_download: 6316.0
+            speed_download: 4287.0
             speed_upload: 0.0
             download_content_length: 1149.0
             upload_content_length: 0.0
-            starttransfer_time: 0.181843
+            starttransfer_time: 0.26795
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 192.168.1.201
-            local_port: 50684
+            local_ip: 10.130.6.21
+            local_port: 50303
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 78566
-            connect_time_us: 33804
-            namelookup_time_us: 2651
-            pretransfer_time_us: 78714
+            appconnect_time_us: 132700
+            connect_time_us: 61457
+            namelookup_time_us: 1743
+            pretransfer_time_us: 132788
             redirect_time_us: 0
-            starttransfer_time_us: 181843
-            total_time_us: 181909
+            starttransfer_time_us: 267950
+            total_time_us: 267987

--- a/test/cassettes/reports/all.yml
+++ b/test/cassettes/reports/all.yml
@@ -23,55 +23,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 58b8c5bc62507d38e2b7d59000422c74
+            x-ep-request-uuid: df63cd0b625471bae786af9a0023b5f1
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
-            content-length: '3469'
-            etag: 'W/"2aa8df38a9b969d313c1d048f74c5574"'
-            x-runtime: '0.038495'
-            x-node: bigweb3nuq
-            x-version-label: easypost-202204071939-d894f5743c-master
+            content-length: '2263'
+            etag: 'W/"d3081de5c56f1a9fee38714d43d1160e"'
+            x-runtime: '0.066477'
+            x-node: bigweb5nuq
+            x-version-label: easypost-202204082123-da17cc1ac2-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq fde591f008', 'intlb1wdc fde591f008', 'extlb3wdc fde591f008']
+            x-proxied: ['intlb2nuq fde591f008', 'extlb1nuq fde591f008']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"reports":[{"id":"shprep_216e94c28f71419bbc7ce994a10ffa2a","object":"ShipmentReport","created_at":"2022-03-23T21:23:39Z","updated_at":"2022-03-23T21:23:39Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220323/597884177c0a451bafbb94815f2c3ea7.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220408%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220408T182144Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=63dc334fcc1ee94940c07f8831e17c61e853205138b5a79bc8c78a164ab4324c","url_expires_at":"2022-04-08T18:22:14Z","include_children":false},{"id":"shprep_fac059e5e2504e1eb78ee9ff68f638cb","object":"ShipmentReport","created_at":"2022-03-23T21:23:39Z","updated_at":"2022-03-23T21:23:39Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220323/db93a13deb844489987de42795166c10.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220408%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220408T182144Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=2e79c7b34644130ce1be6e18698535332b4db28869b47ba8274bf699708a2871","url_expires_at":"2022-04-08T18:22:14Z","include_children":false},{"id":"shprep_acec53ff28f5409a815797a270a53212","object":"ShipmentReport","created_at":"2022-03-23T21:23:38Z","updated_at":"2022-03-23T21:23:38Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220323/eb057116c7634692be41b4c932befd58.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220408%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220408T182144Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=cebea049bdd21c811e1baf0c8b2bdb6898d15d19119333f7dea08c02d461b02f","url_expires_at":"2022-04-08T18:22:14Z","include_children":false},{"id":"shprep_08ac4b4736de41b9ade117e92a4ff15e","object":"ShipmentReport","created_at":"2022-03-23T18:00:03Z","updated_at":"2022-03-23T18:00:03Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220323/b16636cbcd5c40b9977828855501aee4.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220408%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220408T182144Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=3c5cfbd3db2e7dc5b44836c73e83fdf01e107dbb41746fd6d44c5161fed3075c","url_expires_at":"2022-04-08T18:22:14Z","include_children":false},{"id":"shprep_ca4c6b862125463199704b07a10afde4","object":"ShipmentReport","created_at":"2022-03-23T18:00:01Z","updated_at":"2022-03-23T18:00:01Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220323/7cb7c6f3674e467b931dff0d5f2755a4.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220408%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220408T182144Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=dcbeab01bedcd0ff7dcd915063c1a03ae98f9c0d2d446969168c56c851a83abf","url_expires_at":"2022-04-08T18:22:14Z","include_children":false}],"has_more":true}'
+        body: '{"reports":[{"id":"shprep_a2fe26e919b54a728bf0b40c9fac4b11","object":"ShipmentReport","created_at":"2022-04-11T18:21:46Z","updated_at":"2022-04-11T18:21:46Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false},{"id":"shprep_43d58d73bc684031af5acec47cf26d45","object":"ShipmentReport","created_at":"2022-04-11T18:21:46Z","updated_at":"2022-04-11T18:21:46Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false},{"id":"shprep_37d7c033c52f4e05b285f76f728f1aaa","object":"ShipmentReport","created_at":"2022-04-11T18:21:46Z","updated_at":"2022-04-11T18:21:46Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false},{"id":"shprep_bcdeac50a93345d4bc07e3212d70f902","object":"ShipmentReport","created_at":"2022-04-11T18:20:22Z","updated_at":"2022-04-11T18:20:22Z","start_date":"2022-04-09","end_date":"2022-04-11","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220411/192aefe003b04703bcc65e98bff58feb.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220411%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220411T182146Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=5d283a66931e4082124be89a478d9b8e5e2e24f01cc23c0c4d390b800d5456b1","url_expires_at":"2022-04-11T18:22:16Z","include_children":false},{"id":"shprep_5fc94b7852834c0bacbfde291e71e66b","object":"ShipmentReport","created_at":"2022-04-11T18:20:22Z","updated_at":"2022-04-11T18:20:22Z","start_date":"2022-04-09","end_date":"2022-04-11","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220411/5cf62bb05012404fad28cfdf9382d30b.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220411%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220411T182146Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=3617b3b77549a089a40bfb12fa6812817d99aeeff7cec692a89fbb08ada59179","url_expires_at":"2022-04-11T18:22:16Z","include_children":false}],"has_more":true}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/shipment/?type=shipment&page_size=5'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 752
+            header_size: 719
             request_size: 572
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.329954
-            namelookup_time: 0.001283
-            connect_time: 0.052939
-            pretransfer_time: 0.113222
+            total_time: 0.258142
+            namelookup_time: 0.002622
+            connect_time: 0.062014
+            pretransfer_time: 0.128794
             size_upload: 0.0
-            size_download: 3469.0
-            speed_download: 10513.0
+            size_download: 2263.0
+            speed_download: 8766.0
             speed_upload: 0.0
-            download_content_length: 3469.0
+            download_content_length: 2263.0
             upload_content_length: 0.0
-            starttransfer_time: 0.329923
+            starttransfer_time: 0.258111
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.47.33.18
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 192.168.1.201
-            local_port: 50317
+            local_ip: 10.130.6.21
+            local_port: 50323
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 113135
-            connect_time_us: 52939
-            namelookup_time_us: 1283
-            pretransfer_time_us: 113222
+            appconnect_time_us: 128724
+            connect_time_us: 62014
+            namelookup_time_us: 2622
+            pretransfer_time_us: 128794
             redirect_time_us: 0
-            starttransfer_time_us: 329923
-            total_time_us: 329954
+            starttransfer_time_us: 258111
+            total_time_us: 258142

--- a/test/cassettes/reports/createCustomAdditionalColumnReport.yml
+++ b/test/cassettes/reports/createCustomAdditionalColumnReport.yml
@@ -11,7 +11,7 @@
             User-Agent: ''
             X-Client-User-Agent: ''
             EasyPost-Version: '2'
-        body: '{"start_date":"2022\/04\/06","end_date":"2022\/04\/08","type":"shipment","additional_columns":["from_name","from_company"]}'
+        body: '{"start_date":"2022-04-09","end_date":"2022-04-09","type":"shipment","additional_columns":["from_name","from_company"]}'
     response:
         status:
             http_version: '2'
@@ -24,55 +24,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 6583cdfc62507d39e2b7d5ab00499830
+            x-ep-request-uuid: df63cd0e625471bae786af980023b5cf
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '283'
-            etag: 'W/"24879792b1903060fe28fdbf8fd63475"'
-            x-runtime: '0.039423'
-            x-node: bigweb9nuq
-            x-version-label: easypost-202204071939-d894f5743c-master
+            etag: 'W/"aec6ebec2529ef6df47babaeacb0ce23"'
+            x-runtime: '0.038784'
+            x-node: bigweb7nuq
+            x-version-label: easypost-202204082123-da17cc1ac2-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq fde591f008', 'extlb2nuq fde591f008']
+            x-canary: direct
+            x-proxied: ['intlb1nuq fde591f008', 'extlb1nuq fde591f008']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_005709ef76314bc4b630072efd3d91ea","object":"ShipmentReport","created_at":"2022-04-08T18:21:45Z","updated_at":"2022-04-08T18:21:45Z","start_date":"2022-03-08","end_date":"2022-04-08","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shprep_43d58d73bc684031af5acec47cf26d45","object":"ShipmentReport","created_at":"2022-04-11T18:21:46Z","updated_at":"2022-04-11T18:21:46Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/shipment/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 718
+            header_size: 736
             request_size: 568
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.145333
-            namelookup_time: 0.002693
-            connect_time: 0.033486
-            pretransfer_time: 0.073702
-            size_upload: 123.0
+            total_time: 0.237816
+            namelookup_time: 0.003365
+            connect_time: 0.0628
+            pretransfer_time: 0.135494
+            size_upload: 119.0
             size_download: 283.0
-            speed_download: 1947.0
-            speed_upload: 846.0
+            speed_download: 1189.0
+            speed_upload: 500.0
             download_content_length: 283.0
-            upload_content_length: 123.0
-            starttransfer_time: 0.073705
+            upload_content_length: 119.0
+            starttransfer_time: 0.135499
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 192.168.1.201
+            local_ip: 10.130.6.21
             local_port: 50321
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 73619
-            connect_time_us: 33486
-            namelookup_time_us: 2693
-            pretransfer_time_us: 73702
+            appconnect_time_us: 135362
+            connect_time_us: 62800
+            namelookup_time_us: 3365
+            pretransfer_time_us: 135494
             redirect_time_us: 0
-            starttransfer_time_us: 73705
-            total_time_us: 145333
+            starttransfer_time_us: 135499
+            total_time_us: 237816

--- a/test/cassettes/reports/createCustomColumnReport.yml
+++ b/test/cassettes/reports/createCustomColumnReport.yml
@@ -11,7 +11,7 @@
             User-Agent: ''
             X-Client-User-Agent: ''
             EasyPost-Version: '2'
-        body: '{"start_date":"2022\/04\/06","end_date":"2022\/04\/08","type":"shipment","columns":["usps_zone"]}'
+        body: '{"start_date":"2022-04-09","end_date":"2022-04-09","type":"shipment","columns":["usps_zone"]}'
     response:
         status:
             http_version: '2'
@@ -24,20 +24,20 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 6583cdf962507d39e2b7d5aa00499821
+            x-ep-request-uuid: df63cd0b625471bae786af970023b5b4
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '283'
-            etag: 'W/"17c29513f452ccb6a2c97be8cc5545ac"'
-            x-runtime: '0.048962'
+            etag: 'W/"0a23b3bfe32cbb3de4161d7477d91cfc"'
+            x-runtime: '0.043305'
             x-node: bigweb5nuq
-            x-version-label: easypost-202204071939-d894f5743c-master
+            x-version-label: easypost-202204082123-da17cc1ac2-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq fde591f008', 'extlb2nuq fde591f008']
+            x-proxied: ['intlb2nuq fde591f008', 'extlb1nuq fde591f008']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_d1d8adb614ca4ea89c6d4d4df9e88eeb","object":"ShipmentReport","created_at":"2022-04-08T18:21:45Z","updated_at":"2022-04-08T18:21:45Z","start_date":"2022-03-08","end_date":"2022-04-08","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shprep_37d7c033c52f4e05b285f76f728f1aaa","object":"ShipmentReport","created_at":"2022-04-11T18:21:46Z","updated_at":"2022-04-11T18:21:46Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/shipment/'
             content_type: 'application/json; charset=utf-8'
@@ -47,32 +47,32 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.14979
-            namelookup_time: 0.001323
-            connect_time: 0.030342
-            pretransfer_time: 0.069933
-            size_upload: 97.0
+            total_time: 0.239679
+            namelookup_time: 0.004593
+            connect_time: 0.062769
+            pretransfer_time: 0.128854
+            size_upload: 93.0
             size_download: 283.0
-            speed_download: 1889.0
-            speed_upload: 647.0
+            speed_download: 1180.0
+            speed_upload: 388.0
             download_content_length: 283.0
-            upload_content_length: 97.0
-            starttransfer_time: 0.069935
+            upload_content_length: 93.0
+            starttransfer_time: 0.128857
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 192.168.1.201
+            local_ip: 10.130.6.21
             local_port: 50320
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 69861
-            connect_time_us: 30342
-            namelookup_time_us: 1323
-            pretransfer_time_us: 69933
+            appconnect_time_us: 128783
+            connect_time_us: 62769
+            namelookup_time_us: 4593
+            pretransfer_time_us: 128854
             redirect_time_us: 0
-            starttransfer_time_us: 69935
-            total_time_us: 149790
+            starttransfer_time_us: 128857
+            total_time_us: 239679

--- a/test/cassettes/reports/createReport.yml
+++ b/test/cassettes/reports/createReport.yml
@@ -11,7 +11,7 @@
             User-Agent: ''
             X-Client-User-Agent: ''
             EasyPost-Version: '2'
-        body: '{"start_date":"2022\/04\/06","end_date":"2022\/04\/08","type":"shipment"}'
+        body: '{"start_date":"2022-04-09","end_date":"2022-04-09","type":"shipment"}'
     response:
         status:
             http_version: '2'
@@ -24,55 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 58b8c5ba62507d38e2b7d59100422c92
+            x-ep-request-uuid: df63cd0d625471bae786af990023b5e1
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '283'
-            etag: 'W/"4f7cb0341275c622b7867de89b525c9a"'
-            x-runtime: '0.035071'
-            x-node: bigweb3nuq
-            x-version-label: easypost-202204071939-d894f5743c-master
+            etag: 'W/"55055204600fb98502581d6b03bbe395"'
+            x-runtime: '0.038451'
+            x-node: bigweb2nuq
+            x-version-label: easypost-202204082123-da17cc1ac2-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq fde591f008', 'intlb2wdc fde591f008', 'extlb3wdc fde591f008']
+            x-proxied: ['intlb1nuq fde591f008', 'extlb1nuq fde591f008']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_9b26e8cb64e6498eba8b7fbfc8a0550a","object":"ShipmentReport","created_at":"2022-04-08T18:21:45Z","updated_at":"2022-04-08T18:21:45Z","start_date":"2022-03-08","end_date":"2022-04-08","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shprep_a2fe26e919b54a728bf0b40c9fac4b11","object":"ShipmentReport","created_at":"2022-04-11T18:21:46Z","updated_at":"2022-04-11T18:21:46Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
             url: 'https://api.easypost.com/v2/reports/shipment/'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 751
+            header_size: 718
             request_size: 567
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.354584
-            namelookup_time: 0.002063
-            connect_time: 0.06035
-            pretransfer_time: 0.134849
-            size_upload: 73.0
+            total_time: 0.236535
+            namelookup_time: 0.001857
+            connect_time: 0.061285
+            pretransfer_time: 0.137335
+            size_upload: 69.0
             size_download: 283.0
-            speed_download: 798.0
-            speed_upload: 205.0
+            speed_download: 1196.0
+            speed_upload: 291.0
             download_content_length: 283.0
-            upload_content_length: 73.0
-            starttransfer_time: 0.134854
+            upload_content_length: 69.0
+            starttransfer_time: 0.137338
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.47.33.18
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 192.168.1.201
-            local_port: 50318
+            local_ip: 10.130.6.21
+            local_port: 50322
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 134724
-            connect_time_us: 60350
-            namelookup_time_us: 2063
-            pretransfer_time_us: 134849
+            appconnect_time_us: 137271
+            connect_time_us: 61285
+            namelookup_time_us: 1857
+            pretransfer_time_us: 137335
             redirect_time_us: 0
-            starttransfer_time_us: 134854
-            total_time_us: 354584
+            starttransfer_time_us: 137338
+            total_time_us: 236535

--- a/test/cassettes/reports/retrieveReport.yml
+++ b/test/cassettes/reports/retrieveReport.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/reports/shprep_9b26e8cb64e6498eba8b7fbfc8a0550a'
+        url: 'https://api.easypost.com/v2/reports/shprep_a2fe26e919b54a728bf0b40c9fac4b11'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -23,22 +23,22 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 6583cdf962507d39e2b7d5ac0049983c
+            x-ep-request-uuid: df63cd0a625471bbe786af9b0023b601
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '285'
-            etag: 'W/"f303275ad44236caafd839fa301f1e88"'
-            x-runtime: '0.036347'
+            etag: 'W/"baa5024d31070b0409cf96df6747d384"'
+            x-runtime: '0.034123'
             x-node: bigweb2nuq
-            x-version-label: easypost-202204071939-d894f5743c-master
+            x-version-label: easypost-202204082123-da17cc1ac2-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq fde591f008', 'extlb2nuq fde591f008']
+            x-proxied: ['intlb1nuq fde591f008', 'extlb1nuq fde591f008']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_9b26e8cb64e6498eba8b7fbfc8a0550a","object":"ShipmentReport","created_at":"2022-04-08T18:21:45Z","updated_at":"2022-04-08T18:21:45Z","start_date":"2022-03-08","end_date":"2022-04-08","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shprep_a2fe26e919b54a728bf0b40c9fac4b11","object":"ShipmentReport","created_at":"2022-04-11T18:21:46Z","updated_at":"2022-04-11T18:21:46Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shprep_9b26e8cb64e6498eba8b7fbfc8a0550a'
+            url: 'https://api.easypost.com/v2/reports/shprep_a2fe26e919b54a728bf0b40c9fac4b11'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 718
@@ -46,32 +46,32 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.14635
-            namelookup_time: 0.001431
-            connect_time: 0.032491
-            pretransfer_time: 0.077021
+            total_time: 0.236141
+            namelookup_time: 0.002478
+            connect_time: 0.062073
+            pretransfer_time: 0.1411
             size_upload: 0.0
             size_download: 285.0
-            speed_download: 1947.0
+            speed_download: 1206.0
             speed_upload: 0.0
             download_content_length: 285.0
             upload_content_length: 0.0
-            starttransfer_time: 0.146318
+            starttransfer_time: 0.236103
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 192.168.1.201
-            local_port: 50322
+            local_ip: 10.130.6.21
+            local_port: 50324
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 76899
-            connect_time_us: 32491
-            namelookup_time_us: 1431
-            pretransfer_time_us: 77021
+            appconnect_time_us: 140995
+            connect_time_us: 62073
+            namelookup_time_us: 2478
+            pretransfer_time_us: 141100
             redirect_time_us: 0
-            starttransfer_time_us: 146318
-            total_time_us: 146350
+            starttransfer_time_us: 236103
+            total_time_us: 236141


### PR DESCRIPTION
I was too trusting of VCR to play nice with dynamic dates in fixtures which broke the master branch build. Going back to hard-coded dates in the test suite but simplifying how many date fixtures we need so that recorded cassettes stay happy regardless of when it's run.