### PR TITLE
Remove `return` docstrings for unit tests

### DIFF
--- a/test/EasyPost/AddressTest.php
+++ b/test/EasyPost/AddressTest.php
@@ -12,7 +12,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     *
      */
     public static function setUpBeforeClass(): void
     {
@@ -24,7 +24,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     *
      */
     public static function tearDownAfterClass(): void
     {
@@ -35,7 +35,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating an address.
      *
-     * @return void
+     *
      */
     public function testCreate()
     {
@@ -53,7 +53,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
      *
      * We purposefully pass in slightly incorrect data to get the corrected address back once verified.
      *
-     * @return void
+     *
      */
     public function testCreateVerify()
     {
@@ -73,7 +73,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating an address with verify_strict param.
      *
-     * @return void
+     *
      */
     public function testCreateVerifyStrict()
     {
@@ -94,7 +94,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
      *
      * We purposefully pass in slightly incorrect data to get the corrected address back once verified.
      *
-     * @return void
+     *
      */
     public function testCreateVerifyArray()
     {
@@ -114,7 +114,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving an address.
      *
-     * @return void
+     *
      */
     public function testRetrieve()
     {
@@ -131,7 +131,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving all addresses.
      *
-     * @return void
+     *
      */
     public function testAll()
     {
@@ -153,7 +153,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
      *
      * We purposefully pass in slightly incorrect data to get the corrected address back once verified.
      *
-     * @return void
+     *
      */
     public function testCreateAndVerify()
     {
@@ -171,7 +171,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
     /**
      * Test we can verify an already created address.
      *
-     * @return void
+     *
      */
     public function testVerify()
     {

--- a/test/EasyPost/AddressTest.php
+++ b/test/EasyPost/AddressTest.php
@@ -11,8 +11,6 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     *
      */
     public static function setUpBeforeClass(): void
     {
@@ -23,8 +21,6 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     *
      */
     public static function tearDownAfterClass(): void
     {
@@ -34,8 +30,6 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating an address.
-     *
-     *
      */
     public function testCreate()
     {
@@ -52,8 +46,6 @@ class AddressTest extends \PHPUnit\Framework\TestCase
      * Test creating a verified address.
      *
      * We purposefully pass in slightly incorrect data to get the corrected address back once verified.
-     *
-     *
      */
     public function testCreateVerify()
     {
@@ -72,8 +64,6 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating an address with verify_strict param.
-     *
-     *
      */
     public function testCreateVerifyStrict()
     {
@@ -93,8 +83,6 @@ class AddressTest extends \PHPUnit\Framework\TestCase
      * Test creating a verified address using the old array syntax for the `verify` key.
      *
      * We purposefully pass in slightly incorrect data to get the corrected address back once verified.
-     *
-     *
      */
     public function testCreateVerifyArray()
     {
@@ -113,8 +101,6 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving an address.
-     *
-     *
      */
     public function testRetrieve()
     {
@@ -130,8 +116,6 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving all addresses.
-     *
-     *
      */
     public function testAll()
     {
@@ -152,8 +136,6 @@ class AddressTest extends \PHPUnit\Framework\TestCase
      * Test creating a verified address.
      *
      * We purposefully pass in slightly incorrect data to get the corrected address back once verified.
-     *
-     *
      */
     public function testCreateAndVerify()
     {
@@ -170,8 +152,6 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test we can verify an already created address.
-     *
-     *
      */
     public function testVerify()
     {

--- a/test/EasyPost/BatchTest.php
+++ b/test/EasyPost/BatchTest.php
@@ -12,8 +12,6 @@ class BatchTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -24,8 +22,6 @@ class BatchTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -35,8 +31,6 @@ class BatchTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a Batch.
-     *
-     * 
      */
     public function testCreate()
     {
@@ -53,8 +47,6 @@ class BatchTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving a Batch.
-     *
-     * 
      */
     public function testRetrieve()
     {
@@ -72,8 +64,6 @@ class BatchTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving all batches.
-     *
-     * 
      */
     public function testAll()
     {
@@ -92,8 +82,6 @@ class BatchTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating and buying a Batch in a single call.
-     *
-     * 
      */
     public function testCreateAndBuy()
     {
@@ -111,8 +99,6 @@ class BatchTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test buying a batch.
-     *
-     * 
      */
     public function testBuy()
     {
@@ -135,8 +121,6 @@ class BatchTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a scanform for a batch.
-     *
-     * 
      */
     public function testCreateScanForm()
     {
@@ -162,8 +146,6 @@ class BatchTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test adding and removing a shipment from a batch.
-     *
-     * 
      */
     public function testAddRemoveShipment()
     {
@@ -186,8 +168,6 @@ class BatchTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test generating a label for a Batch.
-     *
-     * 
      */
     public function testLabel()
     {

--- a/test/EasyPost/BatchTest.php
+++ b/test/EasyPost/BatchTest.php
@@ -13,7 +13,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -25,7 +25,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -36,7 +36,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a Batch.
      *
-     * @return void
+     * 
      */
     public function testCreate()
     {
@@ -54,7 +54,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving a Batch.
      *
-     * @return void
+     * 
      */
     public function testRetrieve()
     {
@@ -73,7 +73,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving all batches.
      *
-     * @return void
+     * 
      */
     public function testAll()
     {
@@ -93,7 +93,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating and buying a Batch in a single call.
      *
-     * @return void
+     * 
      */
     public function testCreateAndBuy()
     {
@@ -112,7 +112,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
     /**
      * Test buying a batch.
      *
-     * @return void
+     * 
      */
     public function testBuy()
     {
@@ -136,7 +136,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a scanform for a batch.
      *
-     * @return void
+     * 
      */
     public function testCreateScanForm()
     {
@@ -163,7 +163,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
     /**
      * Test adding and removing a shipment from a batch.
      *
-     * @return void
+     * 
      */
     public function testAddRemoveShipment()
     {
@@ -187,7 +187,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
     /**
      * Test generating a label for a Batch.
      *
-     * @return void
+     * 
      */
     public function testLabel()
     {

--- a/test/EasyPost/Beta/EndShipperTest.php
+++ b/test/EasyPost/Beta/EndShipperTest.php
@@ -10,8 +10,6 @@ class EndShipperTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     *
      */
     public static function setUpBeforeClass(): void
     {
@@ -22,8 +20,6 @@ class EndShipperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     *
      */
     public static function tearDownAfterClass(): void
     {
@@ -62,8 +58,6 @@ class EndShipperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving all EndShippers.
-     *
-     *
      */
     public function testAll()
     {

--- a/test/EasyPost/Beta/EndShipperTest.php
+++ b/test/EasyPost/Beta/EndShipperTest.php
@@ -11,7 +11,7 @@ class EndShipperTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     *
      */
     public static function setUpBeforeClass(): void
     {
@@ -23,7 +23,7 @@ class EndShipperTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     *
      */
     public static function tearDownAfterClass(): void
     {
@@ -33,8 +33,6 @@ class EndShipperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating an EndShipper.
-     *
-     * @return EndShipper
      */
     public function testCreate()
     {
@@ -45,32 +43,27 @@ class EndShipperTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('\EasyPost\Beta\EndShipper', $endShipper);
         $this->assertStringMatchesFormat('es_%s', $endShipper->id);
         $this->assertEquals('388 TOWNSEND ST APT 20', $endShipper->street1);
-
-        return $endShipper;
     }
 
     /**
      * Test retrieving an EndShipper.
-     *
-     * @depends testCreate
-     * @return EndShipper
      */
-    public function testRetrieve(EndShipper $endShipper)
+    public function testRetrieve()
     {
         VCR::insertCassette('end_shipper/retrieve.yml');
+
+        $endShipper = EndShipper::create(Fixture::end_shipper_address());
 
         $retrievedEndShipper = EndShipper::retrieve($endShipper->id);
 
         $this->assertInstanceOf('\EasyPost\Beta\EndShipper', $retrievedEndShipper);
         $this->assertEquals($endShipper->street1, $retrievedEndShipper->street1);
-
-        return $retrievedEndShipper;
     }
 
     /**
      * Test retrieving all EndShippers.
      *
-     * @return void
+     *
      */
     public function testAll()
     {
@@ -86,13 +79,12 @@ class EndShipperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test updating an EndShipper.
-     *
-     * @depends testCreate
-     * @return EndShipper
      */
-    public function testUpdate(EndShipper $endShipper)
+    public function testUpdate()
     {
         VCR::insertCassette('end_shipper/update.yml');
+
+        $endShipper = EndShipper::create(Fixture::end_shipper_address());
 
         // All caps because API will return all caps as part of verification.
         $newName = 'NEW NAME';

--- a/test/EasyPost/BillingTest.php
+++ b/test/EasyPost/BillingTest.php
@@ -10,8 +10,6 @@ class BillingTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     *
      */
     public static function setUpBeforeClass(): void
     {
@@ -22,8 +20,6 @@ class BillingTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     *
      */
     public static function tearDownAfterClass(): void
     {
@@ -33,8 +29,6 @@ class BillingTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test funding a EasyPost wallet by using either primary or secondary payment method.
-     *
-     *
      */
     public function testFundWallet()
     {
@@ -49,8 +43,6 @@ class BillingTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test deleting a payment method.
-     *
-     *
      */
     public function testDeletePaymentMethod()
     {
@@ -65,8 +57,6 @@ class BillingTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving all payment methods.
-     *
-     *
      */
     public function testRetrievePaymentMethods()
     {

--- a/test/EasyPost/BillingTest.php
+++ b/test/EasyPost/BillingTest.php
@@ -11,7 +11,7 @@ class BillingTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     *
      */
     public static function setUpBeforeClass(): void
     {
@@ -23,7 +23,7 @@ class BillingTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     *
      */
     public static function tearDownAfterClass(): void
     {
@@ -34,7 +34,7 @@ class BillingTest extends \PHPUnit\Framework\TestCase
     /**
      * Test funding a EasyPost wallet by using either primary or secondary payment method.
      *
-     * @return void
+     *
      */
     public function testFundWallet()
     {
@@ -50,7 +50,7 @@ class BillingTest extends \PHPUnit\Framework\TestCase
     /**
      * Test deleting a payment method.
      *
-     * @return void
+     *
      */
     public function testDeletePaymentMethod()
     {
@@ -66,7 +66,7 @@ class BillingTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving all payment methods.
      *
-     * @return void
+     *
      */
     public function testRetrievePaymentMethods()
     {

--- a/test/EasyPost/CarrierAccountTest.php
+++ b/test/EasyPost/CarrierAccountTest.php
@@ -12,7 +12,7 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     *
      */
     public static function setUpBeforeClass(): void
     {
@@ -24,7 +24,7 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     *
      */
     public static function tearDownAfterClass(): void
     {
@@ -35,7 +35,7 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a carrier account.
      *
-     * @return void
+     *
      */
     public function testCreate()
     {
@@ -53,7 +53,7 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving a carrier account.
      *
-     * @return void
+     *
      */
     public function testRetrieve()
     {
@@ -72,7 +72,7 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving all carrier accounts.
      *
-     * @return void
+     *
      */
     public function testAll()
     {
@@ -86,7 +86,7 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
     /**
      * Test updating a carrier account.
      *
-     * @return void
+     *
      */
     public function testUpdate()
     {
@@ -109,7 +109,7 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
     /**
      * Test deleting a carrier account.
      *
-     * @return void
+     *
      */
     public function testDelete()
     {
@@ -125,7 +125,7 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving the carrier account types available.
      *
-     * @return void
+     *
      */
     public function testTypes()
     {

--- a/test/EasyPost/CarrierAccountTest.php
+++ b/test/EasyPost/CarrierAccountTest.php
@@ -11,8 +11,6 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     *
      */
     public static function setUpBeforeClass(): void
     {
@@ -23,8 +21,6 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     *
      */
     public static function tearDownAfterClass(): void
     {
@@ -34,8 +30,6 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a carrier account.
-     *
-     *
      */
     public function testCreate()
     {
@@ -52,8 +46,6 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving a carrier account.
-     *
-     *
      */
     public function testRetrieve()
     {
@@ -71,8 +63,6 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving all carrier accounts.
-     *
-     *
      */
     public function testAll()
     {
@@ -85,8 +75,6 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test updating a carrier account.
-     *
-     *
      */
     public function testUpdate()
     {
@@ -108,8 +96,6 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test deleting a carrier account.
-     *
-     *
      */
     public function testDelete()
     {
@@ -124,8 +110,6 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving the carrier account types available.
-     *
-     *
      */
     public function testTypes()
     {

--- a/test/EasyPost/CustomsInfoTest.php
+++ b/test/EasyPost/CustomsInfoTest.php
@@ -12,7 +12,7 @@ class CustomsInfoTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     *
      */
     public static function setUpBeforeClass(): void
     {
@@ -24,7 +24,7 @@ class CustomsInfoTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     *
      */
     public static function tearDownAfterClass(): void
     {
@@ -35,7 +35,7 @@ class CustomsInfoTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a CustomsInfo.
      *
-     * @return void
+     *
      */
     public function testCreate()
     {
@@ -51,7 +51,7 @@ class CustomsInfoTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving a CustomsInfo.
      *
-     * @return void
+     *
      */
     public function testRetrieve()
     {

--- a/test/EasyPost/CustomsInfoTest.php
+++ b/test/EasyPost/CustomsInfoTest.php
@@ -11,8 +11,6 @@ class CustomsInfoTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     *
      */
     public static function setUpBeforeClass(): void
     {
@@ -23,8 +21,6 @@ class CustomsInfoTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     *
      */
     public static function tearDownAfterClass(): void
     {
@@ -34,8 +30,6 @@ class CustomsInfoTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a CustomsInfo.
-     *
-     *
      */
     public function testCreate()
     {
@@ -50,8 +44,6 @@ class CustomsInfoTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving a CustomsInfo.
-     *
-     *
      */
     public function testRetrieve()
     {

--- a/test/EasyPost/CustomsItemTest.php
+++ b/test/EasyPost/CustomsItemTest.php
@@ -11,8 +11,6 @@ class CustomsItemTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     *
      */
     public static function setUpBeforeClass(): void
     {
@@ -23,8 +21,6 @@ class CustomsItemTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     *
      */
     public static function tearDownAfterClass(): void
     {
@@ -34,8 +30,6 @@ class CustomsItemTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a CustomsItem.
-     *
-     *
      */
     public function testCreate()
     {
@@ -50,8 +44,6 @@ class CustomsItemTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving a CustomsItem.
-     *
-     *
      */
     public function testRetrieve()
     {

--- a/test/EasyPost/CustomsItemTest.php
+++ b/test/EasyPost/CustomsItemTest.php
@@ -12,7 +12,7 @@ class CustomsItemTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     *
      */
     public static function setUpBeforeClass(): void
     {
@@ -24,7 +24,7 @@ class CustomsItemTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     *
      */
     public static function tearDownAfterClass(): void
     {
@@ -35,7 +35,7 @@ class CustomsItemTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a CustomsItem.
      *
-     * @return void
+     *
      */
     public function testCreate()
     {
@@ -51,7 +51,7 @@ class CustomsItemTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving a CustomsItem.
      *
-     * @return void
+     *
      */
     public function testRetrieve()
     {

--- a/test/EasyPost/EasyPostTest.php
+++ b/test/EasyPost/EasyPostTest.php
@@ -9,7 +9,7 @@ class EasyPostTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -23,7 +23,7 @@ class EasyPostTest extends \PHPUnit\Framework\TestCase
     /**
      * Test setting and getting the API key.
      *
-     * @return void
+     * 
      */
     public function testApiKey()
     {
@@ -36,7 +36,7 @@ class EasyPostTest extends \PHPUnit\Framework\TestCase
     /**
      * Test setting and getting the API base.
      *
-     * @return void
+     * 
      */
     public function testApiBase()
     {
@@ -51,7 +51,7 @@ class EasyPostTest extends \PHPUnit\Framework\TestCase
     /**
      * Test setting and getting the API version.
      *
-     * @return void
+     * 
      */
     public function testApiVersion()
     {
@@ -66,7 +66,7 @@ class EasyPostTest extends \PHPUnit\Framework\TestCase
     /**
      * Test setting and getting the connection timeout.
      *
-     * @return void
+     * 
      */
     public function testConnectionTimeout()
     {
@@ -81,7 +81,7 @@ class EasyPostTest extends \PHPUnit\Framework\TestCase
     /**
      * Test setting and getting the request timeout.
      *
-     * @return void
+     * 
      */
     public function testRequestTimeout()
     {

--- a/test/EasyPost/EasyPostTest.php
+++ b/test/EasyPost/EasyPostTest.php
@@ -8,8 +8,6 @@ class EasyPostTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Cleanup the testing environment once finished.
-     *
-     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -22,8 +20,6 @@ class EasyPostTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test setting and getting the API key.
-     *
-     * 
      */
     public function testApiKey()
     {
@@ -35,8 +31,6 @@ class EasyPostTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test setting and getting the API base.
-     *
-     * 
      */
     public function testApiBase()
     {
@@ -50,8 +44,6 @@ class EasyPostTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test setting and getting the API version.
-     *
-     * 
      */
     public function testApiVersion()
     {
@@ -65,8 +57,6 @@ class EasyPostTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test setting and getting the connection timeout.
-     *
-     * 
      */
     public function testConnectionTimeout()
     {
@@ -80,8 +70,6 @@ class EasyPostTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test setting and getting the request timeout.
-     *
-     * 
      */
     public function testRequestTimeout()
     {

--- a/test/EasyPost/ErrorTest.php
+++ b/test/EasyPost/ErrorTest.php
@@ -11,8 +11,6 @@ class ErrorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     *
      */
     public static function setUpBeforeClass(): void
     {
@@ -23,8 +21,6 @@ class ErrorTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     *
      */
     public static function tearDownAfterClass(): void
     {
@@ -34,8 +30,6 @@ class ErrorTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a bad shipment and retrieving errors.
-     *
-     *
      */
     public function testError()
     {

--- a/test/EasyPost/ErrorTest.php
+++ b/test/EasyPost/ErrorTest.php
@@ -12,7 +12,7 @@ class ErrorTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     *
      */
     public static function setUpBeforeClass(): void
     {
@@ -24,7 +24,7 @@ class ErrorTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     *
      */
     public static function tearDownAfterClass(): void
     {
@@ -35,7 +35,7 @@ class ErrorTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a bad shipment and retrieving errors.
      *
-     * @return void
+     *
      */
     public function testError()
     {

--- a/test/EasyPost/EventTest.php
+++ b/test/EasyPost/EventTest.php
@@ -13,7 +13,7 @@ class EventTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     *
      */
     public static function setUpBeforeClass(): void
     {
@@ -25,7 +25,7 @@ class EventTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     *
      */
     public static function tearDownAfterClass(): void
     {
@@ -36,7 +36,7 @@ class EventTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving all events.
      *
-     * @return void
+     *
      */
     public function testAll()
     {
@@ -56,7 +56,7 @@ class EventTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving an event.
      *
-     * @return void
+     *
      */
     public function testRetrieve()
     {
@@ -75,7 +75,7 @@ class EventTest extends \PHPUnit\Framework\TestCase
     /**
      * Test receiving (converting) an event.
      *
-     * @return void
+     *
      */
     public function testReceive()
     {
@@ -88,7 +88,7 @@ class EventTest extends \PHPUnit\Framework\TestCase
     /**
      * Test that we throw an error when bad input is received.
      *
-     * @return void
+     *
      */
     public function testReceiveBadInput()
     {
@@ -100,7 +100,7 @@ class EventTest extends \PHPUnit\Framework\TestCase
     /**
      * Test that we throw an error when no input is received.
      *
-     * @return void
+     *
      */
     public function testReceiveNoInput()
     {

--- a/test/EasyPost/EventTest.php
+++ b/test/EasyPost/EventTest.php
@@ -12,8 +12,6 @@ class EventTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     *
      */
     public static function setUpBeforeClass(): void
     {
@@ -24,8 +22,6 @@ class EventTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     *
      */
     public static function tearDownAfterClass(): void
     {
@@ -35,8 +31,6 @@ class EventTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving all events.
-     *
-     *
      */
     public function testAll()
     {
@@ -55,8 +49,6 @@ class EventTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving an event.
-     *
-     *
      */
     public function testRetrieve()
     {
@@ -74,8 +66,6 @@ class EventTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test receiving (converting) an event.
-     *
-     *
      */
     public function testReceive()
     {
@@ -87,8 +77,6 @@ class EventTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test that we throw an error when bad input is received.
-     *
-     *
      */
     public function testReceiveBadInput()
     {
@@ -99,8 +87,6 @@ class EventTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test that we throw an error when no input is received.
-     *
-     *
      */
     public function testReceiveNoInput()
     {

--- a/test/EasyPost/InsuranceTest.php
+++ b/test/EasyPost/InsuranceTest.php
@@ -13,7 +13,7 @@ class InsuranceTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -25,7 +25,7 @@ class InsuranceTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -36,7 +36,7 @@ class InsuranceTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating an insurance object.
      *
-     * @return void
+     * 
      */
     public function testCreate()
     {
@@ -57,7 +57,7 @@ class InsuranceTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving an insurance object.
      *
-     * @return void
+     * 
      */
     public function testRetrieve()
     {
@@ -79,7 +79,7 @@ class InsuranceTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving all insurance.
      *
-     * @return void
+     * 
      */
     public function testAll()
     {

--- a/test/EasyPost/InsuranceTest.php
+++ b/test/EasyPost/InsuranceTest.php
@@ -12,8 +12,6 @@ class InsuranceTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -24,8 +22,6 @@ class InsuranceTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -35,8 +31,6 @@ class InsuranceTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating an insurance object.
-     *
-     * 
      */
     public function testCreate()
     {
@@ -56,8 +50,6 @@ class InsuranceTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving an insurance object.
-     *
-     * 
      */
     public function testRetrieve()
     {
@@ -78,8 +70,6 @@ class InsuranceTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving all insurance.
-     *
-     * 
      */
     public function testAll()
     {

--- a/test/EasyPost/OrderTest.php
+++ b/test/EasyPost/OrderTest.php
@@ -13,7 +13,7 @@ class OrderTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -25,7 +25,7 @@ class OrderTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -36,7 +36,7 @@ class OrderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating an Order.
      *
-     * @return void
+     * 
      */
     public function testCreate()
     {
@@ -52,7 +52,7 @@ class OrderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving an Order.
      *
-     * @return void
+     * 
      */
     public function testRetrieve()
     {
@@ -69,7 +69,7 @@ class OrderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving rates for a order.
      *
-     * @return void
+     * 
      */
     public function testGetRates()
     {
@@ -88,7 +88,7 @@ class OrderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test buying an Order.
      *
-     * @return void
+     * 
      */
     public function testBuy()
     {
@@ -111,7 +111,7 @@ class OrderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test various usage alterations of the lowest_rate method.
      *
-     * @return void
+     * 
      */
     public function testLowestRate()
     {

--- a/test/EasyPost/OrderTest.php
+++ b/test/EasyPost/OrderTest.php
@@ -12,8 +12,6 @@ class OrderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -24,8 +22,6 @@ class OrderTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -35,8 +31,6 @@ class OrderTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating an Order.
-     *
-     * 
      */
     public function testCreate()
     {
@@ -51,8 +45,6 @@ class OrderTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving an Order.
-     *
-     * 
      */
     public function testRetrieve()
     {
@@ -68,8 +60,6 @@ class OrderTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving rates for a order.
-     *
-     * 
      */
     public function testGetRates()
     {
@@ -87,8 +77,6 @@ class OrderTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test buying an Order.
-     *
-     * 
      */
     public function testBuy()
     {
@@ -110,8 +98,6 @@ class OrderTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test various usage alterations of the lowest_rate method.
-     *
-     * 
      */
     public function testLowestRate()
     {

--- a/test/EasyPost/ParcelTest.php
+++ b/test/EasyPost/ParcelTest.php
@@ -11,8 +11,6 @@ class ParcelTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -23,8 +21,6 @@ class ParcelTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -34,8 +30,6 @@ class ParcelTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a Parcel.
-     *
-     * 
      */
     public function testCreate()
     {
@@ -50,8 +44,6 @@ class ParcelTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving a Parcel.
-     *
-     * 
      */
     public function testRetrieve()
     {

--- a/test/EasyPost/ParcelTest.php
+++ b/test/EasyPost/ParcelTest.php
@@ -12,7 +12,7 @@ class ParcelTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -24,7 +24,7 @@ class ParcelTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -35,7 +35,7 @@ class ParcelTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a Parcel.
      *
-     * @return void
+     * 
      */
     public function testCreate()
     {
@@ -51,7 +51,7 @@ class ParcelTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving a Parcel.
      *
-     * @return void
+     * 
      */
     public function testRetrieve()
     {

--- a/test/EasyPost/PickupTest.php
+++ b/test/EasyPost/PickupTest.php
@@ -13,8 +13,6 @@ class PickupTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -25,8 +23,6 @@ class PickupTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -36,8 +32,6 @@ class PickupTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a pickup.
-     *
-     * 
      */
     public function testCreate()
     {
@@ -57,8 +51,6 @@ class PickupTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving a pickup.
-     *
-     * 
      */
     public function testRetrieve()
     {
@@ -103,8 +95,6 @@ class PickupTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test cancelling a pickup.
-     *
-     * 
      */
     public function testCancel()
     {
@@ -131,8 +121,6 @@ class PickupTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test various usage alterations of the lowest_rate method.
-     *
-     * 
      */
     public function testLowestRate()
     {

--- a/test/EasyPost/PickupTest.php
+++ b/test/EasyPost/PickupTest.php
@@ -14,7 +14,7 @@ class PickupTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -26,7 +26,7 @@ class PickupTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -37,7 +37,7 @@ class PickupTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a pickup.
      *
-     * @return void
+     * 
      */
     public function testCreate()
     {
@@ -58,7 +58,7 @@ class PickupTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving a pickup.
      *
-     * @return void
+     * 
      */
     public function testRetrieve()
     {
@@ -78,8 +78,6 @@ class PickupTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test buying a pickup.
-     *
-     * @return Pickup
      */
     public function testBuy()
     {
@@ -106,7 +104,7 @@ class PickupTest extends \PHPUnit\Framework\TestCase
     /**
      * Test cancelling a pickup.
      *
-     * @return void
+     * 
      */
     public function testCancel()
     {
@@ -134,7 +132,7 @@ class PickupTest extends \PHPUnit\Framework\TestCase
     /**
      * Test various usage alterations of the lowest_rate method.
      *
-     * @return void
+     * 
      */
     public function testLowestRate()
     {

--- a/test/EasyPost/RateTest.php
+++ b/test/EasyPost/RateTest.php
@@ -13,7 +13,7 @@ class RateTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -25,7 +25,7 @@ class RateTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -36,7 +36,7 @@ class RateTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving a rate.
      *
-     * @return void
+     * 
      */
     public function testRetrieve()
     {

--- a/test/EasyPost/RateTest.php
+++ b/test/EasyPost/RateTest.php
@@ -12,8 +12,6 @@ class RateTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -24,8 +22,6 @@ class RateTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -35,8 +31,6 @@ class RateTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving a rate.
-     *
-     * 
      */
     public function testRetrieve()
     {

--- a/test/EasyPost/RefundTest.php
+++ b/test/EasyPost/RefundTest.php
@@ -13,7 +13,7 @@ class RefundTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -25,7 +25,7 @@ class RefundTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -36,7 +36,7 @@ class RefundTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a refund.
      *
-     * @return void
+     * 
      */
     public function testCreate()
     {
@@ -57,7 +57,7 @@ class RefundTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving all refunds.
      *
-     * @return void
+     * 
      */
     public function testAll()
     {
@@ -80,7 +80,7 @@ class RefundTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving a refund.
      *
-     * @return void
+     * 
      */
     public function testRetrieve()
     {

--- a/test/EasyPost/RefundTest.php
+++ b/test/EasyPost/RefundTest.php
@@ -12,8 +12,6 @@ class RefundTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -24,8 +22,6 @@ class RefundTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -35,8 +31,6 @@ class RefundTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a refund.
-     *
-     * 
      */
     public function testCreate()
     {
@@ -56,8 +50,6 @@ class RefundTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving all refunds.
-     *
-     * 
      */
     public function testAll()
     {
@@ -79,8 +71,6 @@ class RefundTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving a refund.
-     *
-     * 
      */
     public function testRetrieve()
     {

--- a/test/EasyPost/ReportTest.php
+++ b/test/EasyPost/ReportTest.php
@@ -11,8 +11,6 @@ class ReportTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -23,8 +21,6 @@ class ReportTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -51,8 +47,6 @@ class ReportTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a report with custom columns
-     *
-     * 
      */
     public function testCreateCustomColumnReport()
     {
@@ -73,8 +67,6 @@ class ReportTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a report with custom additional columns
-     *
-     * 
      */
     public function testCreateCustomAdditionalColumnReport()
     {
@@ -95,8 +87,6 @@ class ReportTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving a report.
-     *
-     * 
      */
     public function testRetrieveReport()
     {
@@ -117,8 +107,6 @@ class ReportTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving all reports.
-     *
-     * 
      */
     public function testAll()
     {
@@ -138,8 +126,6 @@ class ReportTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test throwing an error when creating a report with no report type set.
-     *
-     * 
      */
     public function testCreateNoType()
     {
@@ -150,8 +136,6 @@ class ReportTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test throwing an error when retrieving all reports with no report type set.
-     *
-     * 
      */
     public function testAllNoType()
     {

--- a/test/EasyPost/ReportTest.php
+++ b/test/EasyPost/ReportTest.php
@@ -12,7 +12,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -24,7 +24,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -34,8 +34,6 @@ class ReportTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a report.
-     *
-     * @return Report
      */
     public function testCreateReport()
     {
@@ -54,7 +52,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a report with custom columns
      *
-     * @return void
+     * 
      */
     public function testCreateCustomColumnReport()
     {
@@ -76,7 +74,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a report with custom additional columns
      *
-     * @return void
+     * 
      */
     public function testCreateCustomAdditionalColumnReport()
     {
@@ -98,7 +96,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving a report.
      *
-     * @return void
+     * 
      */
     public function testRetrieveReport()
     {
@@ -120,7 +118,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving all reports.
      *
-     * @return void
+     * 
      */
     public function testAll()
     {
@@ -141,7 +139,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
     /**
      * Test throwing an error when creating a report with no report type set.
      *
-     * @return void
+     * 
      */
     public function testCreateNoType()
     {
@@ -153,7 +151,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
     /**
      * Test throwing an error when retrieving all reports with no report type set.
      *
-     * @return void
+     * 
      */
     public function testAllNoType()
     {

--- a/test/EasyPost/ScanFormTest.php
+++ b/test/EasyPost/ScanFormTest.php
@@ -13,7 +13,7 @@ class ScanFormTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -25,7 +25,7 @@ class ScanFormTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -36,7 +36,7 @@ class ScanFormTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a scanform.
      *
-     * @return void
+     * 
      */
     public function testCreate()
     {
@@ -55,7 +55,7 @@ class ScanFormTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving a scanform.
      *
-     * @return void
+     * 
      */
     public function testRetrieve()
     {
@@ -76,7 +76,7 @@ class ScanFormTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving all scanforms.
      *
-     * @return void
+     * 
      */
     public function testAll()
     {

--- a/test/EasyPost/ScanFormTest.php
+++ b/test/EasyPost/ScanFormTest.php
@@ -12,8 +12,6 @@ class ScanFormTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -24,8 +22,6 @@ class ScanFormTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -35,8 +31,6 @@ class ScanFormTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a scanform.
-     *
-     * 
      */
     public function testCreate()
     {
@@ -54,8 +48,6 @@ class ScanFormTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving a scanform.
-     *
-     * 
      */
     public function testRetrieve()
     {
@@ -75,8 +67,6 @@ class ScanFormTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving all scanforms.
-     *
-     * 
      */
     public function testAll()
     {

--- a/test/EasyPost/ShipmentTest.php
+++ b/test/EasyPost/ShipmentTest.php
@@ -18,8 +18,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -30,8 +28,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -41,8 +37,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a Shipment.
-     *
-     * 
      */
     public function testCreate()
     {
@@ -60,8 +54,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving a Shipment.
-     *
-     * 
      */
     public function testRetrieve()
     {
@@ -77,8 +69,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving all shipments.
-     *
-     * 
      */
     public function testAll()
     {
@@ -97,8 +87,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test buying a Shipment.
-     *
-     * 
      */
     public function testBuy()
     {
@@ -115,8 +103,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test regenerating rates for a shipment.
-     *
-     * 
      */
     public function testRegenerateRates()
     {
@@ -136,8 +122,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test converting the label format of a Shipment.
-     *
-     * 
      */
     public function testConvertLabel()
     {
@@ -157,8 +141,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
      *
      * If the shipment was purchased with a USPS rate, it must have had its insurance set to `0` when bought
      * so that USPS doesn't automatically insure it so we could manually insure it here.
-     *
-     * 
      */
     public function testInsure()
     {
@@ -183,8 +165,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
      * Refunding a test shipment must happen within seconds of the shipment being created as test shipments naturally
      * follow a flow of created -> delivered to cycle through tracking events in test mode - as such anything older
      * than a few seconds in test mode may not be refundable.
-     *
-     * 
      */
     public function testRefund()
     {
@@ -199,8 +179,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving smartrates for a shipment.
-     *
-     * 
      */
     public function testSmartrate()
     {
@@ -223,8 +201,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a Shipment with empty or null objects and arrays.
-     *
-     * 
      */
     public function testCreateEmptyObjects()
     {
@@ -247,8 +223,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a Shipment with `tax_identifiers`.
-     *
-     * 
      */
     public function testCreateTaxIdentifiers()
     {
@@ -266,8 +240,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a Shipment when only IDs are used.
-     *
-     * 
      */
     public function testCreateWithIds()
     {
@@ -293,8 +265,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test various usage alterations of the lowest_rate method.
-     *
-     * 
      */
     public function testLowestRate()
     {
@@ -324,8 +294,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test various usage alterations of the lowest_smartrate method.
-     *
-     * 
      */
     public function testLowestSmartrate()
     {
@@ -356,8 +324,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test various usage alterations of the get_lowest_smartrate method.
-     *
-     * 
      */
     public function testGetLowestSmartrate()
     {

--- a/test/EasyPost/ShipmentTest.php
+++ b/test/EasyPost/ShipmentTest.php
@@ -19,7 +19,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -31,7 +31,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -42,7 +42,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a Shipment.
      *
-     * @return void
+     * 
      */
     public function testCreate()
     {
@@ -61,7 +61,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving a Shipment.
      *
-     * @return void
+     * 
      */
     public function testRetrieve()
     {
@@ -78,7 +78,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving all shipments.
      *
-     * @return void
+     * 
      */
     public function testAll()
     {
@@ -98,7 +98,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     /**
      * Test buying a Shipment.
      *
-     * @return void
+     * 
      */
     public function testBuy()
     {
@@ -116,7 +116,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     /**
      * Test regenerating rates for a shipment.
      *
-     * @return void
+     * 
      */
     public function testRegenerateRates()
     {
@@ -137,7 +137,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     /**
      * Test converting the label format of a Shipment.
      *
-     * @return void
+     * 
      */
     public function testConvertLabel()
     {
@@ -158,7 +158,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
      * If the shipment was purchased with a USPS rate, it must have had its insurance set to `0` when bought
      * so that USPS doesn't automatically insure it so we could manually insure it here.
      *
-     * @return void
+     * 
      */
     public function testInsure()
     {
@@ -184,7 +184,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
      * follow a flow of created -> delivered to cycle through tracking events in test mode - as such anything older
      * than a few seconds in test mode may not be refundable.
      *
-     * @return void
+     * 
      */
     public function testRefund()
     {
@@ -200,7 +200,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving smartrates for a shipment.
      *
-     * @return void
+     * 
      */
     public function testSmartrate()
     {
@@ -224,7 +224,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a Shipment with empty or null objects and arrays.
      *
-     * @return void
+     * 
      */
     public function testCreateEmptyObjects()
     {
@@ -248,7 +248,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a Shipment with `tax_identifiers`.
      *
-     * @return void
+     * 
      */
     public function testCreateTaxIdentifiers()
     {
@@ -267,7 +267,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a Shipment when only IDs are used.
      *
-     * @return void
+     * 
      */
     public function testCreateWithIds()
     {
@@ -294,7 +294,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     /**
      * Test various usage alterations of the lowest_rate method.
      *
-     * @return void
+     * 
      */
     public function testLowestRate()
     {
@@ -325,7 +325,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     /**
      * Test various usage alterations of the lowest_smartrate method.
      *
-     * @return void
+     * 
      */
     public function testLowestSmartrate()
     {
@@ -357,7 +357,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
     /**
      * Test various usage alterations of the get_lowest_smartrate method.
      *
-     * @return void
+     * 
      */
     public function testGetLowestSmartrate()
     {

--- a/test/EasyPost/TrackerTest.php
+++ b/test/EasyPost/TrackerTest.php
@@ -11,8 +11,6 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -23,8 +21,6 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -34,8 +30,6 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a Tracker.
-     *
-     * 
      */
     public function testCreate()
     {
@@ -52,8 +46,6 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving a Tracker.
-     *
-     * 
      */
     public function testRetrieve()
     {
@@ -72,8 +64,6 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving all trackers.
-     *
-     * 
      */
     public function testAll()
     {
@@ -92,8 +82,6 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Tests that we can create a list of bulk trackers with one request.
-     *
-     * 
      */
     public function testCreateList()
     {

--- a/test/EasyPost/TrackerTest.php
+++ b/test/EasyPost/TrackerTest.php
@@ -12,7 +12,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -24,7 +24,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -35,7 +35,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a Tracker.
      *
-     * @return void
+     * 
      */
     public function testCreate()
     {
@@ -53,7 +53,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving a Tracker.
      *
-     * @return void
+     * 
      */
     public function testRetrieve()
     {
@@ -73,7 +73,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving all trackers.
      *
-     * @return void
+     * 
      */
     public function testAll()
     {
@@ -93,7 +93,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
     /**
      * Tests that we can create a list of bulk trackers with one request.
      *
-     * @return void
+     * 
      */
     public function testCreateList()
     {

--- a/test/EasyPost/UserTest.php
+++ b/test/EasyPost/UserTest.php
@@ -11,7 +11,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -23,7 +23,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -34,7 +34,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
     /**
      * Test creating a child user.
      *
-     * @return void
+     * 
      */
     public function testCreate()
     {
@@ -52,7 +52,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving a child user.
      *
-     * @return void
+     * 
      */
     public function testRetrieve()
     {
@@ -69,7 +69,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving the authenticated user.
      *
-     * @return void
+     * 
      */
     public function testRetrieveMe()
     {
@@ -84,7 +84,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
     /**
      * Test updating the authenticated user.
      *
-     * @return void
+     * 
      */
     public function testUpdate()
     {
@@ -105,7 +105,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
     /**
      * Test deleting a child user.
      *
-     * @return void
+     * 
      */
     public function testDelete()
     {
@@ -123,7 +123,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving all API keys.
      *
-     * @return void
+     * 
      */
     public function testAllApiKeys()
     {
@@ -139,7 +139,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving the authenticated user's API keys.
      *
-     * @return void
+     * 
      */
     public function testApiKeys()
     {
@@ -157,7 +157,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
     /**
      * Test updating the authenticated user's Brand.
      *
-     * @return void
+     * 
      */
     public function testUpdateBrand()
     {

--- a/test/EasyPost/UserTest.php
+++ b/test/EasyPost/UserTest.php
@@ -10,8 +10,6 @@ class UserTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -22,8 +20,6 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -33,8 +29,6 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a child user.
-     *
-     * 
      */
     public function testCreate()
     {
@@ -51,8 +45,6 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving a child user.
-     *
-     * 
      */
     public function testRetrieve()
     {
@@ -68,8 +60,6 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving the authenticated user.
-     *
-     * 
      */
     public function testRetrieveMe()
     {
@@ -83,8 +73,6 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test updating the authenticated user.
-     *
-     * 
      */
     public function testUpdate()
     {
@@ -104,8 +92,6 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test deleting a child user.
-     *
-     * 
      */
     public function testDelete()
     {
@@ -122,8 +108,6 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving all API keys.
-     *
-     * 
      */
     public function testAllApiKeys()
     {
@@ -138,8 +122,6 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving the authenticated user's API keys.
-     *
-     * 
      */
     public function testApiKeys()
     {
@@ -156,8 +138,6 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test updating the authenticated user's Brand.
-     *
-     * 
      */
     public function testUpdateBrand()
     {

--- a/test/EasyPost/WebhookTest.php
+++ b/test/EasyPost/WebhookTest.php
@@ -12,8 +12,6 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Setup the testing environment for this file.
-     *
-     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -24,8 +22,6 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Cleanup the testing environment once finished.
-     *
-     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -53,8 +49,6 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving a Webhook.
-     *
-     * 
      */
     public function testRetrieve()
     {
@@ -74,8 +68,6 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test retrieving all webhooks.
-     *
-     * 
      */
     public function testAll()
     {
@@ -93,8 +85,6 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test updating a Webhook.
-     *
-     * 
      */
     public function testUpdate()
     {
@@ -114,8 +104,6 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test deleting a Webhook.
-     *
-     * 
      */
     public function testDelete()
     {
@@ -134,8 +122,6 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
     /**
      * Test a webhook signature that is originated from EasyPost by comparing the HMAC header
      * to a shared secret.
-     *
-     * 
      */
     public function testValidateWebhook()
     {
@@ -152,8 +138,6 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test a webhook signature that has invalid secret.
-     *
-     * 
      */
     public function testValidateWebhookInvalidSecret()
     {
@@ -171,8 +155,6 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test a webhook signature does not have HMAC signature header.
-     *
-     * 
      */
     public function testValidateWebhookMissingSecret()
     {

--- a/test/EasyPost/WebhookTest.php
+++ b/test/EasyPost/WebhookTest.php
@@ -13,7 +13,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the testing environment for this file.
      *
-     * @return void
+     * 
      */
     public static function setUpBeforeClass(): void
     {
@@ -25,7 +25,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleanup the testing environment once finished.
      *
-     * @return void
+     * 
      */
     public static function tearDownAfterClass(): void
     {
@@ -35,8 +35,6 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test creating a Webhook.
-     *
-     * @return Webhook
      */
     public function testCreate()
     {
@@ -56,7 +54,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving a Webhook.
      *
-     * @return void
+     * 
      */
     public function testRetrieve()
     {
@@ -77,7 +75,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
     /**
      * Test retrieving all webhooks.
      *
-     * @return void
+     * 
      */
     public function testAll()
     {
@@ -96,7 +94,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
     /**
      * Test updating a Webhook.
      *
-     * @return void
+     * 
      */
     public function testUpdate()
     {
@@ -117,7 +115,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
     /**
      * Test deleting a Webhook.
      *
-     * @return void
+     * 
      */
     public function testDelete()
     {
@@ -137,7 +135,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
      * Test a webhook signature that is originated from EasyPost by comparing the HMAC header
      * to a shared secret.
      *
-     * @return void
+     * 
      */
     public function testValidateWebhook()
     {
@@ -155,7 +153,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
     /**
      * Test a webhook signature that has invalid secret.
      *
-     * @return void
+     * 
      */
     public function testValidateWebhookInvalidSecret()
     {
@@ -174,7 +172,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
     /**
      * Test a webhook signature does not have HMAC signature header.
      *
-     * @return void
+     * 
      */
     public function testValidateWebhookMissingSecret()
     {

--- a/test/cassettes/end_shipper/retrieve.yml
+++ b/test/cassettes/end_shipper/retrieve.yml
@@ -1,8 +1,83 @@
 
 -
     request:
+        method: POST
+        url: 'https://api.easypost.com/beta/end_shippers'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+        body: '{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555","country":"US","email":"test@example.com"}}'
+    response:
+        status:
+            http_version: '2'
+            code: '201'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 9e5a01b462eab7b5ec71bc89001cb041
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '357'
+            etag: 'W/"8efd1d32f030855c912a6a264efbfe0d"'
+            x-runtime: '0.039814'
+            x-node: bigweb6nuq
+            x-version-label: easypost-202208031644-7982371108-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq 403f17ff97', 'extlb1nuq 403f17ff97']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"es_e654dd5f74a048a680394b6d346f68fe","object":"EndShipper","created_at":"2022-08-03T18:00:21+00:00","updated_at":"2022-08-03T18:00:21+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>"}'
+        curl_info:
+            url: 'https://api.easypost.com/beta/end_shippers'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 718
+            request_size: 312
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.156704
+            namelookup_time: 0.001171
+            connect_time: 0.03351
+            pretransfer_time: 0.082301
+            size_upload: 216.0
+            size_download: 357.0
+            speed_download: 2278.0
+            speed_upload: 1378.0
+            download_content_length: 357.0
+            upload_content_length: 216.0
+            starttransfer_time: 0.08231
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.154
+            local_port: 54666
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 82140
+            connect_time_us: 33510
+            namelookup_time_us: 1171
+            pretransfer_time_us: 82301
+            redirect_time_us: 0
+            starttransfer_time_us: 82310
+            total_time_us: 156704
+-
+    request:
         method: GET
-        url: 'https://api.easypost.com/beta/end_shippers/es_90f50a58d0e546dcb7f3339a8e791a6a'
+        url: 'https://api.easypost.com/beta/end_shippers/es_e654dd5f74a048a680394b6d346f68fe'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -21,55 +96,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: d74fd115627e6f72ff147fa3002f2b95
+            x-ep-request-uuid: 9e5a01b262eab7b5fa8fb369001cb051
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '359'
-            etag: 'W/"ab8ca53d83101c986afc783b9501e8b3"'
-            x-runtime: '0.086741'
-            x-node: bigweb1nuq
-            x-version-label: easypost-202205110022-b4df6b5700-master
+            etag: 'W/"711b0561eca0482b3d31eba817e68d08"'
+            x-runtime: '0.036381'
+            x-node: bigweb3nuq
+            x-version-label: easypost-202208031644-7982371108-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 570dfcbc0a', 'intlb2wdc 570dfcbc0a', 'extlb3wdc c51cdb8bf2']
+            x-proxied: ['intlb2nuq 403f17ff97', 'extlb1nuq 403f17ff97']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"es_90f50a58d0e546dcb7f3339a8e791a6a","object":"EndShipper","created_at":"2022-05-13T14:47:13+00:00","updated_at":"2022-05-13T14:47:13+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":"TEST@EXAMPLE.COM"}'
+        body: '{"id":"es_e654dd5f74a048a680394b6d346f68fe","object":"EndShipper","created_at":"2022-08-03T18:00:21+00:00","updated_at":"2022-08-03T18:00:21+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>"}'
         curl_info:
-            url: 'https://api.easypost.com/beta/end_shippers/es_90f50a58d0e546dcb7f3339a8e791a6a'
+            url: 'https://api.easypost.com/beta/end_shippers/es_e654dd5f74a048a680394b6d346f68fe'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 751
-            request_size: 558
+            header_size: 718
+            request_size: 326
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.272389
-            namelookup_time: 0.00155
-            connect_time: 0.015527
-            pretransfer_time: 0.045494
+            total_time: 0.15674
+            namelookup_time: 0.001354
+            connect_time: 0.034489
+            pretransfer_time: 0.085943
             size_upload: 0.0
             size_download: 359.0
-            speed_download: 1317.0
+            speed_download: 2290.0
             speed_upload: 0.0
             download_content_length: 359.0
             upload_content_length: 0.0
-            starttransfer_time: 0.272357
+            starttransfer_time: 0.156698
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.47.33.18
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 192.168.1.156
-            local_port: 58437
+            local_ip: 192.168.1.154
+            local_port: 54667
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 45394
-            connect_time_us: 15527
-            namelookup_time_us: 1550
-            pretransfer_time_us: 45494
+            appconnect_time_us: 85817
+            connect_time_us: 34489
+            namelookup_time_us: 1354
+            pretransfer_time_us: 85943
             redirect_time_us: 0
-            starttransfer_time_us: 272357
-            total_time_us: 272389
+            starttransfer_time_us: 156698
+            total_time_us: 156740

--- a/test/cassettes/end_shipper/update.yml
+++ b/test/cassettes/end_shipper/update.yml
@@ -1,8 +1,83 @@
 
 -
     request:
+        method: POST
+        url: 'https://api.easypost.com/beta/end_shippers'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+        body: '{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555","country":"US","email":"test@example.com"}}'
+    response:
+        status:
+            http_version: '2'
+            code: '201'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 9e5a01b562eab7b5ec70b4ef001cb022
+            cache-control: 'no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '357'
+            etag: 'W/"5fc32856d392ae3600e6dcf832577895"'
+            x-runtime: '0.038478'
+            x-node: bigweb6nuq
+            x-version-label: easypost-202208031644-7982371108-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq 403f17ff97', 'extlb1nuq 403f17ff97']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"es_27099e589f41466c94d38bffa418529a","object":"EndShipper","created_at":"2022-08-03T18:00:21+00:00","updated_at":"2022-08-03T18:00:21+00:00","name":"JACK SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>"}'
+        curl_info:
+            url: 'https://api.easypost.com/beta/end_shippers'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 718
+            request_size: 312
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 1.805394
+            namelookup_time: 1.644872
+            connect_time: 1.678819
+            pretransfer_time: 1.729001
+            size_upload: 216.0
+            size_download: 357.0
+            speed_download: 197.0
+            speed_upload: 119.0
+            download_content_length: 357.0
+            upload_content_length: 216.0
+            starttransfer_time: 1.729007
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.154
+            local_port: 54664
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 1728795
+            connect_time_us: 1678819
+            namelookup_time_us: 1644872
+            pretransfer_time_us: 1729001
+            redirect_time_us: 0
+            starttransfer_time_us: 1729007
+            total_time_us: 1805394
+-
+    request:
         method: PUT
-        url: 'https://api.easypost.com/beta/end_shippers/es_90f50a58d0e546dcb7f3339a8e791a6a'
+        url: 'https://api.easypost.com/beta/end_shippers/es_27099e589f41466c94d38bffa418529a'
         headers:
             Host: api.easypost.com
             Accept: application/json
@@ -22,55 +97,55 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 60f1d883629fbc3de609a8810002e475
+            x-ep-request-uuid: 9e5a01b562eab7b5ec4c88b0001cb02f
             cache-control: 'no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '353'
-            etag: 'W/"591df6e0d4203c67d9e03a4f18dfdf05"'
-            x-runtime: '0.053879'
-            x-node: bigweb6nuq
-            x-version-label: easypost-202206072045-d56b35a2b3-master
+            etag: 'W/"469e67a5db1a3c1b735f7bb870801aba"'
+            x-runtime: '0.135038'
+            x-node: bigweb9nuq
+            x-version-label: easypost-202208031644-7982371108-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 0910011e7e', 'intlb2wdc 0910011e7e', 'extlb1wdc 0910011e7e']
+            x-proxied: ['intlb2nuq 403f17ff97', 'extlb1nuq 403f17ff97']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"es_90f50a58d0e546dcb7f3339a8e791a6a","object":"EndShipper","created_at":"2022-05-13T14:47:13+00:00","updated_at":"2022-06-07T20:59:41+00:00","name":"NEW NAME","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>"}'
+        body: '{"id":"es_27099e589f41466c94d38bffa418529a","object":"EndShipper","created_at":"2022-08-03T18:00:21+00:00","updated_at":"2022-08-03T18:00:21+00:00","name":"NEW NAME","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>"}'
         curl_info:
-            url: 'https://api.easypost.com/beta/end_shippers/es_90f50a58d0e546dcb7f3339a8e791a6a'
+            url: 'https://api.easypost.com/beta/end_shippers/es_27099e589f41466c94d38bffa418529a'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 751
-            request_size: 575
+            header_size: 718
+            request_size: 347
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.366561
-            namelookup_time: 0.007454
-            connect_time: 0.059615
-            pretransfer_time: 0.132294
+            total_time: 0.252696
+            namelookup_time: 0.001214
+            connect_time: 0.034189
+            pretransfer_time: 0.08341
             size_upload: 212.0
             size_download: 353.0
-            speed_download: 963.0
-            speed_upload: 578.0
+            speed_download: 1396.0
+            speed_upload: 838.0
             download_content_length: 353.0
             upload_content_length: 212.0
-            starttransfer_time: 0.132307
+            starttransfer_time: 0.083418
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.47.33.19
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
             local_ip: 192.168.1.154
-            local_port: 59175
+            local_port: 54665
             http_version: 3
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 132061
-            connect_time_us: 59615
-            namelookup_time_us: 7454
-            pretransfer_time_us: 132294
+            appconnect_time_us: 83194
+            connect_time_us: 34189
+            namelookup_time_us: 1214
+            pretransfer_time_us: 83410
             redirect_time_us: 0
-            starttransfer_time_us: 132307
-            total_time_us: 366561
+            starttransfer_time_us: 83418
+            total_time_us: 252696


### PR DESCRIPTION
# Description

- Remove `return` docstrings for unit tests
- Remove EndShipper dependence on `testCreate`

# Testing

- All unit tests pass as expected

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
