### PR TITLE
Add helper function to validate a webhook that is originated from Eas…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Adds `validateWebhook` function that returns your webhook or raises an error if there is a `webhookSecret` mismatch
+
 ## v5.4.0 (2022-07-18)
 
 - Add ability to generate forms for shipments via `generate_form()` function

--- a/lib/EasyPost/Webhook.php
+++ b/lib/EasyPost/Webhook.php
@@ -101,10 +101,10 @@ class Webhook extends EasypostResource
 
         if ($easypostHmacSignature != null) {
             $normalizedSecret = Normalizer::normalize($webhookSecret, Normalizer::FORM_KD);
-            $encodedSecret = mb_convert_encoding(utf8_encode($normalizedSecret), "ISO-8859-1", "UTF-8");
+            $encodedSecret = mb_convert_encoding($normalizedSecret, "UTF-8");
 
             $expectedSignature = hash_hmac("sha256", $eventBody, $encodedSecret);
-            $digest = "hmac-sha256-hex=" . $expectedSignature;
+            $digest = "hmac-sha256-hex=$expectedSignature";
 
             if (hash_equals($digest, $easypostHmacSignature)) {
                 $webhookBody = json_decode($eventBody);

--- a/test/EasyPost/Fixture.php
+++ b/test/EasyPost/Fixture.php
@@ -296,4 +296,41 @@ class Fixture
             ],
         ];
     }
+
+    public static function webhookBody()
+    {
+        $data = [
+            'result' => [
+                'id' => 'batch_123...',
+                'object' => 'Batch',
+                'mode' => 'test',
+                'state' => 'created',
+                'num_shipments' => 0,
+                'reference' => null,
+                'created_at' => '2022-07-26T17:22:32Z',
+                'updated_at' => '2022-07-26T17:22:32Z',
+                'scan_form' => null,
+                'shipments' => [],
+                'status' => [
+                    'created' => 0,
+                    'queued_for_purchase' => 0,
+                    'creation_failed' => 0,
+                    'postage_purchased' => 0,
+                    'postage_purchase_failed' => 0,
+                ],
+                'pickup' => null,
+                'label_url' => null,
+            ],
+            'description' => 'batch.created',
+            'mode' => 'test',
+            'previous_attributes' => null,
+            'completed_urls' => null,
+            'user_id' => 'user_123...',
+            'status' => 'pending',
+            'object' => 'Event',
+            'id' => 'evt_123...',
+        ];
+
+        return utf8_encode(json_encode($data));
+    }
 }


### PR DESCRIPTION
# Description

Adds a new function to validate if a webhook originated from EasyPost with the stored Webhook secret, if they do the function will return `event_body`, otherwise an error will be thrown.

# Testing

Add three unit tests

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
