### PR TITLE
fix: add missing Referral class to imports

### DIFF
--- a/lib/easypost.php
+++ b/lib/easypost.php
@@ -42,6 +42,7 @@ require_once(dirname(__FILE__) . '/EasyPost/Pickup.php');
 require_once(dirname(__FILE__) . '/EasyPost/PickupRate.php');
 require_once(dirname(__FILE__) . '/EasyPost/PostageLabel.php');
 require_once(dirname(__FILE__) . '/EasyPost/Rate.php');
+require_once(dirname(__FILE__) . '/EasyPost/Referral.php');
 require_once(dirname(__FILE__) . '/EasyPost/Refund.php');
 require_once(dirname(__FILE__) . '/EasyPost/Report.php');
 require_once(dirname(__FILE__) . '/EasyPost/ScanForm.php');


### PR DESCRIPTION
# Description

Forgot to add the `Referral` import when it got added.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
