### PR TITLE
refactor: removes unreachable address verification code

### DIFF
--- a/lib/EasyPost/Address.php
+++ b/lib/EasyPost/Address.php
@@ -97,13 +97,7 @@ class Address extends EasypostResource
         $url = self::classUrl($class);
         list($response, $apiKey) = $requestor->request('post', $url . '/create_and_verify', $params);
 
-        if (isset($response['address'])) {
-            $verifiedAddress = Util::convertToEasyPostObject($response['address'], $apiKey);
-
-            return $verifiedAddress;
-        } else {
-            return Util::convertToEasyPostObject($response, $apiKey);
-        }
+        return Util::convertToEasyPostObject($response['address'], $apiKey);
     }
 
     /**
@@ -118,12 +112,6 @@ class Address extends EasypostResource
         $url = $this->instanceUrl() . '/verify';
         list($response, $apiKey) = $requestor->request('get', $url, null);
 
-        if (isset($response['address'])) {
-            $verifiedAddress = Util::convertToEasyPostObject($response['address'], $apiKey);
-
-            return $verifiedAddress;
-        } else {
-            return Util::convertToEasyPostObject($response, $apiKey);
-        }
+        return Util::convertToEasyPostObject($response['address'], $apiKey);
     }
 }

--- a/test/EasyPost/AddressTest.php
+++ b/test/EasyPost/AddressTest.php
@@ -165,4 +165,19 @@ class AddressTest extends \PHPUnit\Framework\TestCase
         $this->assertStringMatchesFormat('adr_%s', $address->id);
         $this->assertEquals('388 Townsend St', $address->street1);
     }
+
+    /**
+     * Test we throw an error for an invalid address verification.
+     */
+    public function testVerifyInvalid()
+    {
+        VCR::insertCassette('addresses/verifyInvalid.yml');
+
+        try {
+            $address = Address::create(['street1' => 'invalid']);
+            $address->verify();
+        } catch (\EasyPost\Error $error) {
+            $this->assertEquals('Unable to verify address.', $error->getMessage());
+        }
+    }
 }

--- a/test/cassettes/addresses/verifyInvalid.yml
+++ b/test/cassettes/addresses/verifyInvalid.yml
@@ -1,0 +1,151 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/addresses'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+        body: '{"address":{"street1":"invalid"}}'
+    response:
+        status:
+            http_version: '2'
+            code: '201'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: ad419059632b34c2e2b8733800140722
+            cache-control: 'private, no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            location: /api/v2/addresses/adr_4d905f7e39c611edb140ac1f6bc72124
+            content-type: 'application/json; charset=utf-8'
+            content-length: '403'
+            etag: 'W/"2d2a93b97fcf2bd581bba1fb126047a8"'
+            x-runtime: '0.046253'
+            x-node: bigweb3nuq
+            x-version-label: easypost-202209210008-610ad55e3f-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq 29913d444b', 'extlb2nuq 29913d444b']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"adr_4d905f7e39c611edb140ac1f6bc72124","object":"Address","created_at":"2022-09-21T15:58:58+00:00","updated_at":"2022-09-21T15:58:58+00:00","name":null,"company":null,"street1":"invalid","street2":null,"city":null,"state":null,"zip":null,"country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":[]}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/addresses'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 793
+            request_size: 305
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.191658
+            namelookup_time: 0.035518
+            connect_time: 0.068513
+            pretransfer_time: 0.111175
+            size_upload: 33.0
+            size_download: 403.0
+            speed_download: 2102.0
+            speed_upload: 172.0
+            download_content_length: 403.0
+            upload_content_length: 33.0
+            starttransfer_time: 0.111178
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.130
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.201
+            local_port: 51738
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 109532
+            connect_time_us: 68513
+            namelookup_time_us: 35518
+            pretransfer_time_us: 111175
+            redirect_time_us: 0
+            starttransfer_time_us: 111178
+            total_time_us: 191658
+-
+    request:
+        method: GET
+        url: 'https://api.easypost.com/v2/addresses/adr_4d905f7e39c611edb140ac1f6bc72124/verify'
+        headers:
+            Host: api.easypost.com
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+    response:
+        status:
+            http_version: '2'
+            code: '422'
+            message: ''
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: ad419056632b34c2e2b873390014072f
+            cache-control: 'private, no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '295'
+            x-runtime: '0.031686'
+            x-node: bigweb7nuq
+            x-version-label: easypost-202209210008-610ad55e3f-master
+            x-backend: easypost
+            x-canary: direct
+            x-proxied: ['intlb2nuq 29913d444b', 'extlb2nuq 29913d444b']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"error":{"code":"ADDRESS.VERIFY.FAILURE","message":"Unable to verify address.","errors":[{"code":"E.ADDRESS.NOT_FOUND","field":"address","message":"Address not found","suggestion":null},{"code":"E.HOUSE_NUMBER.MISSING","field":"street1","message":"House number is missing","suggestion":null}]}}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/addresses/adr_4d905f7e39c611edb140ac1f6bc72124/verify'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 422
+            header_size: 701
+            request_size: 328
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.146737
+            namelookup_time: 0.001897
+            connect_time: 0.036264
+            pretransfer_time: 0.080092
+            size_upload: 0.0
+            size_download: 295.0
+            speed_download: 2010.0
+            speed_upload: 0.0
+            download_content_length: 295.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.146712
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.130
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.201
+            local_port: 51739
+            http_version: 3
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 80023
+            connect_time_us: 36264
+            namelookup_time_us: 1897
+            pretransfer_time_us: 80092
+            redirect_time_us: 0
+            starttransfer_time_us: 146712
+            total_time_us: 146737


### PR DESCRIPTION
# Description

Removes some unreachable address verification code. If an error occurs during verification, we will fail earlier than this function in the stack (closer to the request) and therefore we don't need to check for the existence of the `address` key. I added a unit test to ensure that we still properly throw error when an invalid address is passed meaning this change doesn't affect user expectations.
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Added a unit test for throwing errors on invalid address verifications
<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
