### PR TITLE
fix: address verify params no longer required to be arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 - Adds `validateWebhook` function that returns your webhook or raises an error if there is a `webhookSecret` mismatch
+- Fixes a bug that required the values of `verify` and `verify_strict` params on an Address creation call to be arrays since passing `true` as a boolean is also valid (passing an array will continue to work but is no longer required)
 
 ## v5.4.0 (2022-07-18)
 

--- a/lib/EasyPost/Address.php
+++ b/lib/EasyPost/Address.php
@@ -60,13 +60,13 @@ class Address extends EasypostResource
     {
         $wrappedParams = [];
 
-        if (isset($params['verify']) && is_array($params['verify'])) {
+        if (isset($params['verify'])) {
             $verify = $params['verify'];
             unset($params['verify']);
             $wrappedParams['verify'] = $verify;
         }
 
-        if (isset($params['verify_strict']) && is_array($params['verify_strict'])) {
+        if (isset($params['verify_strict'])) {
             $verifyStrict = $params['verify_strict'];
             unset($params['verify_strict']);
             $wrappedParams['verify_strict'] = $verifyStrict;

--- a/test/EasyPost/AddressTest.php
+++ b/test/EasyPost/AddressTest.php
@@ -49,6 +49,28 @@ class AddressTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test creating a verified address.
+     *
+     * We purposefully pass in slightly incorrect data to get the corrected address back once verified.
+     *
+     * @return void
+     */
+    public function testCreateVerify()
+    {
+        VCR::insertCassette('addresses/createVerify.yml');
+
+        $addressData = Fixture::incorrect_address_to_verify();
+        $addressData['verify'] = true;
+
+        $address = Address::create($addressData);
+
+        $this->assertInstanceOf('\EasyPost\Address', $address);
+        $this->assertStringMatchesFormat('adr_%s', $address->id);
+        $this->assertEquals('417 MONTGOMERY ST FL 5', $address->street1);
+        $this->assertEquals('Invalid secondary information(Apt/Suite#)', $address->verifications->zip4->errors[0]->message);
+    }
+
+    /**
      * Test creating an address with verify_strict param.
      *
      * @return void
@@ -58,13 +80,35 @@ class AddressTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('addresses/createVerifyStrict.yml');
 
         $addressData = Fixture::basic_address();
-        $addressData['verify_strict'] = [true];
+        $addressData['verify_strict'] = true;
 
         $address = Address::create($addressData);
 
         $this->assertInstanceOf('\EasyPost\Address', $address);
         $this->assertStringMatchesFormat('adr_%s', $address->id);
         $this->assertEquals('388 TOWNSEND ST APT 20', $address->street1);
+    }
+
+    /**
+     * Test creating a verified address using the old array syntax for the `verify` key.
+     *
+     * We purposefully pass in slightly incorrect data to get the corrected address back once verified.
+     *
+     * @return void
+     */
+    public function testCreateVerifyArray()
+    {
+        VCR::insertCassette('addresses/createVerifyArray.yml');
+
+        $addressData = Fixture::incorrect_address_to_verify();
+        $addressData['verify'] = [true];
+
+        $address = Address::create($addressData);
+
+        $this->assertInstanceOf('\EasyPost\Address', $address);
+        $this->assertStringMatchesFormat('adr_%s', $address->id);
+        $this->assertEquals('417 MONTGOMERY ST FL 5', $address->street1);
+        $this->assertEquals('Invalid secondary information(Apt/Suite#)', $address->verifications->zip4->errors[0]->message);
     }
 
     /**
@@ -111,34 +155,12 @@ class AddressTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testCreateVerify()
-    {
-        VCR::insertCassette('addresses/createVerify.yml');
-
-        $addressData = Fixture::incorrect_address_to_verify();
-        $addressData['verify'] = [true];
-
-        $address = Address::create($addressData);
-
-        $this->assertInstanceOf('\EasyPost\Address', $address);
-        $this->assertStringMatchesFormat('adr_%s', $address->id);
-        $this->assertEquals('417 MONTGOMERY ST FL 5', $address->street1);
-        $this->assertEquals('Invalid secondary information(Apt/Suite#)', $address->verifications->zip4->errors[0]->message);
-    }
-
-    /**
-     * Test creating a verified address.
-     *
-     * We purposefully pass in slightly incorrect data to get the corrected address back once verified.
-     *
-     * @return void
-     */
     public function testCreateAndVerify()
     {
         VCR::insertCassette('addresses/createAndVerify.yml');
 
         $addressData = Fixture::incorrect_address_to_verify();
-        $addressData['verify'] = [true];
+        $addressData['verify'] = true;
 
         $address = Address::create_and_verify($addressData);
 

--- a/test/cassettes/addresses/createAndVerify.yml
+++ b/test/cassettes/addresses/createAndVerify.yml
@@ -9,7 +9,7 @@
             Authorization: ''
             Content-Type: application/json
             User-Agent: ''
-        body: '{"address":{"street1":"417 montgomery street","street2":"FL 5","city":"San Francisco","state":"CA","zip":"94104","country":"US","company":"EasyPost","phone":"415-123-4567","verify":["true"]}}'
+        body: '{"address":{"street1":"417 montgomery street","street2":"FL 5","city":"San Francisco","state":"CA","zip":"94104","country":"US","company":"EasyPost","phone":"415-123-4567","verify":"true"}}'
     response:
         status:
             http_version: '2'
@@ -22,56 +22,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 2f26e940627ed3f0e798bb370006f005
+            x-ep-request-uuid: 2415913e62e4123ee786a33c0002e640
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
-            location: /api/v2/addresses/adr_79fe46f2d30711ecb747ac1f6bc72124
+            location: /api/v2/addresses/adr_fd16c1dc0f5f11ed9cecac1f6b0a0d1e
             content-type: 'application/json; charset=utf-8'
             content-length: '905'
-            etag: 'W/"47565ba736df9896cfdb6b2a27ff6652"'
-            x-runtime: '0.040916'
-            x-node: bigweb9nuq
-            x-version-label: easypost-202205131956-9146889ba0-master
+            etag: 'W/"2ca2fd8c981651e70a8ccc8a79f07baf"'
+            x-runtime: '0.046285'
+            x-node: bigweb3nuq
+            x-version-label: easypost-202207282305-ef64fb0c25-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 570dfcbc0a', 'extlb1nuq c51cdb8bf2']
+            x-proxied: ['intlb2nuq 403f17ff97', 'extlb2nuq 403f17ff97']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"address":{"id":"adr_79fe46f2d30711ecb747ac1f6bc72124","object":"Address","created_at":"2022-05-13T21:56:00+00:00","updated_at":"2022-05-13T21:56:00+00:00","name":null,"company":"EASYPOST","street1":"417 MONTGOMERY ST FL 5","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94104-1129","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid secondary information(Apt\/Suite#)","suggestion":null}],"details":null},"delivery":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid secondary information(Apt\/Suite#)","suggestion":null}],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America\/Los_Angeles"}}}}}'
+        body: '{"address":{"id":"adr_fd16c1dc0f5f11ed9cecac1f6b0a0d1e","object":"Address","created_at":"2022-07-29T17:00:46+00:00","updated_at":"2022-07-29T17:00:46+00:00","name":null,"company":"EASYPOST","street1":"417 MONTGOMERY ST FL 5","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94104-1129","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid secondary information(Apt\/Suite#)","suggestion":null}],"details":null},"delivery":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid secondary information(Apt\/Suite#)","suggestion":null}],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America\/Los_Angeles"}}}}}'
         curl_info:
             url: 'https://api.easypost.com/v2/addresses/create_and_verify'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 784
-            request_size: 578
+            request_size: 324
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.233692
-            namelookup_time: 0.001922
-            connect_time: 0.061759
-            pretransfer_time: 0.13032
-            size_upload: 191.0
+            total_time: 0.234134
+            namelookup_time: 0.001739
+            connect_time: 0.060028
+            pretransfer_time: 0.127276
+            size_upload: 189.0
             size_download: 905.0
-            speed_download: 3872.0
-            speed_upload: 817.0
+            speed_download: 3865.0
+            speed_upload: 807.0
             download_content_length: 905.0
-            upload_content_length: 191.0
-            starttransfer_time: 0.130322
+            upload_content_length: 189.0
+            starttransfer_time: 0.127279
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 60013
+            local_ip: 10.130.6.25
+            local_port: 50055
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 130262
-            connect_time_us: 61759
-            namelookup_time_us: 1922
-            pretransfer_time_us: 130320
+            appconnect_time_us: 127226
+            connect_time_us: 60028
+            namelookup_time_us: 1739
+            pretransfer_time_us: 127276
             redirect_time_us: 0
-            starttransfer_time_us: 130322
-            total_time_us: 233692
+            starttransfer_time_us: 127279
+            total_time_us: 234134

--- a/test/cassettes/addresses/createVerify.yml
+++ b/test/cassettes/addresses/createVerify.yml
@@ -9,7 +9,7 @@
             Authorization: ''
             Content-Type: application/json
             User-Agent: ''
-        body: '{"verify":["true"],"address":{"street1":"417 montgomery street","street2":"FL 5","city":"San Francisco","state":"CA","zip":"94104","country":"US","company":"EasyPost","phone":"415-123-4567"}}'
+        body: '{"verify":"true","address":{"street1":"417 montgomery street","street2":"FL 5","city":"San Francisco","state":"CA","zip":"94104","country":"US","company":"EasyPost","phone":"415-123-4567"}}'
     response:
         status:
             http_version: '2'
@@ -22,56 +22,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 2f26e945627ed3f0e798bb360006eff6
+            x-ep-request-uuid: 2415913962e4123de786a33b0002e626
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
-            location: /api/v2/addresses/adr_79da1822d30711ec8a46ac1f6bc7b362
+            location: /api/v2/addresses/adr_fcf29a1f0f5f11eda4a9ac1f6bc7bdc6
             content-type: 'application/json; charset=utf-8'
             content-length: '893'
-            etag: 'W/"049c24482b4d722c497ea17338a86e75"'
-            x-runtime: '0.054281'
-            x-node: bigweb3nuq
-            x-version-label: easypost-202205131956-9146889ba0-master
+            etag: 'W/"9c393e8bc16789c77399923ae89c8916"'
+            x-runtime: '0.049199'
+            x-node: bigweb8nuq
+            x-version-label: easypost-202207282305-ef64fb0c25-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 570dfcbc0a', 'extlb1nuq c51cdb8bf2']
+            x-proxied: ['intlb2nuq 403f17ff97', 'extlb2nuq 403f17ff97']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"adr_79da1822d30711ec8a46ac1f6bc7b362","object":"Address","created_at":"2022-05-13T21:56:00+00:00","updated_at":"2022-05-13T21:56:00+00:00","name":null,"company":"EASYPOST","street1":"417 MONTGOMERY ST FL 5","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94104-1129","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid secondary information(Apt\/Suite#)","suggestion":null}],"details":null},"delivery":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid secondary information(Apt\/Suite#)","suggestion":null}],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America\/Los_Angeles"}}}}'
+        body: '{"id":"adr_fcf29a1f0f5f11eda4a9ac1f6bc7bdc6","object":"Address","created_at":"2022-07-29T17:00:45+00:00","updated_at":"2022-07-29T17:00:45+00:00","name":null,"company":"EASYPOST","street1":"417 MONTGOMERY ST FL 5","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94104-1129","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid secondary information(Apt\/Suite#)","suggestion":null}],"details":null},"delivery":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid secondary information(Apt\/Suite#)","suggestion":null}],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America\/Los_Angeles"}}}}'
         curl_info:
             url: 'https://api.easypost.com/v2/addresses'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
             header_size: 784
-            request_size: 560
+            request_size: 306
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.253979
-            namelookup_time: 0.002605
-            connect_time: 0.06291
-            pretransfer_time: 0.134749
-            size_upload: 191.0
+            total_time: 0.247346
+            namelookup_time: 0.003362
+            connect_time: 0.065035
+            pretransfer_time: 0.137359
+            size_upload: 189.0
             size_download: 893.0
-            speed_download: 3516.0
-            speed_upload: 752.0
+            speed_download: 3610.0
+            speed_upload: 764.0
             download_content_length: 893.0
-            upload_content_length: 191.0
-            starttransfer_time: 0.134753
+            upload_content_length: 189.0
+            starttransfer_time: 0.137364
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 60012
+            local_ip: 10.130.6.25
+            local_port: 50054
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 134662
-            connect_time_us: 62910
-            namelookup_time_us: 2605
-            pretransfer_time_us: 134749
+            appconnect_time_us: 137242
+            connect_time_us: 65035
+            namelookup_time_us: 3362
+            pretransfer_time_us: 137359
             redirect_time_us: 0
-            starttransfer_time_us: 134753
-            total_time_us: 253979
+            starttransfer_time_us: 137364
+            total_time_us: 247346

--- a/test/cassettes/addresses/createVerifyArray.yml
+++ b/test/cassettes/addresses/createVerifyArray.yml
@@ -1,0 +1,77 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/addresses'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+        body: '{"verify":["true"],"address":{"street1":"417 montgomery street","street2":"FL 5","city":"San Francisco","state":"CA","zip":"94104","country":"US","company":"EasyPost","phone":"415-123-4567"}}'
+    response:
+        status:
+            http_version: '2'
+            code: '201'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 2415914062e412ade786a3610003161c
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            location: /api/v2/addresses/adr_3f66e4d40f6011edb4daac1f6b0a0d1e
+            content-type: 'application/json; charset=utf-8'
+            content-length: '893'
+            etag: 'W/"cba0d02d4ee44bb00e2d192ac5f0949d"'
+            x-runtime: '0.046842'
+            x-node: bigweb3nuq
+            x-version-label: easypost-202207282305-ef64fb0c25-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq 403f17ff97', 'extlb2nuq 403f17ff97']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"adr_3f66e4d40f6011edb4daac1f6b0a0d1e","object":"Address","created_at":"2022-07-29T17:02:37+00:00","updated_at":"2022-07-29T17:02:37+00:00","name":null,"company":"EASYPOST","street1":"417 MONTGOMERY ST FL 5","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94104-1129","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid secondary information(Apt\/Suite#)","suggestion":null}],"details":null},"delivery":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid secondary information(Apt\/Suite#)","suggestion":null}],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America\/Los_Angeles"}}}}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/addresses'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 784
+            request_size: 306
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.241082
+            namelookup_time: 0.006848
+            connect_time: 0.067259
+            pretransfer_time: 0.133174
+            size_upload: 191.0
+            size_download: 893.0
+            speed_download: 3704.0
+            speed_upload: 792.0
+            download_content_length: 893.0
+            upload_content_length: 191.0
+            starttransfer_time: 0.133177
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.130
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.25
+            local_port: 50069
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 133105
+            connect_time_us: 67259
+            namelookup_time_us: 6848
+            pretransfer_time_us: 133174
+            redirect_time_us: 0
+            starttransfer_time_us: 133177
+            total_time_us: 241082

--- a/test/cassettes/addresses/createVerifyStrict.yml
+++ b/test/cassettes/addresses/createVerifyStrict.yml
@@ -9,7 +9,7 @@
             Authorization: ''
             Content-Type: application/json
             User-Agent: ''
-        body: '{"verify_strict":["true"],"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"}}'
+        body: '{"verify_strict":"true","address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"}}'
     response:
         status:
             http_version: '2'
@@ -22,56 +22,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 2f26e940627ed3f1e798bb390006f018
+            x-ep-request-uuid: 2415913a62e4123de786a33a0002e608
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
-            location: /api/v2/addresses/adr_7a47a935d30711ec8a54ac1f6bc7b362
+            location: /api/v2/addresses/adr_fcca3e8f0f5f11eda489ac1f6bc7b362
             content-type: 'application/json; charset=utf-8'
             content-length: '638'
-            etag: 'W/"5190d7e5f4e29f7ad23c1169681fc3fb"'
-            x-runtime: '0.045004'
-            x-node: bigweb1nuq
-            x-version-label: easypost-202205131956-9146889ba0-master
+            etag: 'W/"6cf5ee7863078aa1554e22dc056cfc8c"'
+            x-runtime: '0.058602'
+            x-node: bigweb2nuq
+            x-version-label: easypost-202207282305-ef64fb0c25-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 570dfcbc0a', 'extlb1nuq c51cdb8bf2']
+            x-proxied: ['intlb1nuq 403f17ff97', 'extlb2nuq 403f17ff97']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"adr_7a47a935d30711ec8a54ac1f6bc7b362","object":"Address","created_at":"2022-05-13T21:56:01+00:00","updated_at":"2022-05-13T21:56:01+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}}'
+        body: '{"id":"adr_fcca3e8f0f5f11eda489ac1f6bc7b362","object":"Address","created_at":"2022-07-29T17:00:45+00:00","updated_at":"2022-07-29T17:00:45+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}}'
         curl_info:
             url: 'https://api.easypost.com/v2/addresses'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
             header_size: 784
-            request_size: 560
+            request_size: 306
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.236666
-            namelookup_time: 0.002593
-            connect_time: 0.061469
-            pretransfer_time: 0.130677
-            size_upload: 199.0
+            total_time: 0.269344
+            namelookup_time: 0.019559
+            connect_time: 0.079228
+            pretransfer_time: 0.149813
+            size_upload: 197.0
             size_download: 638.0
-            speed_download: 2695.0
-            speed_upload: 840.0
+            speed_download: 2368.0
+            speed_upload: 731.0
             download_content_length: 638.0
-            upload_content_length: 199.0
-            starttransfer_time: 0.130681
+            upload_content_length: 197.0
+            starttransfer_time: 0.149817
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.6
-            local_port: 60015
+            local_ip: 10.130.6.25
+            local_port: 50053
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 130569
-            connect_time_us: 61469
-            namelookup_time_us: 2593
-            pretransfer_time_us: 130677
+            appconnect_time_us: 149027
+            connect_time_us: 79228
+            namelookup_time_us: 19559
+            pretransfer_time_us: 149813
             redirect_time_us: 0
-            starttransfer_time_us: 130681
-            total_time_us: 236666
+            starttransfer_time_us: 149817
+            total_time_us: 269344


### PR DESCRIPTION
# Description

Fixes a bug that required the values of `verify` and `verify_strict` params on an Address creation call to be arrays since passing `true` as a boolean is also valid (passing an array will continue to work but is no longer required)

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- Updates unit tests to use boolean instead of an array
- Adds a new unit test to ensure that arrays continue to work (backwards compatible fix)

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
