### PR TITLE
feat: adds support to specify endShipperId on the buy call of a Shipment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## NEXT RELEASE
+
+- Adds support to specify an `$endShipperId` on the buy call of a Shipment
+
 ## v5.6.0 (2022-08-25)
 
 - Moves EndShipper out of beta into the general library namespace

--- a/lib/EasyPost/Shipment.php
+++ b/lib/EasyPost/Shipment.php
@@ -124,7 +124,7 @@ class Shipment extends EasypostResource
      * @return $this
      * @throws \EasyPost\Error
      */
-    public function buy($params = null, $withCarbonOffset = false)
+    public function buy($params = null, $withCarbonOffset = false, $endShipperId = false)
     {
         $requestor = new Requestor($this->_apiKey);
         $url = $this->instanceUrl() . '/buy';
@@ -136,6 +136,12 @@ class Shipment extends EasypostResource
         }
 
         $params['carbon_offset'] = $withCarbonOffset;
+        // @codeCoverageIgnoreStart
+        if ($endShipperId !== false) {
+            $params['end_shipper_id'] = $endShipperId;
+        }
+        // @codeCoverageIgnoreEnd
+
         list($response, $apiKey) = $requestor->request('post', $url, $params);
         $this->refreshFrom($response, $apiKey, true);
 

--- a/test/EasyPost/ShipmentTest.php
+++ b/test/EasyPost/ShipmentTest.php
@@ -378,7 +378,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Tests creating a carbon offset shipment.
-     *
      */
     public function testCreatebasicShipment()
     {
@@ -395,7 +394,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Tests buying a carbon offset shipment.
-     *
      */
     public function testBuybasicShipment()
     {
@@ -425,7 +423,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Tests one call buy a carbon offset shipment.
-     *
      */
     public function testOneCallBuybasicShipment()
     {
@@ -442,7 +439,6 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Tests rerate a shipment with carbon offset.
-     *
      */
     public function testRerateShipmentWithCarbonOffset()
     {


### PR DESCRIPTION
# Description

Adds support to specify an `$endShipperId` on the buy call of a shipment.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

We cannot easily test this due to needing to buy in prod.

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
