### PR TITLE
feat: adds lowest_rate to more objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## NEXT RELEASE
 
+- Adds a `lowest_rate` function to Orders and Pickups
+- Adds `Shipment::get_lowest_smartrate()` and `$shipment.lowest_smartrate()` functions
 - Removes the `params` from the `Address->verify()` method since it's non-static and unused
-- Add `columns` and `additional_columns` support to `Report->create()`
 - Removes dead conditional `message` check in `Address::create_and_verify`
 
 ## v5.0.0 (2022-02-09)

--- a/lib/EasyPost/Order.php
+++ b/lib/EasyPost/Order.php
@@ -92,4 +92,19 @@ class Order extends EasypostResource
 
         return $this;
     }
+
+    /**
+     * Get the lowest rate for the order.
+     *
+     * @param array $carriers
+     * @param array $services
+     * @return Rate
+     * @throws \EasyPost\Error
+     */
+    public function lowest_rate($carriers = [], $services = [])
+    {
+        $lowest_rate = Util::getLowestObjectRate($this, $carriers, $services);
+
+        return $lowest_rate;
+    }
 }

--- a/lib/EasyPost/Pickup.php
+++ b/lib/EasyPost/Pickup.php
@@ -89,4 +89,19 @@ class Pickup extends EasypostResource
 
         return $this;
     }
+
+    /**
+     * Get the lowest rate for the pickup.
+     *
+     * @param array $carriers
+     * @param array $services
+     * @return Rate
+     * @throws \EasyPost\Error
+     */
+    public function lowest_rate($carriers = [], $services = [])
+    {
+        $lowest_rate = Util::getLowestObjectRate($this, $carriers, $services, 'pickup_rates');
+
+        return $lowest_rate;
+    }
 }

--- a/test/EasyPost/Fixture.php
+++ b/test/EasyPost/Fixture.php
@@ -180,7 +180,7 @@ class Fixture
     // USPS only does "next-day" pickups including Saturday but not Sunday or Holidays.
     public static function basic_pickup()
     {
-        $pickup_date = '2022-04-12';
+        $pickup_date = '2022-05-04';
 
         return [
             'address' => self::basic_address(),

--- a/test/cassettes/orders/lowestRate.yml
+++ b/test/cassettes/orders/lowestRate.yml
@@ -1,0 +1,79 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/orders'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+            X-Client-User-Agent: ''
+            EasyPost-Version: '2'
+        body: '{"order":{"from_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"to_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"shipments":[{"to_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"from_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"}}]}}'
+    response:
+        status:
+            http_version: '2'
+            code: '201'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 4b8804f8627017f7e7873336001e93b1
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            location: /api/v2/orders/order_77569e3318994999993003dc2ef13e1d
+            content-type: 'application/json; charset=utf-8'
+            content-length: '8848'
+            etag: 'W/"393f2cf4ee265e0f7b5716c73bb56013"'
+            x-runtime: '0.324026'
+            x-node: bigweb9nuq
+            x-version-label: easypost-202204282028-6188e715cb-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq fde591f008', 'intlb1wdc fde591f008', 'extlb1wdc 5fac7c1107']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"mode":"test","reference":null,"is_return":false,"options":{"currency":"USD","payment":{"type":"SENDER"}},"messages":[],"created_at":"2022-05-02T17:42:15Z","updated_at":"2022-05-02T17:42:15Z","customs_info":null,"from_address":{"id":"adr_347455a9ca3f11ec93d4ac1f6bc72124","object":"Address","created_at":"2022-05-02T17:42:15+00:00","updated_at":"2022-05-02T17:42:15+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"to_address":{"id":"adr_3472fb8cca3f11ecabefac1f6bc7b362","object":"Address","created_at":"2022-05-02T17:42:15+00:00","updated_at":"2022-05-02T17:42:15+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_3472fb8cca3f11ecabefac1f6bc7b362","object":"Address","created_at":"2022-05-02T17:42:15+00:00","updated_at":"2022-05-02T17:42:15+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"return_address":{"id":"adr_347455a9ca3f11ec93d4ac1f6bc72124","object":"Address","created_at":"2022-05-02T17:42:15+00:00","updated_at":"2022-05-02T17:42:15+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"shipments":[{"created_at":"2022-05-02T17:42:15Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-05-02T17:42:15Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_347455a9ca3f11ec93d4ac1f6bc72124","object":"Address","created_at":"2022-05-02T17:42:15+00:00","updated_at":"2022-05-02T17:42:15+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":"order_77569e3318994999993003dc2ef13e1d","parcel":{"id":"prcl_254905c12a4c471dbb8f65cb64f0cdcd","object":"Parcel","created_at":"2022-05-02T17:42:15Z","updated_at":"2022-05-02T17:42:15Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_d2aed333c9464d46bbc804deee79a496","object":"Rate","created_at":"2022-05-02T17:42:15Z","updated_at":"2022-05-02T17:42:15Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_3872079616234bb9b3c2185c810b69ca","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_403c9f3118eb4c5aa1e873122cc5ab9b","object":"Rate","created_at":"2022-05-02T17:42:15Z","updated_at":"2022-05-02T17:42:15Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_3872079616234bb9b3c2185c810b69ca","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_8074358d33f44527b48e153e4443842c","object":"Rate","created_at":"2022-05-02T17:42:15Z","updated_at":"2022-05-02T17:42:15Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_3872079616234bb9b3c2185c810b69ca","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_4841ec1b85f642e4b768c1a4e3f9786e","object":"Rate","created_at":"2022-05-02T17:42:15Z","updated_at":"2022-05-02T17:42:15Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_3872079616234bb9b3c2185c810b69ca","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_3472fb8cca3f11ecabefac1f6bc7b362","object":"Address","created_at":"2022-05-02T17:42:15+00:00","updated_at":"2022-05-02T17:42:15+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_347455a9ca3f11ec93d4ac1f6bc72124","object":"Address","created_at":"2022-05-02T17:42:15+00:00","updated_at":"2022-05-02T17:42:15+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_3472fb8cca3f11ecabefac1f6bc7b362","object":"Address","created_at":"2022-05-02T17:42:15+00:00","updated_at":"2022-05-02T17:42:15+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_3872079616234bb9b3c2185c810b69ca","object":"Shipment"}],"rates":[{"id":"rate_d2aed333c9464d46bbc804deee79a496","object":"Rate","created_at":null,"updated_at":null,"mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_3872079616234bb9b3c2185c810b69ca","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_403c9f3118eb4c5aa1e873122cc5ab9b","object":"Rate","created_at":null,"updated_at":null,"mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_3872079616234bb9b3c2185c810b69ca","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_8074358d33f44527b48e153e4443842c","object":"Rate","created_at":null,"updated_at":null,"mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_3872079616234bb9b3c2185c810b69ca","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_4841ec1b85f642e4b768c1a4e3f9786e","object":"Rate","created_at":null,"updated_at":null,"mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_3872079616234bb9b3c2185c810b69ca","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"}],"id":"order_77569e3318994999993003dc2ef13e1d","object":"Order"}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/orders'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 817
+            request_size: 557
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.810532
+            namelookup_time: 0.009384
+            connect_time: 0.122433
+            pretransfer_time: 0.24627
+            size_upload: 801.0
+            size_download: 8848.0
+            speed_download: 10916.0
+            speed_upload: 988.0
+            download_content_length: 8848.0
+            upload_content_length: 801.0
+            starttransfer_time: 0.246275
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.47.33.19
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.22
+            local_port: 51102
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 246153
+            connect_time_us: 122433
+            namelookup_time_us: 9384
+            pretransfer_time_us: 246270
+            redirect_time_us: 0
+            starttransfer_time_us: 246275
+            total_time_us: 810532

--- a/test/cassettes/pickups/buy.yml
+++ b/test/cassettes/pickups/buy.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: POST
-        url: 'https://api.easypost.com/v2/pickups/pickup_5451ee8718904b5f9d7faf67aa7c24a2/buy'
+        url: 'https://api.easypost.com/v2/pickups/pickup_3a19c8e1c7c8478ebf09ad83e7052ba1/buy'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -24,55 +24,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: df63cd0b62547161e786af5900239903
+            x-ep-request-uuid: 2ed774f9627027a1e788e95e0003484a
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '1160'
-            etag: 'W/"bc510864f81206504f676fad9d7d6c15"'
-            x-runtime: '1.288440'
-            x-node: bigweb5nuq
-            x-version-label: easypost-202204082123-da17cc1ac2-master
+            etag: 'W/"3121c9197e5fb3fe3444230fbc510343"'
+            x-runtime: '1.107366'
+            x-node: bigweb7nuq
+            x-version-label: easypost-202205021749-d8209c081b-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq fde591f008', 'extlb1nuq fde591f008']
+            x-canary: direct
+            x-proxied: ['intlb2nuq fde591f008', 'extlb2nuq 5fac7c1107']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"pickup_5451ee8718904b5f9d7faf67aa7c24a2","object":"Pickup","created_at":"2022-04-11T18:20:15Z","updated_at":"2022-04-11T18:20:18Z","mode":"test","status":"scheduled","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":"WTC61774794","address":{"id":"adr_08f58c9bb9c411ec9a46ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:20:15+00:00","updated_at":"2022-04-11T18:20:15+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:20:17Z","updated_at":"2022-04-11T18:20:17Z","carrier":"USPS","pickup_id":"pickup_5451ee8718904b5f9d7faf67aa7c24a2","id":"pickuprate_2f9d75ab8de44ab9a77d36332752e442","object":"PickupRate"}]}'
+        body: '{"id":"pickup_3a19c8e1c7c8478ebf09ad83e7052ba1","object":"Pickup","created_at":"2022-05-02T18:49:04Z","updated_at":"2022-05-02T18:49:06Z","mode":"test","status":"scheduled","reference":null,"min_datetime":"2022-05-04T00:00:00Z","max_datetime":"2022-05-04T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":"WTC61777030","address":{"id":"adr_89d942a2ca4811ecbfcfac1f6bc72124","object":"Address","created_at":"2022-05-02T18:49:04+00:00","updated_at":"2022-05-02T18:49:04+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-05-02T18:49:04Z","updated_at":"2022-05-02T18:49:04Z","carrier":"USPS","pickup_id":"pickup_3a19c8e1c7c8478ebf09ad83e7052ba1","id":"pickuprate_3ea4305878f445afbe5d201f988c4cc8","object":"PickupRate"}]}'
         curl_info:
-            url: 'https://api.easypost.com/v2/pickups/pickup_5451ee8718904b5f9d7faf67aa7c24a2/buy'
+            url: 'https://api.easypost.com/v2/pickups/pickup_3a19c8e1c7c8478ebf09ad83e7052ba1/buy'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 719
+            header_size: 737
             request_size: 601
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 1.48443
-            namelookup_time: 0.003191
-            connect_time: 0.061123
-            pretransfer_time: 0.133179
+            total_time: 1.299152
+            namelookup_time: 0.001165
+            connect_time: 0.058491
+            pretransfer_time: 0.132394
             size_upload: 38.0
             size_download: 1160.0
-            speed_download: 781.0
-            speed_upload: 25.0
+            speed_download: 892.0
+            speed_upload: 29.0
             download_content_length: 1160.0
             upload_content_length: 38.0
-            starttransfer_time: 0.133183
+            starttransfer_time: 0.132397
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.21
-            local_port: 50304
+            local_ip: 10.130.6.22
+            local_port: 54503
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 133077
-            connect_time_us: 61123
-            namelookup_time_us: 3191
-            pretransfer_time_us: 133179
+            appconnect_time_us: 132099
+            connect_time_us: 58491
+            namelookup_time_us: 1165
+            pretransfer_time_us: 132394
             redirect_time_us: 0
-            starttransfer_time_us: 133183
-            total_time_us: 1484430
+            starttransfer_time_us: 132397
+            total_time_us: 1299152

--- a/test/cassettes/pickups/cancel.yml
+++ b/test/cassettes/pickups/cancel.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: POST
-        url: 'https://api.easypost.com/v2/pickups/pickup_5451ee8718904b5f9d7faf67aa7c24a2/cancel'
+        url: 'https://api.easypost.com/v2/pickups/pickup_3a19c8e1c7c8478ebf09ad83e7052ba1/cancel'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -24,56 +24,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: df63cd0b62547163e786af5b002399bb
+            x-ep-request-uuid: 2ed774f5627027a4e788e9bf00034a91
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '1159'
-            etag: 'W/"3822d44fbf7574e5135f35db727fd094"'
-            x-runtime: '0.977849'
-            x-node: bigweb7nuq
-            x-version-label: easypost-202204082123-da17cc1ac2-master
+            etag: 'W/"77ac91dd8a30292c21af2ef246466761"'
+            x-runtime: '0.909083'
+            x-node: bigweb5nuq
+            x-version-label: easypost-202205021749-d8209c081b-master
             x-backend: easypost
-            x-canary: direct
-            x-proxied: ['intlb1nuq fde591f008', 'extlb1nuq fde591f008']
+            x-proxied: ['intlb2nuq fde591f008', 'extlb2nuq 5fac7c1107']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"pickup_5451ee8718904b5f9d7faf67aa7c24a2","object":"Pickup","created_at":"2022-04-11T18:20:15Z","updated_at":"2022-04-11T18:20:20Z","mode":"test","status":"canceled","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":"WTC61774794","address":{"id":"adr_08f58c9bb9c411ec9a46ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:20:15+00:00","updated_at":"2022-04-11T18:20:15+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:20:17Z","updated_at":"2022-04-11T18:20:17Z","carrier":"USPS","pickup_id":"pickup_5451ee8718904b5f9d7faf67aa7c24a2","id":"pickuprate_2f9d75ab8de44ab9a77d36332752e442","object":"PickupRate"}]}'
+        body: '{"id":"pickup_3a19c8e1c7c8478ebf09ad83e7052ba1","object":"Pickup","created_at":"2022-05-02T18:49:04Z","updated_at":"2022-05-02T18:49:09Z","mode":"test","status":"canceled","reference":null,"min_datetime":"2022-05-04T00:00:00Z","max_datetime":"2022-05-04T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":"WTC61777030","address":{"id":"adr_89d942a2ca4811ecbfcfac1f6bc72124","object":"Address","created_at":"2022-05-02T18:49:04+00:00","updated_at":"2022-05-02T18:49:04+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-05-02T18:49:04Z","updated_at":"2022-05-02T18:49:04Z","carrier":"USPS","pickup_id":"pickup_3a19c8e1c7c8478ebf09ad83e7052ba1","id":"pickuprate_3ea4305878f445afbe5d201f988c4cc8","object":"PickupRate"}]}'
         curl_info:
-            url: 'https://api.easypost.com/v2/pickups/pickup_5451ee8718904b5f9d7faf67aa7c24a2/cancel'
+            url: 'https://api.easypost.com/v2/pickups/pickup_3a19c8e1c7c8478ebf09ad83e7052ba1/cancel'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 737
+            header_size: 719
             request_size: 603
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 1.171937
-            namelookup_time: 0.002186
-            connect_time: 0.0614
-            pretransfer_time: 0.129852
+            total_time: 1.129424
+            namelookup_time: 0.001909
+            connect_time: 0.061263
+            pretransfer_time: 0.132011
             size_upload: 2.0
             size_download: 1159.0
-            speed_download: 988.0
+            speed_download: 1026.0
             speed_upload: 1.0
             download_content_length: 1159.0
             upload_content_length: 2.0
-            starttransfer_time: 0.129855
+            starttransfer_time: 0.132013
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.21
-            local_port: 50306
+            local_ip: 10.130.6.22
+            local_port: 54531
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 129798
-            connect_time_us: 61400
-            namelookup_time_us: 2186
-            pretransfer_time_us: 129852
+            appconnect_time_us: 131954
+            connect_time_us: 61263
+            namelookup_time_us: 1909
+            pretransfer_time_us: 132011
             redirect_time_us: 0
-            starttransfer_time_us: 129855
-            total_time_us: 1171937
+            starttransfer_time_us: 132013
+            total_time_us: 1129424

--- a/test/cassettes/pickups/create.yml
+++ b/test/cassettes/pickups/create.yml
@@ -24,21 +24,21 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: df63cd086254715ee786af5600239756
+            x-ep-request-uuid: 2ed774f86270279ee788e6470003474f
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
-            location: /api/v2/shipments/shp_07da9df174de4643ba0e949e40ef1a97
+            location: /api/v2/shipments/shp_7bdf85f656194315af5274b4f04825ab
             content-type: 'application/json; charset=utf-8'
             content-length: '6919'
-            etag: 'W/"61a56462bd4c0c704ca131dc0049d856"'
-            x-runtime: '1.036456'
+            etag: 'W/"40d2d5f3b4f28c2d70f7518f21c78b18"'
+            x-runtime: '1.074226'
             x-node: bigweb1nuq
-            x-version-label: easypost-202204082123-da17cc1ac2-master
+            x-version-label: easypost-202205021749-d8209c081b-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq fde591f008', 'extlb1nuq fde591f008']
+            x-proxied: ['intlb1nuq fde591f008', 'extlb2nuq 5fac7c1107']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"created_at":"2022-04-11T18:20:14Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361114520515","updated_at":"2022-04-11T18:20:15Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_083b082bb9c411ec99f6ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:20:14+00:00","updated_at":"2022-04-11T18:20:14+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":"50.00","order_id":null,"parcel":{"id":"prcl_600df1bd858a497b828f210ec3341235","object":"Parcel","created_at":"2022-04-11T18:20:14Z","updated_at":"2022-04-11T18:20:14Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_4490bcc05f0143e99ec0380a28ed288e","created_at":"2022-04-11T18:20:14Z","updated_at":"2022-04-11T18:20:15Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-11T18:20:14Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220411/4591311d29094dd4b9eada19ecc12baf.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_f8b7589aea2e49e9b5cf90a7d1a0fc20","object":"Rate","created_at":"2022-04-11T18:20:14Z","updated_at":"2022-04-11T18:20:14Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_07da9df174de4643ba0e949e40ef1a97","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_7e46460891504d69b9134ec5f84e6f15","object":"Rate","created_at":"2022-04-11T18:20:14Z","updated_at":"2022-04-11T18:20:14Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_07da9df174de4643ba0e949e40ef1a97","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_ee477b076fe84ef794c7f9677756f414","object":"Rate","created_at":"2022-04-11T18:20:14Z","updated_at":"2022-04-11T18:20:14Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_07da9df174de4643ba0e949e40ef1a97","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_eca3c53642004f549a208ec3b281751b","object":"Rate","created_at":"2022-04-11T18:20:14Z","updated_at":"2022-04-11T18:20:14Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_07da9df174de4643ba0e949e40ef1a97","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_f8b7589aea2e49e9b5cf90a7d1a0fc20","object":"Rate","created_at":"2022-04-11T18:20:15Z","updated_at":"2022-04-11T18:20:15Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_07da9df174de4643ba0e949e40ef1a97","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},"tracker":{"id":"trk_b7abc8ae947642b5a17a7d7f0beda627","object":"Tracker","mode":"test","tracking_code":"9400100109361114520515","status":"unknown","status_detail":"unknown","created_at":"2022-04-11T18:20:15Z","updated_at":"2022-04-11T18:20:15Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_07da9df174de4643ba0e949e40ef1a97","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2I3YWJjOGFlOTQ3NjQyYjVhMTdhN2Q3ZjBiZWRhNjI3"},"to_address":{"id":"adr_08392fb4b9c411ec9457ac1f6bc7bdc6","object":"Address","created_at":"2022-04-11T18:20:14+00:00","updated_at":"2022-04-11T18:20:14+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_083b082bb9c411ec99f6ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:20:14+00:00","updated_at":"2022-04-11T18:20:14+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_08392fb4b9c411ec9457ac1f6bc7bdc6","object":"Address","created_at":"2022-04-11T18:20:14+00:00","updated_at":"2022-04-11T18:20:14+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false},{"object":"Fee","type":"InsuranceFee","amount":"0.25000","charged":true,"refunded":false}],"id":"shp_07da9df174de4643ba0e949e40ef1a97","object":"Shipment"}'
+        body: '{"created_at":"2022-05-02T18:49:02Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117446577","updated_at":"2022-05-02T18:49:03Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_890f8b03ca4811ecb459ac1f6b0a0d1e","object":"Address","created_at":"2022-05-02T18:49:02+00:00","updated_at":"2022-05-02T18:49:02+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":"50.00","order_id":null,"parcel":{"id":"prcl_630152a0cf684aa89035b66c1e3781b0","object":"Parcel","created_at":"2022-05-02T18:49:02Z","updated_at":"2022-05-02T18:49:02Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_1bba0e7da8f24c689844a606b7d89188","created_at":"2022-05-02T18:49:03Z","updated_at":"2022-05-02T18:49:03Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-02T18:49:03Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220502/9b698b21c24d4134a6fd03b863b10a0c.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_b49b524e15074e0ca54ffe656731e699","object":"Rate","created_at":"2022-05-02T18:49:02Z","updated_at":"2022-05-02T18:49:02Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_7bdf85f656194315af5274b4f04825ab","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_406de5e2247843a8b84334a97441bef6","object":"Rate","created_at":"2022-05-02T18:49:02Z","updated_at":"2022-05-02T18:49:02Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_7bdf85f656194315af5274b4f04825ab","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_5d43c377a98341929433bc2060ca12b0","object":"Rate","created_at":"2022-05-02T18:49:02Z","updated_at":"2022-05-02T18:49:02Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_7bdf85f656194315af5274b4f04825ab","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_d0a387d152574da38be847a05a90f13a","object":"Rate","created_at":"2022-05-02T18:49:02Z","updated_at":"2022-05-02T18:49:02Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_7bdf85f656194315af5274b4f04825ab","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_5d43c377a98341929433bc2060ca12b0","object":"Rate","created_at":"2022-05-02T18:49:03Z","updated_at":"2022-05-02T18:49:03Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_7bdf85f656194315af5274b4f04825ab","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},"tracker":{"id":"trk_6df5719d7c074b73bdc56d7fbf8f99ff","object":"Tracker","mode":"test","tracking_code":"9400100109361117446577","status":"unknown","status_detail":"unknown","created_at":"2022-05-02T18:49:03Z","updated_at":"2022-05-02T18:49:03Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_7bdf85f656194315af5274b4f04825ab","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzZkZjU3MTlkN2MwNzRiNzNiZGM1NmQ3ZmJmOGY5OWZm"},"to_address":{"id":"adr_890aa54dca4811ecb457ac1f6b0a0d1e","object":"Address","created_at":"2022-05-02T18:49:02+00:00","updated_at":"2022-05-02T18:49:02+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_890f8b03ca4811ecb459ac1f6b0a0d1e","object":"Address","created_at":"2022-05-02T18:49:02+00:00","updated_at":"2022-05-02T18:49:02+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_890aa54dca4811ecb457ac1f6b0a0d1e","object":"Address","created_at":"2022-05-02T18:49:02+00:00","updated_at":"2022-05-02T18:49:02+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false},{"object":"Fee","type":"InsuranceFee","amount":"0.25000","charged":true,"refunded":false}],"id":"shp_7bdf85f656194315af5274b4f04825ab","object":"Shipment"}'
         curl_info:
             url: 'https://api.easypost.com/v2/shipments'
             content_type: 'application/json; charset=utf-8'
@@ -48,35 +48,35 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 1.230213
-            namelookup_time: 0.010138
-            connect_time: 0.068448
-            pretransfer_time: 0.13446
+            total_time: 1.260113
+            namelookup_time: 0.00212
+            connect_time: 0.059713
+            pretransfer_time: 0.12624
             size_upload: 528.0
             size_download: 6919.0
-            speed_download: 5624.0
-            speed_upload: 429.0
+            speed_download: 5490.0
+            speed_upload: 419.0
             download_content_length: 6919.0
             upload_content_length: 528.0
-            starttransfer_time: 0.134463
+            starttransfer_time: 0.126243
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.21
-            local_port: 50301
+            local_ip: 10.130.6.22
+            local_port: 54494
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 134328
-            connect_time_us: 68448
-            namelookup_time_us: 10138
-            pretransfer_time_us: 134460
+            appconnect_time_us: 126167
+            connect_time_us: 59713
+            namelookup_time_us: 2120
+            pretransfer_time_us: 126240
             redirect_time_us: 0
-            starttransfer_time_us: 134463
-            total_time_us: 1230213
+            starttransfer_time_us: 126243
+            total_time_us: 1260113
 -
     request:
         method: POST
@@ -89,7 +89,7 @@
             User-Agent: ''
             X-Client-User-Agent: ''
             EasyPost-Version: '2'
-        body: '{"pickup":{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-04-12","max_datetime":"2022-04-12","instructions":"Pickup at front door","shipment":{"id":"shp_07da9df174de4643ba0e949e40ef1a97"}}}'
+        body: '{"pickup":{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-05-04","max_datetime":"2022-05-04","instructions":"Pickup at front door","shipment":{"id":"shp_7bdf85f656194315af5274b4f04825ab"}}}'
     response:
         status:
             http_version: '2'
@@ -102,20 +102,20 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: df63cd096254715fe786af5700239807
+            x-ep-request-uuid: 2ed774fc6270279fe788e64b000347e4
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '1149'
-            etag: 'W/"fb34023f4887501ea84c2959d881b235"'
-            x-runtime: '1.531368'
-            x-node: bigweb3nuq
-            x-version-label: easypost-202204082123-da17cc1ac2-master
+            etag: 'W/"c4084ffa9548b6e13b91c51e9776a02d"'
+            x-runtime: '0.909838'
+            x-node: bigweb2nuq
+            x-version-label: easypost-202205021749-d8209c081b-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq fde591f008', 'extlb1nuq fde591f008']
+            x-proxied: ['intlb1nuq fde591f008', 'extlb2nuq 5fac7c1107']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"pickup_5451ee8718904b5f9d7faf67aa7c24a2","object":"Pickup","created_at":"2022-04-11T18:20:15Z","updated_at":"2022-04-11T18:20:15Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":null,"address":{"id":"adr_08f58c9bb9c411ec9a46ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:20:15+00:00","updated_at":"2022-04-11T18:20:15+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:20:17Z","updated_at":"2022-04-11T18:20:17Z","carrier":"USPS","pickup_id":"pickup_5451ee8718904b5f9d7faf67aa7c24a2","id":"pickuprate_2f9d75ab8de44ab9a77d36332752e442","object":"PickupRate"}]}'
+        body: '{"id":"pickup_3a19c8e1c7c8478ebf09ad83e7052ba1","object":"Pickup","created_at":"2022-05-02T18:49:04Z","updated_at":"2022-05-02T18:49:04Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-05-04T00:00:00Z","max_datetime":"2022-05-04T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":null,"address":{"id":"adr_89d942a2ca4811ecbfcfac1f6bc72124","object":"Address","created_at":"2022-05-02T18:49:04+00:00","updated_at":"2022-05-02T18:49:04+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-05-02T18:49:04Z","updated_at":"2022-05-02T18:49:04Z","carrier":"USPS","pickup_id":"pickup_3a19c8e1c7c8478ebf09ad83e7052ba1","id":"pickuprate_3ea4305878f445afbe5d201f988c4cc8","object":"PickupRate"}]}'
         curl_info:
             url: 'https://api.easypost.com/v2/pickups'
             content_type: 'application/json; charset=utf-8'
@@ -125,32 +125,32 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 1.723392
-            namelookup_time: 0.002243
-            connect_time: 0.061149
-            pretransfer_time: 0.131815
+            total_time: 1.102236
+            namelookup_time: 0.002503
+            connect_time: 0.060928
+            pretransfer_time: 0.130246
             size_upload: 336.0
             size_download: 1149.0
-            speed_download: 666.0
-            speed_upload: 194.0
+            speed_download: 1042.0
+            speed_upload: 304.0
             download_content_length: 1149.0
             upload_content_length: 336.0
-            starttransfer_time: 0.131819
+            starttransfer_time: 0.130249
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.21
-            local_port: 50302
+            local_ip: 10.130.6.22
+            local_port: 54498
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 131719
-            connect_time_us: 61149
-            namelookup_time_us: 2243
-            pretransfer_time_us: 131815
+            appconnect_time_us: 130194
+            connect_time_us: 60928
+            namelookup_time_us: 2503
+            pretransfer_time_us: 130246
             redirect_time_us: 0
-            starttransfer_time_us: 131819
-            total_time_us: 1723392
+            starttransfer_time_us: 130249
+            total_time_us: 1102236

--- a/test/cassettes/pickups/lowestRate.yml
+++ b/test/cassettes/pickups/lowestRate.yml
@@ -1,0 +1,156 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/shipments'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+            X-Client-User-Agent: ''
+            EasyPost-Version: '2'
+        body: '{"shipment":{"to_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"from_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"},"service":"First","carrier_accounts":["ca_8dc116debcdb49b5a66a2ddee4612600"],"carrier":"USPS"}}'
+    response:
+        status:
+            http_version: '2'
+            code: '201'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 2ed774f86270279ce788e64400034699
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            location: /api/v2/shipments/shp_ec4de224e5c5461884d6c2bf812ee45a
+            content-type: 'application/json; charset=utf-8'
+            content-length: '6919'
+            etag: 'W/"b82a147b56d8fb1d5dfc42ef015c91d8"'
+            x-runtime: '1.088705'
+            x-node: bigweb9nuq
+            x-version-label: easypost-202205021749-d8209c081b-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq fde591f008', 'extlb2nuq 5fac7c1107']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"created_at":"2022-05-02T18:49:00Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117446560","updated_at":"2022-05-02T18:49:01Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_87962355ca4811ecb3c9ac1f6b0a0d1e","object":"Address","created_at":"2022-05-02T18:49:00+00:00","updated_at":"2022-05-02T18:49:00+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":"50.00","order_id":null,"parcel":{"id":"prcl_ca9c67e23c324835911c65e1a0914c6a","object":"Parcel","created_at":"2022-05-02T18:49:00Z","updated_at":"2022-05-02T18:49:00Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_7aedd5a76c484043a3814d4706fc8abd","created_at":"2022-05-02T18:49:00Z","updated_at":"2022-05-02T18:49:01Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-02T18:49:00Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220502/25b4c0a8f4704713af1d9540afc50180.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_3329eda9253e4a1faf7f9e9c66efa0b5","object":"Rate","created_at":"2022-05-02T18:49:00Z","updated_at":"2022-05-02T18:49:00Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_ec4de224e5c5461884d6c2bf812ee45a","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_f489678a055a498484895c9198edfae3","object":"Rate","created_at":"2022-05-02T18:49:00Z","updated_at":"2022-05-02T18:49:00Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ec4de224e5c5461884d6c2bf812ee45a","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_7ea82960446f49dead64a17b3ccf9e8b","object":"Rate","created_at":"2022-05-02T18:49:00Z","updated_at":"2022-05-02T18:49:00Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_ec4de224e5c5461884d6c2bf812ee45a","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_587a495ff14d4f3687ccfcd58e4a2064","object":"Rate","created_at":"2022-05-02T18:49:00Z","updated_at":"2022-05-02T18:49:00Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ec4de224e5c5461884d6c2bf812ee45a","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_587a495ff14d4f3687ccfcd58e4a2064","object":"Rate","created_at":"2022-05-02T18:49:00Z","updated_at":"2022-05-02T18:49:00Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ec4de224e5c5461884d6c2bf812ee45a","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},"tracker":{"id":"trk_cfef67de8e904610977c91deeb4f90a1","object":"Tracker","mode":"test","tracking_code":"9400100109361117446560","status":"unknown","status_detail":"unknown","created_at":"2022-05-02T18:49:01Z","updated_at":"2022-05-02T18:49:01Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_ec4de224e5c5461884d6c2bf812ee45a","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2NmZWY2N2RlOGU5MDQ2MTA5NzdjOTFkZWViNGY5MGEx"},"to_address":{"id":"adr_879467d0ca4811ec880fac1f6bc7bdc6","object":"Address","created_at":"2022-05-02T18:49:00+00:00","updated_at":"2022-05-02T18:49:00+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_87962355ca4811ecb3c9ac1f6b0a0d1e","object":"Address","created_at":"2022-05-02T18:49:00+00:00","updated_at":"2022-05-02T18:49:00+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_879467d0ca4811ec880fac1f6bc7bdc6","object":"Address","created_at":"2022-05-02T18:49:00+00:00","updated_at":"2022-05-02T18:49:00+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false},{"object":"Fee","type":"InsuranceFee","amount":"0.25000","charged":true,"refunded":false}],"id":"shp_ec4de224e5c5461884d6c2bf812ee45a","object":"Shipment"}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/shipments'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 785
+            request_size: 560
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 1.286248
+            namelookup_time: 0.009084
+            connect_time: 0.067101
+            pretransfer_time: 0.135825
+            size_upload: 528.0
+            size_download: 6919.0
+            speed_download: 5379.0
+            speed_upload: 410.0
+            download_content_length: 6919.0
+            upload_content_length: 528.0
+            starttransfer_time: 0.135827
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.130
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.22
+            local_port: 54491
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 135467
+            connect_time_us: 67101
+            namelookup_time_us: 9084
+            pretransfer_time_us: 135825
+            redirect_time_us: 0
+            starttransfer_time_us: 135827
+            total_time_us: 1286248
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/pickups'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+            X-Client-User-Agent: ''
+            EasyPost-Version: '2'
+        body: '{"pickup":{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-05-04","max_datetime":"2022-05-04","instructions":"Pickup at front door","shipment":{"id":"shp_ec4de224e5c5461884d6c2bf812ee45a"}}}'
+    response:
+        status:
+            http_version: '2'
+            code: '200'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 2ed774f86270279de788e64500034702
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '1149'
+            etag: 'W/"89ad3125a493f4b1e973e2b23fe1200a"'
+            x-runtime: '0.952008'
+            x-node: bigweb8nuq
+            x-version-label: easypost-202205021749-d8209c081b-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq fde591f008', 'extlb2nuq 5fac7c1107']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"pickup_57de549e728942088ee98141392eeeb8","object":"Pickup","created_at":"2022-05-02T18:49:01Z","updated_at":"2022-05-02T18:49:01Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-05-04T00:00:00Z","max_datetime":"2022-05-04T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":null,"address":{"id":"adr_885cbc7dca4811ecbf3dac1f6bc72124","object":"Address","created_at":"2022-05-02T18:49:01+00:00","updated_at":"2022-05-02T18:49:01+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-05-02T18:49:02Z","updated_at":"2022-05-02T18:49:02Z","carrier":"USPS","pickup_id":"pickup_57de549e728942088ee98141392eeeb8","id":"pickuprate_9c9847eb89c8440cb515ac5b08586d4c","object":"PickupRate"}]}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/pickups'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 719
+            request_size: 558
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 1.156255
+            namelookup_time: 0.002893
+            connect_time: 0.062807
+            pretransfer_time: 0.142736
+            size_upload: 336.0
+            size_download: 1149.0
+            speed_download: 993.0
+            speed_upload: 290.0
+            download_content_length: 1149.0
+            upload_content_length: 336.0
+            starttransfer_time: 0.142741
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.130
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.22
+            local_port: 54492
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 142463
+            connect_time_us: 62807
+            namelookup_time_us: 2893
+            pretransfer_time_us: 142736
+            redirect_time_us: 0
+            starttransfer_time_us: 142741
+            total_time_us: 1156255

--- a/test/cassettes/pickups/retrieve.yml
+++ b/test/cassettes/pickups/retrieve.yml
@@ -1,8 +1,163 @@
 
 -
     request:
+        method: POST
+        url: 'https://api.easypost.com/v2/shipments'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+            X-Client-User-Agent: ''
+            EasyPost-Version: '2'
+        body: '{"shipment":{"to_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"from_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"},"service":"First","carrier_accounts":["ca_8dc116debcdb49b5a66a2ddee4612600"],"carrier":"USPS"}}'
+    response:
+        status:
+            http_version: '2'
+            code: '201'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 2ed774f7627027a2e788e9a300034902
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            location: /api/v2/shipments/shp_b201caa6d1e045f28ed8e94cace8c7fd
+            content-type: 'application/json; charset=utf-8'
+            content-length: '6919'
+            etag: 'W/"4da001472d2546ba954bb4f36aa77ff7"'
+            x-runtime: '1.062830'
+            x-node: bigweb2nuq
+            x-version-label: easypost-202205021749-d8209c081b-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq fde591f008', 'extlb2nuq 5fac7c1107']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"created_at":"2022-05-02T18:49:06Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117446584","updated_at":"2022-05-02T18:49:07Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_8b3e24f7ca4811ec88faac1f6bc7bdc6","object":"Address","created_at":"2022-05-02T18:49:06+00:00","updated_at":"2022-05-02T18:49:06+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":"50.00","order_id":null,"parcel":{"id":"prcl_acedd109a3bb4cec9f18ac1c8b85f401","object":"Parcel","created_at":"2022-05-02T18:49:06Z","updated_at":"2022-05-02T18:49:06Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_6ca0639a793e4a9895ebf5fec14b865e","created_at":"2022-05-02T18:49:06Z","updated_at":"2022-05-02T18:49:07Z","date_advance":0,"integrated_form":"none","label_date":"2022-05-02T18:49:06Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220502/4e415609d4ac438c83ccd7fe2a92688b.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_4f3a6503eb9b4e248e807fcbfed20e86","object":"Rate","created_at":"2022-05-02T18:49:06Z","updated_at":"2022-05-02T18:49:06Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_b201caa6d1e045f28ed8e94cace8c7fd","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_46c8165c7a6047cb88f010eaa704d6e1","object":"Rate","created_at":"2022-05-02T18:49:06Z","updated_at":"2022-05-02T18:49:06Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_b201caa6d1e045f28ed8e94cace8c7fd","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_fec785edd857407295d39a85d6d7bd37","object":"Rate","created_at":"2022-05-02T18:49:06Z","updated_at":"2022-05-02T18:49:06Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_b201caa6d1e045f28ed8e94cace8c7fd","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_f0aafee333664da1b5d21859b7b7a045","object":"Rate","created_at":"2022-05-02T18:49:06Z","updated_at":"2022-05-02T18:49:06Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_b201caa6d1e045f28ed8e94cace8c7fd","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_fec785edd857407295d39a85d6d7bd37","object":"Rate","created_at":"2022-05-02T18:49:06Z","updated_at":"2022-05-02T18:49:06Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_b201caa6d1e045f28ed8e94cace8c7fd","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},"tracker":{"id":"trk_7177a5711e3340629af50b8bab6a2242","object":"Tracker","mode":"test","tracking_code":"9400100109361117446584","status":"unknown","status_detail":"unknown","created_at":"2022-05-02T18:49:07Z","updated_at":"2022-05-02T18:49:07Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_b201caa6d1e045f28ed8e94cace8c7fd","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzcxNzdhNTcxMWUzMzQwNjI5YWY1MGI4YmFiNmEyMjQy"},"to_address":{"id":"adr_8b3c3b11ca4811ecb53bac1f6b0a0d1e","object":"Address","created_at":"2022-05-02T18:49:06+00:00","updated_at":"2022-05-02T18:49:06+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_8b3e24f7ca4811ec88faac1f6bc7bdc6","object":"Address","created_at":"2022-05-02T18:49:06+00:00","updated_at":"2022-05-02T18:49:06+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_8b3c3b11ca4811ecb53bac1f6b0a0d1e","object":"Address","created_at":"2022-05-02T18:49:06+00:00","updated_at":"2022-05-02T18:49:06+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.00000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false},{"object":"Fee","type":"InsuranceFee","amount":"0.25000","charged":true,"refunded":false}],"id":"shp_b201caa6d1e045f28ed8e94cace8c7fd","object":"Shipment"}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/shipments'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 785
+            request_size: 560
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 1.252087
+            namelookup_time: 0.001105
+            connect_time: 0.058148
+            pretransfer_time: 0.128702
+            size_upload: 528.0
+            size_download: 6919.0
+            speed_download: 5525.0
+            speed_upload: 421.0
+            download_content_length: 6919.0
+            upload_content_length: 528.0
+            starttransfer_time: 0.128706
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.130
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.22
+            local_port: 54526
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 128561
+            connect_time_us: 58148
+            namelookup_time_us: 1105
+            pretransfer_time_us: 128702
+            redirect_time_us: 0
+            starttransfer_time_us: 128706
+            total_time_us: 1252087
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/pickups'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+            X-Client-User-Agent: ''
+            EasyPost-Version: '2'
+        body: '{"pickup":{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-05-04","max_datetime":"2022-05-04","instructions":"Pickup at front door","shipment":{"id":"shp_b201caa6d1e045f28ed8e94cace8c7fd"}}}'
+    response:
+        status:
+            http_version: '2'
+            code: '200'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 2ed774f9627027a3e788e9a6000349f9
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '1149'
+            etag: 'W/"d080f8afd2953ba6f2f20cffb84584de"'
+            x-runtime: '0.805117'
+            x-node: bigweb1nuq
+            x-version-label: easypost-202205021749-d8209c081b-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq fde591f008', 'extlb2nuq 5fac7c1107']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"pickup_b6d22d794c2e454c87605a53ecbd674d","object":"Pickup","created_at":"2022-05-02T18:49:07Z","updated_at":"2022-05-02T18:49:07Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-05-04T00:00:00Z","max_datetime":"2022-05-04T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":null,"address":{"id":"adr_8bfd4862ca4811ecb594ac1f6b0a0d1e","object":"Address","created_at":"2022-05-02T18:49:07+00:00","updated_at":"2022-05-02T18:49:07+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-05-02T18:49:08Z","updated_at":"2022-05-02T18:49:08Z","carrier":"USPS","pickup_id":"pickup_b6d22d794c2e454c87605a53ecbd674d","id":"pickuprate_b38ccbaf178b47609a301f491bbaf646","object":"PickupRate"}]}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/pickups'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 719
+            request_size: 558
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 1.000983
+            namelookup_time: 0.001375
+            connect_time: 0.060776
+            pretransfer_time: 0.134071
+            size_upload: 336.0
+            size_download: 1149.0
+            speed_download: 1147.0
+            speed_upload: 335.0
+            download_content_length: 1149.0
+            upload_content_length: 336.0
+            starttransfer_time: 0.134075
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.130
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.22
+            local_port: 54529
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 133987
+            connect_time_us: 60776
+            namelookup_time_us: 1375
+            pretransfer_time_us: 134071
+            redirect_time_us: 0
+            starttransfer_time_us: 134075
+            total_time_us: 1000983
+-
+    request:
         method: GET
-        url: 'https://api.easypost.com/v2/pickups/pickup_5451ee8718904b5f9d7faf67aa7c24a2'
+        url: 'https://api.easypost.com/v2/pickups/pickup_b6d22d794c2e454c87605a53ecbd674d'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -23,55 +178,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: df63cd0962547161e786af58002398da
+            x-ep-request-uuid: 2ed774f5627027a4e788e9be00034a72
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '1149'
-            etag: 'W/"fb34023f4887501ea84c2959d881b235"'
-            x-runtime: '0.069650'
-            x-node: bigweb2nuq
-            x-version-label: easypost-202204082123-da17cc1ac2-master
+            etag: 'W/"d080f8afd2953ba6f2f20cffb84584de"'
+            x-runtime: '0.079546'
+            x-node: bigweb7nuq
+            x-version-label: easypost-202205021749-d8209c081b-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq fde591f008', 'extlb1nuq fde591f008']
+            x-canary: direct
+            x-proxied: ['intlb1nuq fde591f008', 'extlb2nuq 5fac7c1107']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"pickup_5451ee8718904b5f9d7faf67aa7c24a2","object":"Pickup","created_at":"2022-04-11T18:20:15Z","updated_at":"2022-04-11T18:20:15Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":null,"address":{"id":"adr_08f58c9bb9c411ec9a46ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:20:15+00:00","updated_at":"2022-04-11T18:20:15+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:20:17Z","updated_at":"2022-04-11T18:20:17Z","carrier":"USPS","pickup_id":"pickup_5451ee8718904b5f9d7faf67aa7c24a2","id":"pickuprate_2f9d75ab8de44ab9a77d36332752e442","object":"PickupRate"}]}'
+        body: '{"id":"pickup_b6d22d794c2e454c87605a53ecbd674d","object":"Pickup","created_at":"2022-05-02T18:49:07Z","updated_at":"2022-05-02T18:49:07Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-05-04T00:00:00Z","max_datetime":"2022-05-04T00:00:00Z","is_account_address":false,"instructions":"Pickup at front door","messages":[],"confirmation":null,"address":{"id":"adr_8bfd4862ca4811ecb594ac1f6b0a0d1e","object":"Address","created_at":"2022-05-02T18:49:07+00:00","updated_at":"2022-05-02T18:49:07+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-05-02T18:49:08Z","updated_at":"2022-05-02T18:49:08Z","carrier":"USPS","pickup_id":"pickup_b6d22d794c2e454c87605a53ecbd674d","id":"pickuprate_b38ccbaf178b47609a301f491bbaf646","object":"PickupRate"}]}'
         curl_info:
-            url: 'https://api.easypost.com/v2/pickups/pickup_5451ee8718904b5f9d7faf67aa7c24a2'
+            url: 'https://api.easypost.com/v2/pickups/pickup_b6d22d794c2e454c87605a53ecbd674d'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 719
+            header_size: 737
             request_size: 576
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.267987
-            namelookup_time: 0.001743
-            connect_time: 0.061457
-            pretransfer_time: 0.132788
+            total_time: 0.2803
+            namelookup_time: 0.002491
+            connect_time: 0.0617
+            pretransfer_time: 0.139761
             size_upload: 0.0
             size_download: 1149.0
-            speed_download: 4287.0
+            speed_download: 4099.0
             speed_upload: 0.0
             download_content_length: 1149.0
             upload_content_length: 0.0
-            starttransfer_time: 0.26795
+            starttransfer_time: 0.280217
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.21
-            local_port: 50303
+            local_ip: 10.130.6.22
+            local_port: 54530
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 132700
-            connect_time_us: 61457
-            namelookup_time_us: 1743
-            pretransfer_time_us: 132788
+            appconnect_time_us: 139665
+            connect_time_us: 61700
+            namelookup_time_us: 2491
+            pretransfer_time_us: 139761
             redirect_time_us: 0
-            starttransfer_time_us: 267950
-            total_time_us: 267987
+            starttransfer_time_us: 280217
+            total_time_us: 280300

--- a/test/cassettes/shipments/getLowestSmartrate.yml
+++ b/test/cassettes/shipments/getLowestSmartrate.yml
@@ -1,0 +1,155 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/shipments'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+            X-Client-User-Agent: ''
+            EasyPost-Version: '2'
+        body: '{"shipment":{"to_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"from_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"},"customs_info":{"eel_pfc":"NOEEI 30.37(a)","customs_certify":"true","customs_signer":"Steve Brule","contents_type":"merchandise","restriction_type":"none","non_delivery_option":"return","customs_items":[{"description":"Sweet shirts","quantity":"2","weight":"11","value":"23","hs_tariff_number":"654321","origin_country":"US"}]},"options":{"label_format":"PNG","invoice_number":"123"},"reference":"123"}}'
+    response:
+        status:
+            http_version: '2'
+            code: '201'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 91732dbc62701e1ee78740e200223937
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            location: /api/v2/shipments/shp_f19468b1744a4b54b33ebded8a860cb0
+            content-type: 'application/json; charset=utf-8'
+            content-length: '5565'
+            etag: 'W/"ef1feaaa77d0d221a73057c0ffe07325"'
+            x-runtime: '0.351758'
+            x-node: bigweb4nuq
+            x-version-label: easypost-202204282028-6188e715cb-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq fde591f008', 'extlb1nuq 5fac7c1107']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"created_at":"2022-05-02T18:08:30Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":null,"updated_at":"2022-05-02T18:08:30Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_3da33e1555fe4f269bea1742ff9d6796","object":"CustomsInfo","created_at":"2022-05-02T18:08:30Z","updated_at":"2022-05-02T18:08:30Z","contents_explanation":null,"contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_6c8cc9c6635342d581f8dc2be8c83243","object":"CustomsItem","created_at":"2022-05-02T18:08:30Z","updated_at":"2022-05-02T18:08:30Z","description":"Sweet shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_df54bf03ca4211ec8051ac1f6bc72124","object":"Address","created_at":"2022-05-02T18:08:30+00:00","updated_at":"2022-05-02T18:08:30+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_73948e1cdb724788b64d95f8b07f33c7","object":"Parcel","created_at":"2022-05-02T18:08:30Z","updated_at":"2022-05-02T18:08:30Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_5db5fe730d0a4601b6a35f356eff1502","object":"Rate","created_at":"2022-05-02T18:08:30Z","updated_at":"2022-05-02T18:08:30Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_f19468b1744a4b54b33ebded8a860cb0","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_089b3d5e03604587abae8608dec3dcb2","object":"Rate","created_at":"2022-05-02T18:08:30Z","updated_at":"2022-05-02T18:08:30Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_f19468b1744a4b54b33ebded8a860cb0","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_a0de02a473e2479e9d53921cee1572d3","object":"Rate","created_at":"2022-05-02T18:08:30Z","updated_at":"2022-05-02T18:08:30Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f19468b1744a4b54b33ebded8a860cb0","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_d8b87a7e2d8543fcb245136b132b0aa0","object":"Rate","created_at":"2022-05-02T18:08:30Z","updated_at":"2022-05-02T18:08:30Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f19468b1744a4b54b33ebded8a860cb0","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_df52fe6cca4211ecb692ac1f6b0a0d1e","object":"Address","created_at":"2022-05-02T18:08:30+00:00","updated_at":"2022-05-02T18:08:30+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_df54bf03ca4211ec8051ac1f6bc72124","object":"Address","created_at":"2022-05-02T18:08:30+00:00","updated_at":"2022-05-02T18:08:30+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_df52fe6cca4211ecb692ac1f6b0a0d1e","object":"Address","created_at":"2022-05-02T18:08:30+00:00","updated_at":"2022-05-02T18:08:30+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_f19468b1744a4b54b33ebded8a860cb0","object":"Shipment"}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/shipments'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 785
+            request_size: 560
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.548518
+            namelookup_time: 0.008649
+            connect_time: 0.068225
+            pretransfer_time: 0.135505
+            size_upload: 836.0
+            size_download: 5565.0
+            speed_download: 10145.0
+            speed_upload: 1524.0
+            download_content_length: 5565.0
+            upload_content_length: 836.0
+            starttransfer_time: 0.135509
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.22
+            local_port: 51474
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 135427
+            connect_time_us: 68225
+            namelookup_time_us: 8649
+            pretransfer_time_us: 135505
+            redirect_time_us: 0
+            starttransfer_time_us: 135509
+            total_time_us: 548518
+-
+    request:
+        method: GET
+        url: 'https://api.easypost.com/v2/shipments/shp_f19468b1744a4b54b33ebded8a860cb0/smartrate'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+            X-Client-User-Agent: ''
+            EasyPost-Version: '2'
+    response:
+        status:
+            http_version: '2'
+            code: '200'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 91732dbd62701e1fe78740e300223976
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '2619'
+            etag: 'W/"3210f1c29dc430c0962d5abfb4f581ab"'
+            x-runtime: '0.085683'
+            x-node: bigweb3nuq
+            x-version-label: easypost-202204282028-6188e715cb-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq fde591f008', 'extlb1nuq 5fac7c1107']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600","created_at":"2022-05-02T18:08:30Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_5db5fe730d0a4601b6a35f356eff1502","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_f19468b1744a4b54b33ebded8a860cb0","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-05-02T18:08:30Z"},{"carrier":"USPS","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600","created_at":"2022-05-02T18:08:30Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_089b3d5e03604587abae8608dec3dcb2","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_f19468b1744a4b54b33ebded8a860cb0","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-05-02T18:08:30Z"},{"carrier":"USPS","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600","created_at":"2022-05-02T18:08:30Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_a0de02a473e2479e9d53921cee1572d3","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_f19468b1744a4b54b33ebded8a860cb0","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-05-02T18:08:30Z"},{"carrier":"USPS","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600","created_at":"2022-05-02T18:08:30Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_d8b87a7e2d8543fcb245136b132b0aa0","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_f19468b1744a4b54b33ebded8a860cb0","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":3,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-05-02T18:08:30Z"}]}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/shipments/shp_f19468b1744a4b54b33ebded8a860cb0/smartrate'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 719
+            request_size: 585
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.275823
+            namelookup_time: 0.002056
+            connect_time: 0.060183
+            pretransfer_time: 0.128148
+            size_upload: 0.0
+            size_download: 2619.0
+            speed_download: 9495.0
+            speed_upload: 0.0
+            download_content_length: 2619.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.2758
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.22
+            local_port: 51475
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 128067
+            connect_time_us: 60183
+            namelookup_time_us: 2056
+            pretransfer_time_us: 128148
+            redirect_time_us: 0
+            starttransfer_time_us: 275800
+            total_time_us: 275823

--- a/test/cassettes/shipments/lowestRate.yml
+++ b/test/cassettes/shipments/lowestRate.yml
@@ -1,0 +1,79 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/shipments'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+            X-Client-User-Agent: ''
+            EasyPost-Version: '2'
+        body: '{"shipment":{"to_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"from_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"},"customs_info":{"eel_pfc":"NOEEI 30.37(a)","customs_certify":"true","customs_signer":"Steve Brule","contents_type":"merchandise","restriction_type":"none","non_delivery_option":"return","customs_items":[{"description":"Sweet shirts","quantity":"2","weight":"11","value":"23","hs_tariff_number":"654321","origin_country":"US"}]},"options":{"label_format":"PNG","invoice_number":"123"},"reference":"123"}}'
+    response:
+        status:
+            http_version: '2'
+            code: '201'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 91732dbb6270117de786c9aa001d3a31
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            location: /api/v2/shipments/shp_9a9881c0e4ce4b3cbb326d8928d353ee
+            content-type: 'application/json; charset=utf-8'
+            content-length: '5565'
+            etag: 'W/"9466da4fea51ad3d428e42bbcc631d41"'
+            x-runtime: '0.259877'
+            x-node: bigweb8nuq
+            x-version-label: easypost-202204282028-6188e715cb-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq fde591f008', 'extlb1nuq 5fac7c1107']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"created_at":"2022-05-02T17:14:37Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":null,"updated_at":"2022-05-02T17:14:37Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_e0fe92d288c840ab8abec814f2fb58aa","object":"CustomsInfo","created_at":"2022-05-02T17:14:37Z","updated_at":"2022-05-02T17:14:37Z","contents_explanation":null,"contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_60eafaa23e074332b7f264e1eaa538fc","object":"CustomsItem","created_at":"2022-05-02T17:14:37Z","updated_at":"2022-05-02T17:14:37Z","description":"Sweet shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_582b61cdca3b11ecb9d3ac1f6bc7b362","object":"Address","created_at":"2022-05-02T17:14:37+00:00","updated_at":"2022-05-02T17:14:37+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_d95d7796b90949788740281943df70df","object":"Parcel","created_at":"2022-05-02T17:14:37Z","updated_at":"2022-05-02T17:14:37Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_899cad66faba4ea8acc8a1be6ea3b64d","object":"Rate","created_at":"2022-05-02T17:14:37Z","updated_at":"2022-05-02T17:14:37Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_9a9881c0e4ce4b3cbb326d8928d353ee","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_b16c124e43e44353b9c27f42bb88431c","object":"Rate","created_at":"2022-05-02T17:14:37Z","updated_at":"2022-05-02T17:14:37Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9a9881c0e4ce4b3cbb326d8928d353ee","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_7d598a11ba6b4cb5af7b5bd6cec902f2","object":"Rate","created_at":"2022-05-02T17:14:37Z","updated_at":"2022-05-02T17:14:37Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_9a9881c0e4ce4b3cbb326d8928d353ee","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_8d18704c24994589ae4565fb095b3ad5","object":"Rate","created_at":"2022-05-02T17:14:37Z","updated_at":"2022-05-02T17:14:37Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_9a9881c0e4ce4b3cbb326d8928d353ee","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_5828e276ca3b11ec9b10ac1f6b0a0d1e","object":"Address","created_at":"2022-05-02T17:14:37+00:00","updated_at":"2022-05-02T17:14:37+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_582b61cdca3b11ecb9d3ac1f6bc7b362","object":"Address","created_at":"2022-05-02T17:14:37+00:00","updated_at":"2022-05-02T17:14:37+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_5828e276ca3b11ec9b10ac1f6b0a0d1e","object":"Address","created_at":"2022-05-02T17:14:37+00:00","updated_at":"2022-05-02T17:14:37+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_9a9881c0e4ce4b3cbb326d8928d353ee","object":"Shipment"}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/shipments'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 785
+            request_size: 560
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.45245
+            namelookup_time: 0.005112
+            connect_time: 0.064135
+            pretransfer_time: 0.130487
+            size_upload: 836.0
+            size_download: 5565.0
+            speed_download: 12299.0
+            speed_upload: 1847.0
+            download_content_length: 5565.0
+            upload_content_length: 836.0
+            starttransfer_time: 0.130491
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.22
+            local_port: 50969
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 130415
+            connect_time_us: 64135
+            namelookup_time_us: 5112
+            pretransfer_time_us: 130487
+            redirect_time_us: 0
+            starttransfer_time_us: 130491
+            total_time_us: 452450

--- a/test/cassettes/shipments/lowestSmartrate.yml
+++ b/test/cassettes/shipments/lowestSmartrate.yml
@@ -1,0 +1,155 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/shipments'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+            X-Client-User-Agent: ''
+            EasyPost-Version: '2'
+        body: '{"shipment":{"to_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"from_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"},"customs_info":{"eel_pfc":"NOEEI 30.37(a)","customs_certify":"true","customs_signer":"Steve Brule","contents_type":"merchandise","restriction_type":"none","non_delivery_option":"return","customs_items":[{"description":"Sweet shirts","quantity":"2","weight":"11","value":"23","hs_tariff_number":"654321","origin_country":"US"}]},"options":{"label_format":"PNG","invoice_number":"123"},"reference":"123"}}'
+    response:
+        status:
+            http_version: '2'
+            code: '201'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 91732dbb62701d3ae78740a10021cdc1
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            location: /api/v2/shipments/shp_706ffc39cf5640129195eb5d81529e38
+            content-type: 'application/json; charset=utf-8'
+            content-length: '5565'
+            etag: 'W/"c9c2174ca263822097cd0dd7c97fccc5"'
+            x-runtime: '0.353850'
+            x-node: bigweb1nuq
+            x-version-label: easypost-202204282028-6188e715cb-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq fde591f008', 'extlb1nuq 5fac7c1107']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"created_at":"2022-05-02T18:04:42Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":null,"updated_at":"2022-05-02T18:04:42Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_70a1d7af92fe4e8b9e0eee964ad3fa49","object":"CustomsInfo","created_at":"2022-05-02T18:04:42Z","updated_at":"2022-05-02T18:04:42Z","contents_explanation":null,"contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_9ad47af091b44bb2bdfb35c3c8919de3","object":"CustomsItem","created_at":"2022-05-02T18:04:42Z","updated_at":"2022-05-02T18:04:42Z","description":"Sweet shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_5750f3abca4211ec8470ac1f6bc72124","object":"Address","created_at":"2022-05-02T18:04:42+00:00","updated_at":"2022-05-02T18:04:42+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_a34b3bd346444db1954516efb87cd7d1","object":"Parcel","created_at":"2022-05-02T18:04:42Z","updated_at":"2022-05-02T18:04:42Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_3f9ef31406b047c09e1c90ff589f335c","object":"Rate","created_at":"2022-05-02T18:04:42Z","updated_at":"2022-05-02T18:04:42Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_706ffc39cf5640129195eb5d81529e38","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_d8b7dc1b7fbd43649308faf2c132288e","object":"Rate","created_at":"2022-05-02T18:04:42Z","updated_at":"2022-05-02T18:04:42Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_706ffc39cf5640129195eb5d81529e38","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_2fffe34345a34a93b1c2a651ee325b6b","object":"Rate","created_at":"2022-05-02T18:04:42Z","updated_at":"2022-05-02T18:04:42Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_706ffc39cf5640129195eb5d81529e38","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"},{"id":"rate_fb69d62d379f4302b50a03346aab3afd","object":"Rate","created_at":"2022-05-02T18:04:42Z","updated_at":"2022-05-02T18:04:42Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_706ffc39cf5640129195eb5d81529e38","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_574f2a71ca4211ec846fac1f6bc72124","object":"Address","created_at":"2022-05-02T18:04:42+00:00","updated_at":"2022-05-02T18:04:42+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_5750f3abca4211ec8470ac1f6bc72124","object":"Address","created_at":"2022-05-02T18:04:42+00:00","updated_at":"2022-05-02T18:04:42+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_574f2a71ca4211ec846fac1f6bc72124","object":"Address","created_at":"2022-05-02T18:04:42+00:00","updated_at":"2022-05-02T18:04:42+00:00","name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_706ffc39cf5640129195eb5d81529e38","object":"Shipment"}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/shipments'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 785
+            request_size: 560
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.580205
+            namelookup_time: 0.038245
+            connect_time: 0.096699
+            pretransfer_time: 0.163871
+            size_upload: 836.0
+            size_download: 5565.0
+            speed_download: 9591.0
+            speed_upload: 1440.0
+            download_content_length: 5565.0
+            upload_content_length: 836.0
+            starttransfer_time: 0.163874
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.22
+            local_port: 51455
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 163801
+            connect_time_us: 96699
+            namelookup_time_us: 38245
+            pretransfer_time_us: 163871
+            redirect_time_us: 0
+            starttransfer_time_us: 163874
+            total_time_us: 580205
+-
+    request:
+        method: GET
+        url: 'https://api.easypost.com/v2/shipments/shp_706ffc39cf5640129195eb5d81529e38/smartrate'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+            X-Client-User-Agent: ''
+            EasyPost-Version: '2'
+    response:
+        status:
+            http_version: '2'
+            code: '200'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 91732dbf62701d3ae78740a20021ce02
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '2619'
+            etag: 'W/"70ea50acdf8311b470484904e76f3367"'
+            x-runtime: '0.078365'
+            x-node: bigweb9nuq
+            x-version-label: easypost-202204282028-6188e715cb-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq fde591f008', 'extlb1nuq 5fac7c1107']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600","created_at":"2022-05-02T18:04:42Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_3f9ef31406b047c09e1c90ff589f335c","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_706ffc39cf5640129195eb5d81529e38","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-05-02T18:04:42Z"},{"carrier":"USPS","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600","created_at":"2022-05-02T18:04:42Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_d8b7dc1b7fbd43649308faf2c132288e","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_706ffc39cf5640129195eb5d81529e38","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":3,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-05-02T18:04:42Z"},{"carrier":"USPS","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600","created_at":"2022-05-02T18:04:42Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_2fffe34345a34a93b1c2a651ee325b6b","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_706ffc39cf5640129195eb5d81529e38","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-05-02T18:04:42Z"},{"carrier":"USPS","carrier_account_id":"ca_8dc116debcdb49b5a66a2ddee4612600","created_at":"2022-05-02T18:04:42Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_fb69d62d379f4302b50a03346aab3afd","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_706ffc39cf5640129195eb5d81529e38","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-05-02T18:04:42Z"}]}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/shipments/shp_706ffc39cf5640129195eb5d81529e38/smartrate'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 200
+            header_size: 719
+            request_size: 585
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.271226
+            namelookup_time: 0.002056
+            connect_time: 0.059444
+            pretransfer_time: 0.134087
+            size_upload: 0.0
+            size_download: 2619.0
+            speed_download: 9656.0
+            speed_upload: 0.0
+            download_content_length: 2619.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.271208
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.22
+            local_port: 51456
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 134030
+            connect_time_us: 59444
+            namelookup_time_us: 2056
+            pretransfer_time_us: 134087
+            redirect_time_us: 0
+            starttransfer_time_us: 271208
+            total_time_us: 271226


### PR DESCRIPTION
# Description

- Adds a `lowest_rate` function to Orders and Pickups
- Adds `Shipment::get_lowest_smartrate()` and `$shipment.lowest_smartrate()` functions
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- [x] Adds various unit tests to ensure this works properly
<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
