### PR TITLE
chore: improves CI runtime by removing redundant steps and bumping ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,21 +7,19 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: set up php
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.1"
-      - name: install composer
-        run: composer self-update
       - name: install dependencies
         run: make install
       - name: lint
         run: make lint
   run-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         phpversion: ["7.3", "7.4", "8.0", "8.1"]
@@ -40,8 +38,6 @@ jobs:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.phpversion }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-${{ matrix.phpversion }}-composer-
-      - name: install composer
-        run: composer self-update
       - name: install dependencies
         run: make install
       - name: test with phpunit on ${{ matrix.phpversion }}


### PR DESCRIPTION
# Description

Very simple PR that bumps the version of ubuntu used so we don't need to maintain it and removes a redundant composer step since `setup-php` will install/update composer for us already.<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
