### PR TITLE
fix: coerce array errors to strings if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Adds `Billing::retrieve_payment_methods()`, `Billing::fund_wallet()`, and `Billing::delete_payment_method()` functions
 - Adds OS specific details to the `User-Agent` header
+- Applies a patch to coerce array error messages to strings where error mapping is done improperly (as is the case with carriers like GSO/GLS)
 
 ## v5.2.1 (2022-05-31)
 

--- a/test/EasyPost/ErrorTest.php
+++ b/test/EasyPost/ErrorTest.php
@@ -46,9 +46,13 @@ class ErrorTest extends \PHPUnit\Framework\TestCase
             $_ = Shipment::create();
         } catch (Error $error) {
             $this->assertEquals(422, $error->getHttpStatus());
+            $this->assertEquals('SHIPMENT.INVALID_PARAMS', $error->ecode);
+            $this->assertEquals('Unable to create shipment, one or more parameters were invalid.', $error->getMessage());
+            $this->assertEquals(["to_address" => "Required and missing."], $error->errors[0]);
+            $this->assertEquals(["from_address" => "Required and missing."], $error->errors[1]);
             $this->assertEquals('{"error":{"code":"SHIPMENT.INVALID_PARAMS","message":"Unable to create shipment, one or more parameters were invalid.","errors":[{"to_address":"Required and missing."},{"from_address":"Required and missing."}]}}', $error->getHttpBody());
 
-            // We check that the printed output is the same here, leave the odd formatting as it is here and do not auto-format the next few lines
+            // We check that the pretty printed output is the same here, leave the odd formatting as it is here and do not auto-format the next few lines
             $error->prettyPrint();
             $this->expectOutputString('SHIPMENT.INVALID_PARAMS (422): Unable to create shipment, one or more parameters were invalid.
 Field errors:


### PR DESCRIPTION
# Description

The changes from #189 are found here with additional comments and tests. Cannot push to the original PR as it was not created off a branch and was on the master branch. These changes are backwards compatible while providing a bandaid fix for carriers like GSO/GLS.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- [x] Adds various tests to ensure we can pull out error properties properly
- [x] A/B tested an error message that was an array (placed the string into an array in the error cassette and it parsed properly)

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
