### PR TITLE
Adds "errors" key handling on error responses

### DIFF
--- a/lib/EasyPost/Requestor.php
+++ b/lib/EasyPost/Requestor.php
@@ -297,7 +297,7 @@ class Requestor
 
         $message = "";
 
-        if (is_array($response['error']) ) {
+        if (is_array($response['error'])) {
             $message = $response['error']['message'];
         } elseif (!empty($response['error'])) {
             $message = $response['error'];

--- a/lib/EasyPost/Requestor.php
+++ b/lib/EasyPost/Requestor.php
@@ -291,10 +291,25 @@ class Requestor
      */
     public function handleApiError($httpBody, $httpStatus, $response)
     {
-        if (!is_array($response) || !isset($response['error'])) {
+        if (!is_array($response) && (!isset($response['error']) || ! isset($response['errors']))) {
             throw new Error("Invalid response object from API: HTTP Status: ({$httpStatus}) {$httpBody})", $httpStatus, $httpBody);
         }
-        throw new Error(is_array($response['error']) ? $response['error']['message'] : (!empty($response['error']) ? $response['error'] : ""), $httpStatus, $httpBody);
+
+        $message = "";
+
+        if (is_array($response['error']) ) {
+            $message = $response['error']['message'];
+        } elseif (!empty($response['error'])) {
+            $message = $response['error'];
+        }
+
+        if (isset($response['errors']) && is_array($response['errors'])) {
+            $message = join(' ', $response['errors']);
+        } elseif (!empty($response['errors'])) {
+            $message = $response['errors'];
+        }
+
+        throw new Error($message, $httpStatus, $httpBody);
     }
 
     /**

--- a/lib/EasyPost/Requestor.php
+++ b/lib/EasyPost/Requestor.php
@@ -291,7 +291,7 @@ class Requestor
      */
     public function handleApiError($httpBody, $httpStatus, $response)
     {
-        if (!is_array($response) && (!isset($response['error']) || ! isset($response['errors']))) {
+        if (!is_array($response) || !isset($response['error'])) {
             throw new Error("Invalid response object from API: HTTP Status: ({$httpStatus}) {$httpBody})", $httpStatus, $httpBody);
         }
 


### PR DESCRIPTION
# Description

- Fixes [https://github.com/EasyPost/easypost-php/issues/181](https://github.com/EasyPost/easypost-php/issues/181 ) by adding handling for cases where the error response message is found under the `errors` key. Currently only the `error` key is handled, leading to unhandled errors. 

# Testing
Not exactly sure if / how we can update the tests here. It seems only a specific error path is tested currently. This preserves current behavior by adding an `errors` key handling to handle GLS error responses from breaking apps when using the library. The other issue is that apparently production keys are required when running tests.

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
