### PR TITLE
fix: extra imports and add regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v5.5.1 (2022-08-20)
+
+- Removes some extra imports that no longer exist causing errors when importing this library. Adds a regression test to protect against this in the future.
+
 ## v5.5.0 (2022-08-02)
 
 - Adds Carbon Offset support

--- a/lib/easypost.php
+++ b/lib/easypost.php
@@ -1,6 +1,6 @@
 <?php
 
-// Require this file if you're not using composer's vendor/autoload
+// `require` this file if you're not using composer's vendor/autoload
 
 // Required PHP extensions
 if (!function_exists('curl_init')) {
@@ -11,48 +11,46 @@ if (!function_exists('json_decode')) {
 }
 
 // Config and Utilities
-require(dirname(__FILE__) . '/EasyPost/EasyPost.php');
-require(dirname(__FILE__) . '/EasyPost/Util.php');
-require(dirname(__FILE__) . '/EasyPost/Error.php');
+require_once(dirname(__FILE__) . '/EasyPost/EasyPost.php');
+require_once(dirname(__FILE__) . '/EasyPost/Util.php');
+require_once(dirname(__FILE__) . '/EasyPost/Error.php');
 
 // Guts
-require(dirname(__FILE__) . '/EasyPost/EasyPostObject.php');
-require(dirname(__FILE__) . '/EasyPost/EasypostResource.php');
-require(dirname(__FILE__) . '/EasyPost/Requestor.php');
+require_once(dirname(__FILE__) . '/EasyPost/EasyPostObject.php');
+require_once(dirname(__FILE__) . '/EasyPost/EasypostResource.php');
+require_once(dirname(__FILE__) . '/EasyPost/Requestor.php');
 
 // API Resources
-require(dirname(__FILE__) . '/EasyPost/Address.php');
-require(dirname(__FILE__) . '/EasyPost/Batch.php');
-require(dirname(__FILE__) . '/EasyPost/Brand.php');
-require(dirname(__FILE__) . '/EasyPost/CarbonOffset.php');
-require(dirname(__FILE__) . '/EasyPost/CarrierAccount.php');
-require(dirname(__FILE__) . '/EasyPost/CarrierDetail.php');
-require(dirname(__FILE__) . '/EasyPost/CreditCard.php');
-require(dirname(__FILE__) . '/EasyPost/CustomsInfo.php');
-require(dirname(__FILE__) . '/EasyPost/CustomsItem.php');
-require(dirname(__FILE__) . '/EasyPost/Beta/EndShipper.php');
-require(dirname(__FILE__) . '/EasyPost/Event.php');
-require(dirname(__FILE__) . '/EasyPost/Fee.php');
-require(dirname(__FILE__) . '/EasyPost/FieldError.php');
-require(dirname(__FILE__) . '/EasyPost/Insurance.php');
-require(dirname(__FILE__) . '/EasyPost/Message.php');
-require(dirname(__FILE__) . '/EasyPost/Order.php');
-require(dirname(__FILE__) . '/EasyPost/Parcel.php');
-require(dirname(__FILE__) . '/EasyPost/PaymentMethod.php');
-require(dirname(__FILE__) . '/EasyPost/Pickup.php');
-require(dirname(__FILE__) . '/EasyPost/PickupRate.php');
-require(dirname(__FILE__) . '/EasyPost/PostageLabel.php');
-require(dirname(__FILE__) . '/EasyPost/Rate.php');
-require(dirname(__FILE__) . '/EasyPost/Refund.php');
-require(dirname(__FILE__) . '/EasyPost/Report.php');
-require(dirname(__FILE__) . '/EasyPost/ScanForm.php');
-require(dirname(__FILE__) . '/EasyPost/Shipment.php');
-require(dirname(__FILE__) . '/EasyPost/TaxIdentifier.php');
-require(dirname(__FILE__) . '/EasyPost/Tracker.php');
-require(dirname(__FILE__) . '/EasyPost/TrackingDetail.php');
-require(dirname(__FILE__) . '/EasyPost/TrackingLocation.php');
-require(dirname(__FILE__) . '/EasyPost/User.php');
-require(dirname(__FILE__) . '/EasyPost/Verification.php');
-require(dirname(__FILE__) . '/EasyPost/VerificationDetails.php');
-require(dirname(__FILE__) . '/EasyPost/Verifications.php');
-require(dirname(__FILE__) . '/EasyPost/Webhook.php');
+require_once(dirname(__FILE__) . '/EasyPost/Address.php');
+require_once(dirname(__FILE__) . '/EasyPost/Batch.php');
+require_once(dirname(__FILE__) . '/EasyPost/Brand.php');
+require_once(dirname(__FILE__) . '/EasyPost/CarbonOffset.php');
+require_once(dirname(__FILE__) . '/EasyPost/CarrierAccount.php');
+require_once(dirname(__FILE__) . '/EasyPost/CarrierDetail.php');
+require_once(dirname(__FILE__) . '/EasyPost/CustomsInfo.php');
+require_once(dirname(__FILE__) . '/EasyPost/CustomsItem.php');
+require_once(dirname(__FILE__) . '/EasyPost/Beta/EndShipper.php');
+require_once(dirname(__FILE__) . '/EasyPost/Event.php');
+require_once(dirname(__FILE__) . '/EasyPost/Fee.php');
+require_once(dirname(__FILE__) . '/EasyPost/FieldError.php');
+require_once(dirname(__FILE__) . '/EasyPost/Insurance.php');
+require_once(dirname(__FILE__) . '/EasyPost/Message.php');
+require_once(dirname(__FILE__) . '/EasyPost/Order.php');
+require_once(dirname(__FILE__) . '/EasyPost/Parcel.php');
+require_once(dirname(__FILE__) . '/EasyPost/Pickup.php');
+require_once(dirname(__FILE__) . '/EasyPost/PickupRate.php');
+require_once(dirname(__FILE__) . '/EasyPost/PostageLabel.php');
+require_once(dirname(__FILE__) . '/EasyPost/Rate.php');
+require_once(dirname(__FILE__) . '/EasyPost/Refund.php');
+require_once(dirname(__FILE__) . '/EasyPost/Report.php');
+require_once(dirname(__FILE__) . '/EasyPost/ScanForm.php');
+require_once(dirname(__FILE__) . '/EasyPost/Shipment.php');
+require_once(dirname(__FILE__) . '/EasyPost/TaxIdentifier.php');
+require_once(dirname(__FILE__) . '/EasyPost/Tracker.php');
+require_once(dirname(__FILE__) . '/EasyPost/TrackingDetail.php');
+require_once(dirname(__FILE__) . '/EasyPost/TrackingLocation.php');
+require_once(dirname(__FILE__) . '/EasyPost/User.php');
+require_once(dirname(__FILE__) . '/EasyPost/Verification.php');
+require_once(dirname(__FILE__) . '/EasyPost/VerificationDetails.php');
+require_once(dirname(__FILE__) . '/EasyPost/Verifications.php');
+require_once(dirname(__FILE__) . '/EasyPost/Webhook.php');

--- a/test/EasyPost/RequireTest.php
+++ b/test/EasyPost/RequireTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace EasyPost\Test;
+
+require 'lib/easypost.php';
+
+class RequireTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Tests that no errors are thrown when we import the library without using the autoloader.
+     * Things like missing or extra imports should be caught by this. The actual assertion here
+     * doesn't matter, only that an import/require error isn't thrown.
+     */
+    public function testRequireLibrary()
+    {
+        $apiBase = \EasyPost\EasyPost::getApiBase();
+        $this->assertEquals('https://api.easypost.com/v2', $apiBase);
+    }
+}


### PR DESCRIPTION
# Description

Removes `CreditCard` and `PaymentMethod` imports that no longer exist. This fixes an import bug when importing this library (instead of using the autoloader which doesn't raise this error).

Closes #211 

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Adds a regression test by trying to manually import the library in our test suite (the test suite uses the auto loader which is why this wasn't caught.)

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
