### PR TITLE
fix: double to single quotes and lint rule

### DIFF
--- a/lib/EasyPost/Address.php
+++ b/lib/EasyPost/Address.php
@@ -72,7 +72,7 @@ class Address extends EasypostResource
             $wrappedParams['verify_strict'] = $verifyStrict;
         }
 
-        $wrappedParams["address"] = $params;
+        $wrappedParams['address'] = $params;
 
         return self::createResource(get_class(), $wrappedParams, $apiKey);
     }

--- a/lib/EasyPost/Batch.php
+++ b/lib/EasyPost/Batch.php
@@ -88,7 +88,7 @@ class Batch extends EasypostResource
             ];
         }
 
-        $encodedParams = str_replace("\\", '', json_encode($params));
+        $encodedParams = str_replace('\\', '', json_encode($params));
 
         $requestor = new Requestor($apiKey);
         $url = self::classUrl(get_class());

--- a/lib/EasyPost/Beta/EndShipper.php
+++ b/lib/EasyPost/Beta/EndShipper.php
@@ -30,7 +30,7 @@ class EndShipper extends EasypostResource
     public static function create($params = null, $apiKey = null)
     {
         $wrappedParams = [];
-        $wrappedParams["address"] = $params;
+        $wrappedParams['address'] = $params;
 
         return self::createResource(get_class(), $wrappedParams, $apiKey, null, true);
     }

--- a/lib/EasyPost/Billing.php
+++ b/lib/EasyPost/Billing.php
@@ -20,7 +20,7 @@ class Billing extends EasypostResource
      */
     public static function retrieve_payment_methods($params = null, $apiKey = null)
     {
-        $paymentMethods = self::allResources("paymentMethod", $params, $apiKey);
+        $paymentMethods = self::allResources('paymentMethod', $params, $apiKey);
 
         if ($paymentMethods->id == null) {
             throw new Error('Billing has not been setup for this user. Please add a payment method.');

--- a/lib/EasyPost/EasypostResource.php
+++ b/lib/EasyPost/EasypostResource.php
@@ -20,7 +20,7 @@ abstract class EasypostResource extends EasyPostObject
             $class = substr($class, strlen('EasyPost'));
         }
         $class = str_replace('_', '', $class);
-        $class = substr($class, 0, 1) . preg_replace("/([A-Z])/", "_$1", substr($class, 1)); // Camel -> snake
+        $class = substr($class, 0, 1) . preg_replace('/([A-Z])/', '_$1', substr($class, 1)); // Camel -> snake
         $name = urlencode($class);
         $name = strtolower($name);
 
@@ -36,7 +36,7 @@ abstract class EasypostResource extends EasyPostObject
     public static function classUrl($class)
     {
         $className = self::className($class);
-        if (substr($className, -1) !== "s" && substr($className, -1) !== "h") {
+        if (substr($className, -1) !== 's' && substr($className, -1) !== 'h') {
             return "/{$className}s";
         }
 
@@ -90,7 +90,7 @@ abstract class EasypostResource extends EasyPostObject
     protected static function validate($params = null, $apiKey = null)
     {
         if ($params && !is_array($params)) {
-            throw new Error("You must pass an array as the first argument to EasyPost API method calls.");
+            throw new Error('You must pass an array as the first argument to EasyPost API method calls.');
         }
         if ($apiKey && !is_string($apiKey)) {
             throw new Error('The second argument to EasyPost API method calls is an optional per-request apiKey, which must be a string.');

--- a/lib/EasyPost/Error.php
+++ b/lib/EasyPost/Error.php
@@ -74,13 +74,13 @@ class Error extends \Exception
      */
     public function prettyPrint()
     {
-        print($this->ecode . " (" . $this->getHttpStatus() . "): " .
+        print($this->ecode . ' (' . $this->getHttpStatus() . '): ' .
             $this->getMessage() . "\n");
         if (!empty($this->errors)) {
             print("Field errors:\n");
             foreach ($this->errors as $fieldError) {
                 foreach ($fieldError as $k => $v) {
-                    print("  " . $k . ": " . $v . "\n");
+                    print('  ' . $k . ': ' . $v . "\n");
                 }
                 print("\n");
             }

--- a/lib/EasyPost/Requestor.php
+++ b/lib/EasyPost/Requestor.php
@@ -49,7 +49,7 @@ class Requestor
      */
     public static function utf8($value)
     {
-        if (is_string($value) && mb_detect_encoding($value, "UTF-8", true) != "UTF-8") {
+        if (is_string($value) && mb_detect_encoding($value, 'UTF-8', true) != 'UTF-8') {
             return utf8_encode($value);
         }
 
@@ -67,7 +67,7 @@ class Requestor
         if (is_null($data)) {
             return [];
         } elseif ($data instanceof EasypostResource) {
-            return ["id" => self::utf8($data->id)];
+            return ['id' => self::utf8($data->id)];
         } elseif ($data === true) {
             return 'true';
         } elseif ($data === false) {
@@ -75,7 +75,7 @@ class Requestor
         } elseif (is_array($data)) {
             $resource = [];
             foreach ($data as $k => $v) {
-                if (!is_null($v) and ($v !== "") and (!is_array($v) or !empty($v))) {
+                if (!is_null($v) and ($v !== '') and (!is_array($v) or !empty($v))) {
                     $resource[$k] = self::encodeObjects($v);
                 }
             }
@@ -106,19 +106,19 @@ class Requestor
             }
 
             if ($prefix && isset($k)) {
-                $k = $prefix . "[" . $k . "]";
+                $k = $prefix . '[' . $k . ']';
             } elseif ($prefix) {
-                $k = $prefix . "[]";
+                $k = $prefix . '[]';
             }
 
             if (is_array($v)) {
                 $r[] = self::urlEncode($v, $k, true);
             } else {
-                $r[] = urlencode($k) . "=" . urlencode($v);
+                $r[] = urlencode($k) . '=' . urlencode($v);
             }
         }
 
-        return implode("&", $r);
+        return implode('&', $r);
     }
 
     /**

--- a/lib/EasyPost/Shipment.php
+++ b/lib/EasyPost/Shipment.php
@@ -297,7 +297,7 @@ class Shipment extends EasypostResource
         }
 
         if ($lowestSmartrate == false) {
-            throw new Error("No rates found.");
+            throw new Error('No rates found.');
         }
 
         return $lowestSmartrate;

--- a/lib/EasyPost/Tracker.php
+++ b/lib/EasyPost/Tracker.php
@@ -84,7 +84,7 @@ class Tracker extends EasypostResource
             $params['trackers'] = (object)$clone;
         }
 
-        $encodedParams = str_replace("\\", '', json_encode($params));
+        $encodedParams = str_replace('\\', '', json_encode($params));
 
         $requestor = new Requestor($apiKey);
         $url = self::classUrl(get_class());

--- a/lib/EasyPost/Util.php
+++ b/lib/EasyPost/Util.php
@@ -138,8 +138,8 @@ abstract class Util
         } elseif (is_array($response)) {
             if (isset($response['object']) && is_string($response['object']) && isset($types[$response['object']])) {
                 $class = $types[$response['object']];
-            } elseif (isset($response['id']) && isset($prefixes[substr($response['id'], 0, strpos($response['id'], "_"))])) {
-                $class = $prefixes[substr($response['id'], 0, strpos($response['id'], "_"))];
+            } elseif (isset($response['id']) && isset($prefixes[substr($response['id'], 0, strpos($response['id'], '_'))])) {
+                $class = $prefixes[substr($response['id'], 0, strpos($response['id'], '_'))];
             } else {
                 $class = '\EasyPost\EasyPostObject';
             }

--- a/lib/EasyPost/Webhook.php
+++ b/lib/EasyPost/Webhook.php
@@ -97,22 +97,22 @@ class Webhook extends EasypostResource
      */
     public static function validateWebhook($eventBody, $headers, $webhookSecret)
     {
-        $easypostHmacSignature = $headers["X-Hmac-Signature"] ?? null;
+        $easypostHmacSignature = $headers['X-Hmac-Signature'] ?? null;
 
         if ($easypostHmacSignature != null) {
             $normalizedSecret = Normalizer::normalize($webhookSecret, Normalizer::FORM_KD);
-            $encodedSecret = mb_convert_encoding($normalizedSecret, "UTF-8");
+            $encodedSecret = mb_convert_encoding($normalizedSecret, 'UTF-8');
 
-            $expectedSignature = hash_hmac("sha256", $eventBody, $encodedSecret);
+            $expectedSignature = hash_hmac('sha256', $eventBody, $encodedSecret);
             $digest = "hmac-sha256-hex=$expectedSignature";
 
             if (hash_equals($digest, $easypostHmacSignature)) {
                 $webhookBody = json_decode($eventBody);
             } else {
-                throw new Error("Webhook received did not originate from EasyPost or had a webhook secret mismatch.");
+                throw new Error('Webhook received did not originate from EasyPost or had a webhook secret mismatch.');
             }
         } else {
-            throw new Error("Webhook received does not contain an HMAC signature.");
+            throw new Error('Webhook received does not contain an HMAC signature.');
         }
 
         return $webhookBody;

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -31,4 +31,5 @@
         <!-- TODO: Change $delivery_days and $delivery_accuracy to camel caps on the next major release -->
         <exclude-pattern>/lib/EasyPost/Shipment\.php</exclude-pattern>
     </rule>
+    <rule ref="Squiz.Strings.DoubleQuoteUsage.NotRequired" />
 </ruleset>

--- a/test/EasyPost/ErrorTest.php
+++ b/test/EasyPost/ErrorTest.php
@@ -42,8 +42,8 @@ class ErrorTest extends \PHPUnit\Framework\TestCase
             $this->assertEquals(422, $error->getHttpStatus());
             $this->assertEquals('SHIPMENT.INVALID_PARAMS', $error->ecode);
             $this->assertEquals('Unable to create shipment, one or more parameters were invalid.', $error->getMessage());
-            $this->assertEquals(["to_address" => "Required and missing."], $error->errors[0]);
-            $this->assertEquals(["from_address" => "Required and missing."], $error->errors[1]);
+            $this->assertEquals(['to_address' => 'Required and missing.'], $error->errors[0]);
+            $this->assertEquals(['from_address' => 'Required and missing.'], $error->errors[1]);
             $this->assertEquals('{"error":{"code":"SHIPMENT.INVALID_PARAMS","message":"Unable to create shipment, one or more parameters were invalid.","errors":[{"to_address":"Required and missing."},{"from_address":"Required and missing."}]}}', $error->getHttpBody());
 
             // We check that the pretty printed output is the same here, leave the odd formatting as it is here and do not auto-format the next few lines

--- a/test/EasyPost/ShipmentTest.php
+++ b/test/EasyPost/ShipmentTest.php
@@ -364,7 +364,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
         $shipment = Shipment::create(Fixture::one_call_buy_shipment());
 
-        $formType = "return_packing_slip";
+        $formType = 'return_packing_slip';
         $shipment->generate_form(
             $formType,
             Fixture::rma_form_options()

--- a/test/EasyPost/TrackerTest.php
+++ b/test/EasyPost/TrackerTest.php
@@ -36,7 +36,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('trackers/create.yml');
 
         $tracker = Tracker::create([
-            "tracking_code" => "EZ1000000001",
+            'tracking_code' => 'EZ1000000001',
         ]);
 
         $this->assertInstanceOf('\EasyPost\Tracker', $tracker);
@@ -52,7 +52,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('trackers/retrieve.yml');
 
         $tracker = Tracker::create([
-            "tracking_code" => "EZ1000000001",
+            'tracking_code' => 'EZ1000000001',
         ]);
 
         // Test trackers cycle through their "dummy" statuses automatically, the created and retrieved objects may differ
@@ -88,9 +88,9 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('trackers/createList.yml');
 
         $response = Tracker::create_list([
-            '0' => ["tracking_code" => "EZ1000000001"],
-            '1' => ["tracking_code" => "EZ1000000002"],
-            '2' => ["tracking_code" => "EZ1000000003"],
+            '0' => ['tracking_code' => 'EZ1000000001'],
+            '1' => ['tracking_code' => 'EZ1000000002'],
+            '2' => ['tracking_code' => 'EZ1000000003'],
         ]);
 
         // This endpoint returns nothing so we assert the function returns true

--- a/test/EasyPost/WebhookTest.php
+++ b/test/EasyPost/WebhookTest.php
@@ -37,7 +37,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('webhooks/create.yml');
 
         $webhook = Webhook::create([
-            "url" => Fixture::webhook_url(),
+            'url' => Fixture::webhook_url(),
         ]);
 
         $this->assertInstanceOf('\EasyPost\Webhook', $webhook);
@@ -55,7 +55,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('webhooks/retrieve.yml');
 
         $webhook = Webhook::create([
-            "url" => Fixture::webhook_url(),
+            'url' => Fixture::webhook_url(),
         ]);
 
         $retrievedWebhook = Webhook::retrieve($webhook->id);
@@ -91,7 +91,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('webhooks/update.yml');
 
         $webhook = Webhook::create([
-            "url" => Fixture::webhook_url(),
+            'url' => Fixture::webhook_url(),
         ]);
 
         $response = $webhook->update();
@@ -110,7 +110,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         VCR::insertCassette('webhooks/delete.yml');
 
         $webhook = Webhook::create([
-            "url" => Fixture::webhook_url(),
+            'url' => Fixture::webhook_url(),
         ]);
 
         $response = $webhook->delete();
@@ -125,15 +125,15 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
      */
     public function testValidateWebhook()
     {
-        $webhookSecret = "sécret";
-        $expectedHmacSignature = "hmac-sha256-hex=e93977c8ccb20363d51a62b3fe1fc402b7829be1152da9e88cf9e8d07115a46b";
+        $webhookSecret = 'sécret';
+        $expectedHmacSignature = 'hmac-sha256-hex=e93977c8ccb20363d51a62b3fe1fc402b7829be1152da9e88cf9e8d07115a46b';
         $headers = [
-            "X-Hmac-Signature" => $expectedHmacSignature
+            'X-Hmac-Signature' => $expectedHmacSignature
         ];
 
         $webhookBody = Webhook::validateWebhook(Fixture::webhookBody(), $headers, $webhookSecret);
 
-        $this->assertEquals("batch.created", $webhookBody->description);
+        $this->assertEquals('batch.created', $webhookBody->description);
     }
 
     /**
@@ -141,9 +141,9 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
      */
     public function testValidateWebhookInvalidSecret()
     {
-        $webhookSecret = "invalid_secret";
+        $webhookSecret = 'invalid_secret';
         $headers = [
-            "X-Hmac-Signature" => "some-signature"
+            'X-Hmac-Signature' => 'some-signature'
         ];
 
         try {
@@ -158,9 +158,9 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
      */
     public function testValidateWebhookMissingSecret()
     {
-        $webhookSecret = "123";
+        $webhookSecret = '123';
         $headers = [
-            "some-header" => "some-signature"
+            'some-header' => 'some-signature'
         ];
 
         try {


### PR DESCRIPTION
# Description

Switches all use of double quotes (for normal strings without interpolation) to single quotes and adds a lint rule to enforce the consistency in the future since we had a mix of both.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
