### PR TITLE
chore: replace patch method with put

### DIFF
--- a/lib/EasyPost/EasypostResource.php
+++ b/lib/EasyPost/EasypostResource.php
@@ -172,7 +172,7 @@ abstract class EasypostResource extends EasyPostObject
             $requestor = new Requestor($this->_apiKey);
             $url = $this->instanceUrl();
             $params = [self::className($class) => $this->_unsavedValues];
-            list($response, $apiKey) = $requestor->request('patch', $url, $params);
+            list($response, $apiKey) = $requestor->request('put', $url, $params);
             $this->refreshFrom($response, $apiKey);
         }
 

--- a/lib/EasyPost/Requestor.php
+++ b/lib/EasyPost/Requestor.php
@@ -210,7 +210,7 @@ class Requestor
             } else {
                 $curlOptions[CURLOPT_POSTFIELDS] = json_encode($params);
             }
-        } elseif ($method == 'patch' || $method == 'put') {
+        } elseif ($method == 'put') {
             $curlOptions[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
             $curlOptions[CURLOPT_POSTFIELDS] = json_encode($params);
         } elseif ($method == 'delete') {

--- a/test/cassettes/carrier_accounts/create.yml
+++ b/test/cassettes/carrier_accounts/create.yml
@@ -24,20 +24,20 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 71d543bb62508c9ee2b7eaf00048a0a9
+            x-ep-request-uuid: 326a20d46260d38ae2b97ed40045dae8
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '432'
-            etag: 'W/"0324b19bcee9d12cec11ef93542431fa"'
-            x-runtime: '0.113233'
-            x-node: bigweb5nuq
-            x-version-label: easypost-202204071939-d894f5743c-master
+            etag: 'W/"e65e233ed272471f8614b20b5cce20d1"'
+            x-runtime: '0.187116'
+            x-node: bigweb3nuq
+            x-version-label: easypost-202204201907-3f5a844a4c-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq fde591f008', 'intlb1wdc fde591f008', 'extlb1wdc fde591f008']
+            x-proxied: ['intlb2nuq fde591f008', 'intlb2wdc fde591f008', 'extlb1wdc fde591f008']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"ca_131a01ff391244f5bc60431f17b67f14","object":"CarrierAccount","type":"UpsAccount","clone":false,"created_at":"2022-04-08T19:27:26Z","updated_at":"2022-04-08T19:27:26Z","description":"UPS Account","reference":null,"readable":"UPS","logo":null,"fields":{"credentials":{"account_number":{"visibility":"readonly","label":"UPS Account Number","value":"A1A1A1"}}},"credentials":{"account_number":"A1A1A1"},"test_credentials":null}'
+        body: '{"id":"ca_e2f4d31bdf9b4ab785d6650d5f82a1cf","object":"CarrierAccount","type":"UpsAccount","clone":false,"created_at":"2022-04-21T03:46:19Z","updated_at":"2022-04-21T03:46:19Z","description":"UPS Account","reference":null,"readable":"UPS","logo":null,"fields":{"credentials":{"account_number":{"visibility":"readonly","label":"UPS Account Number","value":"A1A1A1"}}},"credentials":{"account_number":"A1A1A1"},"test_credentials":null}'
         curl_info:
             url: 'https://api.easypost.com/v2/carrier_accounts'
             content_type: 'application/json; charset=utf-8'
@@ -47,32 +47,32 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.415945
-            namelookup_time: 0.005449
-            connect_time: 0.058908
-            pretransfer_time: 0.121373
+            total_time: 0.496214
+            namelookup_time: 0.001541
+            connect_time: 0.057832
+            pretransfer_time: 0.123934
             size_upload: 154.0
             size_download: 432.0
-            speed_download: 1038.0
-            speed_upload: 370.0
+            speed_download: 870.0
+            speed_upload: 310.0
             download_content_length: 432.0
             upload_content_length: 154.0
-            starttransfer_time: 0.121377
+            starttransfer_time: 0.123936
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.47.33.19
             certinfo: {  }
             primary_port: 443
-            local_ip: 192.168.1.201
-            local_port: 50821
+            local_ip: 192.168.1.245
+            local_port: 53408
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 121280
-            connect_time_us: 58908
-            namelookup_time_us: 5449
-            pretransfer_time_us: 121373
+            appconnect_time_us: 123839
+            connect_time_us: 57832
+            namelookup_time_us: 1541
+            pretransfer_time_us: 123934
             redirect_time_us: 0
-            starttransfer_time_us: 121377
-            total_time_us: 415945
+            starttransfer_time_us: 123936
+            total_time_us: 496214

--- a/test/cassettes/carrier_accounts/delete.yml
+++ b/test/cassettes/carrier_accounts/delete.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: DELETE
-        url: 'https://api.easypost.com/v2/carrier_accounts/ca_131a01ff391244f5bc60431f17b67f14'
+        url: 'https://api.easypost.com/v2/carrier_accounts/ca_e2f4d31bdf9b4ab785d6650d5f82a1cf'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -23,22 +23,22 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 4ef5cdf162508c9fe2b7eaf4004ed4be
+            x-ep-request-uuid: 401d18d86260d38be2b97eee004b8906
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '2'
             etag: 'W/"44136fa355b3678a1146ad16f7e8649e"'
-            x-runtime: '0.112583'
-            x-node: bigweb3nuq
-            x-version-label: easypost-202204071939-d894f5743c-master
+            x-runtime: '0.110407'
+            x-node: bigweb2nuq
+            x-version-label: easypost-202204201907-3f5a844a4c-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq fde591f008', 'extlb1nuq fde591f008']
+            x-proxied: ['intlb1nuq fde591f008', 'extlb2nuq fde591f008']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
         body: '{}'
         curl_info:
-            url: 'https://api.easypost.com/v2/carrier_accounts/ca_131a01ff391244f5bc60431f17b67f14'
+            url: 'https://api.easypost.com/v2/carrier_accounts/ca_e2f4d31bdf9b4ab785d6650d5f82a1cf'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 716
@@ -46,32 +46,32 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.21352
-            namelookup_time: 0.001131
-            connect_time: 0.030313
-            pretransfer_time: 0.069232
+            total_time: 0.226234
+            namelookup_time: 0.002127
+            connect_time: 0.033215
+            pretransfer_time: 0.079064
             size_upload: 0.0
             size_download: 2.0
-            speed_download: 9.0
+            speed_download: 8.0
             speed_upload: 0.0
             download_content_length: 2.0
             upload_content_length: 0.0
-            starttransfer_time: 0.213483
+            starttransfer_time: 0.226211
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 192.168.1.201
-            local_port: 50825
+            local_ip: 192.168.1.245
+            local_port: 53411
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 69144
-            connect_time_us: 30313
-            namelookup_time_us: 1131
-            pretransfer_time_us: 69232
+            appconnect_time_us: 78919
+            connect_time_us: 33215
+            namelookup_time_us: 2127
+            pretransfer_time_us: 79064
             redirect_time_us: 0
-            starttransfer_time_us: 213483
-            total_time_us: 213520
+            starttransfer_time_us: 226211
+            total_time_us: 226234

--- a/test/cassettes/carrier_accounts/retrieve.yml
+++ b/test/cassettes/carrier_accounts/retrieve.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/carrier_accounts/ca_131a01ff391244f5bc60431f17b67f14'
+        url: 'https://api.easypost.com/v2/carrier_accounts/ca_e2f4d31bdf9b4ab785d6650d5f82a1cf'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -23,55 +23,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 71d543c062508c9ee2b7eaf10048a0c9
+            x-ep-request-uuid: 401d18d56260d38be2b97ed5004b88ea
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '432'
-            etag: 'W/"0324b19bcee9d12cec11ef93542431fa"'
-            x-runtime: '0.028358'
-            x-node: bigweb6nuq
-            x-version-label: easypost-202204071939-d894f5743c-master
+            etag: 'W/"e65e233ed272471f8614b20b5cce20d1"'
+            x-runtime: '0.028349'
+            x-node: bigweb8nuq
+            x-version-label: easypost-202204201907-3f5a844a4c-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq fde591f008', 'intlb1wdc fde591f008', 'extlb1wdc fde591f008']
+            x-proxied: ['intlb1nuq fde591f008', 'extlb2nuq fde591f008']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"ca_131a01ff391244f5bc60431f17b67f14","object":"CarrierAccount","type":"UpsAccount","clone":false,"created_at":"2022-04-08T19:27:26Z","updated_at":"2022-04-08T19:27:26Z","description":"UPS Account","reference":null,"readable":"UPS","logo":null,"fields":{"credentials":{"account_number":{"visibility":"readonly","label":"UPS Account Number","value":"A1A1A1"}}},"credentials":{"account_number":"A1A1A1"},"test_credentials":null}'
+        body: '{"id":"ca_e2f4d31bdf9b4ab785d6650d5f82a1cf","object":"CarrierAccount","type":"UpsAccount","clone":false,"created_at":"2022-04-21T03:46:19Z","updated_at":"2022-04-21T03:46:19Z","description":"UPS Account","reference":null,"readable":"UPS","logo":null,"fields":{"credentials":{"account_number":{"visibility":"readonly","label":"UPS Account Number","value":"A1A1A1"}}},"credentials":{"account_number":"A1A1A1"},"test_credentials":null}'
         curl_info:
-            url: 'https://api.easypost.com/v2/carrier_accounts/ca_131a01ff391244f5bc60431f17b67f14'
+            url: 'https://api.easypost.com/v2/carrier_accounts/ca_e2f4d31bdf9b4ab785d6650d5f82a1cf'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 751
+            header_size: 718
             request_size: 581
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.339373
-            namelookup_time: 0.001719
-            connect_time: 0.056171
-            pretransfer_time: 0.12934
+            total_time: 0.144763
+            namelookup_time: 0.001165
+            connect_time: 0.033983
+            pretransfer_time: 0.078946
             size_upload: 0.0
             size_download: 432.0
-            speed_download: 1272.0
+            speed_download: 2984.0
             speed_upload: 0.0
             download_content_length: 432.0
             upload_content_length: 0.0
-            starttransfer_time: 0.339353
+            starttransfer_time: 0.14473
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.47.33.19
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 192.168.1.201
-            local_port: 50822
+            local_ip: 192.168.1.245
+            local_port: 53409
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 129108
-            connect_time_us: 56171
-            namelookup_time_us: 1719
-            pretransfer_time_us: 129340
+            appconnect_time_us: 78823
+            connect_time_us: 33983
+            namelookup_time_us: 1165
+            pretransfer_time_us: 78946
             redirect_time_us: 0
-            starttransfer_time_us: 339353
-            total_time_us: 339373
+            starttransfer_time_us: 144730
+            total_time_us: 144763

--- a/test/cassettes/carrier_accounts/update.yml
+++ b/test/cassettes/carrier_accounts/update.yml
@@ -1,8 +1,8 @@
 
 -
     request:
-        method: PATCH
-        url: 'https://api.easypost.com/v2/carrier_accounts/ca_131a01ff391244f5bc60431f17b67f14'
+        method: PUT
+        url: 'https://api.easypost.com/v2/carrier_accounts/ca_e2f4d31bdf9b4ab785d6650d5f82a1cf'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -24,55 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 71d543c262508c9fe2b7eaf20048a0e5
+            x-ep-request-uuid: 401d18d86260d38be2b97eed004b88f1
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '442'
-            etag: 'W/"670e59938c0200bad9b3c8ec988b77fd"'
-            x-runtime: '0.186178'
-            x-node: bigweb9nuq
-            x-version-label: easypost-202204071939-d894f5743c-master
+            etag: 'W/"aabfb315e007fe81186771e1d5f8adfa"'
+            x-runtime: '0.196815'
+            x-node: bigweb4nuq
+            x-version-label: easypost-202204201907-3f5a844a4c-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq fde591f008', 'intlb2wdc fde591f008', 'extlb1wdc fde591f008']
+            x-proxied: ['intlb2nuq fde591f008', 'extlb2nuq fde591f008']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"ca_131a01ff391244f5bc60431f17b67f14","object":"CarrierAccount","type":"UpsAccount","clone":false,"created_at":"2022-04-08T19:27:26Z","updated_at":"2022-04-08T19:27:27Z","description":"My custom description","reference":null,"readable":"UPS","logo":null,"fields":{"credentials":{"account_number":{"visibility":"readonly","label":"UPS Account Number","value":"A1A1A1"}}},"credentials":{"account_number":"A1A1A1"},"test_credentials":null}'
+        body: '{"id":"ca_e2f4d31bdf9b4ab785d6650d5f82a1cf","object":"CarrierAccount","type":"UpsAccount","clone":false,"created_at":"2022-04-21T03:46:19Z","updated_at":"2022-04-21T03:46:19Z","description":"My custom description","reference":null,"readable":"UPS","logo":null,"fields":{"credentials":{"account_number":{"visibility":"readonly","label":"UPS Account Number","value":"A1A1A1"}}},"credentials":{"account_number":"A1A1A1"},"test_credentials":null}'
         curl_info:
-            url: 'https://api.easypost.com/v2/carrier_accounts/ca_131a01ff391244f5bc60431f17b67f14'
+            url: 'https://api.easypost.com/v2/carrier_accounts/ca_e2f4d31bdf9b4ab785d6650d5f82a1cf'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 751
-            request_size: 603
+            header_size: 718
+            request_size: 601
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.487984
-            namelookup_time: 0.00153
-            connect_time: 0.055906
-            pretransfer_time: 0.120209
+            total_time: 0.318449
+            namelookup_time: 0.002175
+            connect_time: 0.034198
+            pretransfer_time: 0.083072
             size_upload: 59.0
             size_download: 442.0
-            speed_download: 905.0
-            speed_upload: 120.0
+            speed_download: 1387.0
+            speed_upload: 185.0
             download_content_length: 442.0
             upload_content_length: 59.0
-            starttransfer_time: 0.120213
+            starttransfer_time: 0.083077
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.47.33.19
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 192.168.1.201
-            local_port: 50823
+            local_ip: 192.168.1.245
+            local_port: 53410
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 120100
-            connect_time_us: 55906
-            namelookup_time_us: 1530
-            pretransfer_time_us: 120209
+            appconnect_time_us: 82882
+            connect_time_us: 34198
+            namelookup_time_us: 2175
+            pretransfer_time_us: 83072
             redirect_time_us: 0
-            starttransfer_time_us: 120213
-            total_time_us: 487984
+            starttransfer_time_us: 83077
+            total_time_us: 318449

--- a/test/cassettes/users/update.yml
+++ b/test/cassettes/users/update.yml
@@ -1,7 +1,7 @@
 
 -
     request:
-        method: PATCH
+        method: PUT
         url: 'https://api.easypost.com/v2/users/user_465eab8bb86844108100be2d4d5288ab'
         headers:
             Host: api.easypost.com
@@ -24,57 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 888f660d62015c62e7874de5004b875b
+            x-ep-request-uuid: 326a20d56260d38ae2b97ed30045daca
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '1000'
             etag: 'W/"f99a18ef182f554340396415fe9d1eae"'
-            x-request-id: e62e3950-f62d-4940-9cee-fe6cd449e68e
-            x-runtime: '0.075141'
-            x-node: bigweb7nuq
-            x-version-label: easypost-202202042220-76f9648007-master
+            x-runtime: '0.055809'
+            x-node: bigweb4nuq
+            x-version-label: easypost-202204201907-3f5a844a4c-master
             x-backend: easypost
-            x-canary: direct
-            x-proxied: ['intlb1nuq 88c34981dc', 'extlb1nuq 88c34981dc']
+            x-proxied: ['intlb2nuq fde591f008', 'intlb2wdc fde591f008', 'extlb1wdc fde591f008']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
         body: '{"id":"user_465eab8bb86844108100be2d4d5288ab","object":"User","parent_id":null,"name":"EasyPost PHP Client Library Tests","phone_number":"5555555555","verified":true,"created_at":"2022-02-02T20:16:00Z","balance":"0.00000","price_per_shipment":"0.00000","recharge_amount":null,"secondary_recharge_amount":null,"recharge_threshold":null,"has_billing_method":null,"cc_fee_rate":"0.0325","default_insurance_amount":"50.00","insurance_fee_rate":"0.005","insurance_fee_minimum":"0.25","email":"dev+easypost-php@easypost.com","children":[{"id":"user_e0d4d5ab2c2545b585b1dba6ce0fb9d5","object":"User","parent_id":"user_465eab8bb86844108100be2d4d5288ab","name":"Test Child User","phone_number":"8005550100","verified":true,"created_at":"2022-02-04T23:14:02Z","children":[]},{"id":"user_3878404c0bdd4321952d4cae45c1d184","object":"User","parent_id":"user_465eab8bb86844108100be2d4d5288ab","name":"Test Child User","phone_number":"8005550100","verified":true,"created_at":"2022-02-04T23:17:24Z","children":[]}]}'
         curl_info:
             url: 'https://api.easypost.com/v2/users/user_465eab8bb86844108100be2d4d5288ab'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 789
-            request_size: 590
+            header_size: 752
+            request_size: 592
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.274274
-            namelookup_time: 0.001337
-            connect_time: 0.057929
-            pretransfer_time: 0.140639
+            total_time: 0.42208
+            namelookup_time: 0.041639
+            connect_time: 0.103402
+            pretransfer_time: 0.177184
             size_upload: 31.0
             size_download: 1000.0
-            speed_download: 3645.0
-            speed_upload: 113.0
+            speed_download: 2369.0
+            speed_upload: 73.0
             download_content_length: 1000.0
             upload_content_length: 31.0
-            starttransfer_time: 0.140655
+            starttransfer_time: 0.177187
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.47.33.19
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 51792
+            local_ip: 192.168.1.245
+            local_port: 53407
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 140463
-            connect_time_us: 57929
-            namelookup_time_us: 1337
-            pretransfer_time_us: 140639
+            appconnect_time_us: 176756
+            connect_time_us: 103402
+            namelookup_time_us: 41639
+            pretransfer_time_us: 177184
             redirect_time_us: 0
-            starttransfer_time_us: 140655
-            total_time_us: 274274
+            starttransfer_time_us: 177187
+            total_time_us: 422080


### PR DESCRIPTION
# Description

Removes the `PATCH` HTTP method as we don't use it in our API and replaces it with `PUT` since that's what our docs use (none of our other libs use PATCH either). Based on our docs, we will only partial update anyway meaning we are replicating a PATCH call even though it's PUT. Cleaning up the code here (no affect to a user) to simplify the codebase, reduce complexity, and remove confusion.

<img width="752" alt="Screen Shot 2022-04-20 at 9 51 35 PM" src="https://user-images.githubusercontent.com/39606064/164368585-99531f19-7be5-43af-a8c2-94f9b54b5378.png">

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- Rerecorded cassettes

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
