### PR TITLE
chore: drop 7.3, add 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,28 +8,30 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: set up php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.2"
       - name: install dependencies
         run: make install
       - name: lint
         run: make lint
   run-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        phpversion: ["7.3", "7.4", "8.0", "8.1"]
+        # TODO: We are getting segfaults on PHP 8.2 when running the test suite. This needs to be investigated before enabling
+        phpversion: ["7.4", "8.0", "8.1"]
     steps:
       - uses: actions/checkout@v3
       - name: set up php
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.phpversion }}
+          coverage: xdebug
       - name: get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 ## coverage - Runs the test suite and generates a coverage report
 coverage:
 	composer coverage
-	bin/coverage-check build/logs/clover.xml 86 --only-percentage
+	bin/coverage-check build/logs/clover.xml 82 --only-percentage
 
 ## docs - Generate documentation for the library
 docs:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Upgrading major versions of this project? Refer to the [Upgrade Guide](UPGRADE_G
 
 ## Development
 
-**NOTE:** Recording VCR cassettes only works with PHP 7.3 or 7.4. Once recorded, tests can be run on PHP 7 or 8.
+**NOTE:** Recording VCR cassettes only works with PHP 7.4. Once recorded, tests can be run on PHP 7.4 or 8.0+.
 
 ```bash
 # Install dependencies

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "ext-json": "*",
-    "php": ">=7.3",
+    "php": ">=7.4",
     "guzzlehttp/guzzle": "^7.5"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f83412f653063f5f67e3f4497fe851f5",
+    "content-hash": "a21da5587ff783ebd5f6202aad353621",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1598,20 +1598,20 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
             "autoload": {
@@ -1640,9 +1640,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -1750,12 +1750,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "a5d6404aa779f8c718f5e90164da5c37a6065aaf"
+                "reference": "cd9af30140f6f34d9132986f4c6f04cf5e90cdc8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/a5d6404aa779f8c718f5e90164da5c37a6065aaf",
-                "reference": "a5d6404aa779f8c718f5e90164da5c37a6065aaf",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/cd9af30140f6f34d9132986f4c6f04cf5e90cdc8",
+                "reference": "cd9af30140f6f34d9132986f4c6f04cf5e90cdc8",
                 "shasum": ""
             },
             "conflict": {
@@ -1764,6 +1764,7 @@
                 "adodb/adodb-php": "<=5.20.20|>=5.21,<=5.21.3",
                 "aheinze/cockpit": "<=2.2.1",
                 "akaunting/akaunting": "<2.1.13",
+                "akeneo/pim-community-dev": "<5.0.119|>=6,<6.0.53",
                 "alextselegidis/easyappointments": "<=1.4.3",
                 "alterphp/easyadmin-extension-bundle": ">=1.2,<1.2.11|>=1.3,<1.3.1",
                 "amazing/media2click": ">=1,<1.3.3",
@@ -2286,7 +2287,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-09T00:16:03+00:00"
+            "time": "2022-12-09T21:04:12+00:00"
         },
         {
             "name": "rregeer/phpunit-coverage-check",
@@ -4697,7 +4698,7 @@
     "prefer-lowest": false,
     "platform": {
         "ext-json": "*",
-        "php": ">=7.3"
+        "php": ">=7.4"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/lib/EasyPost/EasyPostClient.php
+++ b/lib/EasyPost/EasyPostClient.php
@@ -5,6 +5,7 @@ namespace EasyPost;
 use EasyPost\Constant\Constants;
 use EasyPost\Exception\Error;
 use EasyPost\Service\AddressService;
+use EasyPost\Service\BaseService;
 use EasyPost\Service\BatchService;
 use EasyPost\Service\BillingService;
 use EasyPost\Service\CarrierAccountService;
@@ -52,8 +53,36 @@ use EasyPost\Service\WebhookService;
  * @property UserService $user;
  * @property WebhookService $webhook;
  */
-class EasyPostClient extends Service\BaseService
+class EasyPostClient extends BaseService
 {
+    // Client properties
+    private $apiKey;
+    private $timeout;
+    private $apiBase;
+
+    // Services
+    public $address;
+    public $batch;
+    public $billing;
+    public $carrierAccount;
+    public $customsInfo;
+    public $customsItem;
+    public $endShipper;
+    public $event;
+    public $insurance;
+    public $order;
+    public $parcel;
+    public $pickup;
+    public $rate;
+    public $referralCustomer;
+    public $refund;
+    public $report;
+    public $scanForm;
+    public $shipment;
+    public $tracker;
+    public $user;
+    public $webhook;
+
     /**
      * Constructor for an EasyPostClient.
      *
@@ -63,14 +92,13 @@ class EasyPostClient extends Service\BaseService
      */
     public function __construct($apiKey, $timeout = Constants::TIMEOUT, $apiBase = Constants::API_BASE)
     {
-        // TODO: Make these all read only when we support PHP >= 8.1
-
         // Client properties
         $this->apiKey = $apiKey;
         $this->timeout = $timeout;
         $this->apiBase = $apiBase;
 
-        // Service
+        // Services
+        // TODO: Make these all read only when we support PHP >= 8.1
         $this->address = new AddressService($this);
         $this->batch = new BatchService($this);
         $this->billing = new BillingService($this);
@@ -96,5 +124,35 @@ class EasyPostClient extends Service\BaseService
         if (!$this->apiKey) {
             throw new Error('No API key provided. See https://www.easypost.com/docs for details, or contact ' . Constants::SUPPORT_EMAIL . ' for assistance.');
         }
+    }
+
+    /**
+     * Get the API key of an EasyPostClient.
+     *
+     * @return string
+     */
+    public function getApiKey()
+    {
+        return $this->apiKey;
+    }
+
+    /**
+     * Get the timeout of an EasyPostClient.
+     *
+     * @return float
+     */
+    public function getTimeout()
+    {
+        return $this->timeout;
+    }
+
+    /**
+     * Get the API Base URL of an EasyPostClient.
+     *
+     * @return string
+     */
+    public function getApiBase()
+    {
+        return $this->apiBase;
     }
 }

--- a/lib/EasyPost/Exception/Error.php
+++ b/lib/EasyPost/Exception/Error.php
@@ -10,6 +10,14 @@ namespace EasyPost\Exception;
  */
 class Error extends \Exception
 {
+    private $httpBody;
+    private $httpStatus;
+    private $jsonBody;
+    public $code;
+    public $ecode;
+    public $errors;
+    public $message;
+
     /**
      * Constructor.
      *

--- a/lib/EasyPost/Service/AddressService.php
+++ b/lib/EasyPost/Service/AddressService.php
@@ -75,9 +75,8 @@ class AddressService extends BaseService
             $params['address'] = $clone;
         }
 
-        $requestor = new Requestor($this->client);
         $url = self::classUrl(self::$modelClass);
-        $response = $requestor->request('post', $url . '/create_and_verify', $params);
+        $response = Requestor::request($this->client, 'post', $url . '/create_and_verify', $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response['address']);
     }
@@ -90,9 +89,8 @@ class AddressService extends BaseService
      */
     public function verify($id)
     {
-        $requestor = new Requestor($this->client);
         $url = $this->instanceUrl(self::$modelClass, $id) . '/verify';
-        $response = $requestor->request('get', $url, null);
+        $response = Requestor::request($this->client, 'get', $url, null);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response['address'], self::$modelClass);
     }

--- a/lib/EasyPost/Service/BaseService.php
+++ b/lib/EasyPost/Service/BaseService.php
@@ -8,6 +8,8 @@ use EasyPost\Util\InternalUtil;
 
 class BaseService
 {
+    protected $client;
+
     /**
      * Service constructor shared by all child services.
      *
@@ -99,10 +101,9 @@ class BaseService
      */
     protected function retrieveResource($class, $id, $beta = false)
     {
-        $requestor = new Requestor($this->client);
         $url = $this->instanceUrl($class, $id);
 
-        $response = $requestor->request('get', $url, null, $beta);
+        $response = Requestor::request($this->client, 'get', $url, null, $beta);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -118,9 +119,8 @@ class BaseService
     protected function allResources($class, $params = null, $beta = false)
     {
         self::validate($params);
-        $requestor = new Requestor($this->client);
         $url = self::classUrl($class);
-        $response = $requestor->request('get', $url, $params, $beta);
+        $response = Requestor::request($this->client, 'get', $url, $params, $beta);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -136,10 +136,8 @@ class BaseService
     protected function createResource($class, $params = null, $beta = false)
     {
         self::validate($params);
-        $requestor = new Requestor($this->client);
         $url = self::classUrl($class);
-
-        $response = $requestor->request('post', $url, $params, $beta);
+        $response = Requestor::request($this->client, 'post', $url, $params, $beta);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -156,9 +154,9 @@ class BaseService
     protected function deleteResource($class, $id, $params = null, $beta = false)
     {
         self::validate();
-        $requestor = new Requestor($this->client);
         $url = $this->instanceUrl($class, $id);
-        $requestor->request('delete', $url, $params, $beta);
+
+        Requestor::request($this->client, 'delete', $url, $params, $beta);
     }
 
     /**
@@ -174,9 +172,8 @@ class BaseService
     protected function updateResource($class, $id, $params = null, $method = 'patch', $beta = false)
     {
         self::validate();
-        $requestor = new Requestor($this->client);
         $url = $this->instanceUrl($class, $id);
-        $response = $requestor->request($method, $url, $params, $beta);
+        $response = Requestor::request($this->client, $method, $url, $params, $beta);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }

--- a/lib/EasyPost/Service/BatchService.php
+++ b/lib/EasyPost/Service/BatchService.php
@@ -76,9 +76,8 @@ class BatchService extends BaseService
             ];
         }
 
-        $requestor = new Requestor($this->client);
         $url = self::classUrl(self::$modelClass);
-        $response = $requestor->request('post', $url . '/create_and_buy', $params);
+        $response = Requestor::request($this->client, 'post', $url . '/create_and_buy', $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -92,10 +91,8 @@ class BatchService extends BaseService
      */
     public function buy($id, $params = null)
     {
-        $requestor = new Requestor($this->client);
         $url = $this->instanceUrl(self::$modelClass, $id) . '/buy';
-
-        $response = $requestor->request('post', $url, $params);
+        $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -109,10 +106,8 @@ class BatchService extends BaseService
      */
     public function label($id, $params = null)
     {
-        $requestor = new Requestor($this->client);
         $url = $this->instanceUrl(self::$modelClass, $id) . '/label';
-
-        $response = $requestor->request('post', $url, $params);
+        $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -126,10 +121,8 @@ class BatchService extends BaseService
      */
     public function removeShipments($id, $params = null)
     {
-        $requestor = new Requestor($this->client);
         $url = $this->instanceUrl(self::$modelClass, $id) . '/remove_shipments';
-
-        $response = $requestor->request('post', $url, $params);
+        $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -143,10 +136,8 @@ class BatchService extends BaseService
      */
     public function addShipments($id, $params = null)
     {
-        $requestor = new Requestor($this->client);
         $url = $this->instanceUrl(self::$modelClass, $id) . '/add_shipments';
-
-        $response = $requestor->request('post', $url, $params);
+        $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -160,10 +151,8 @@ class BatchService extends BaseService
      */
     public function createScanForm($id, $params = null)
     {
-        $requestor = new Requestor($this->client);
         $url = $this->instanceUrl(self::$modelClass, $id) . '/scan_form';
-
-        $response = $requestor->request('post', $url, $params);
+        $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }

--- a/lib/EasyPost/Service/BillingService.php
+++ b/lib/EasyPost/Service/BillingService.php
@@ -43,8 +43,7 @@ class BillingService extends BaseService
 
         $url = $paymentMethodEndpoint . "/$paymentMethodId/charges";
         $wrappedParams = ['amount' => $amount];
-        $requestor = new Requestor($this->client);
-        $requestor->request('post', $url, $wrappedParams);
+        Requestor::request($this->client, 'post', $url, $wrappedParams);
     }
 
     /**
@@ -58,8 +57,7 @@ class BillingService extends BaseService
         [$paymentMethodEndpoint, $paymentMethodId] = self::getPaymentInfo(strtolower($primaryOrSecondary));
 
         $url = $paymentMethodEndpoint . "/$paymentMethodId";
-        $requestor = new Requestor($this->client);
-        $requestor->request('delete', $url);
+        Requestor::request($this->client, 'delete', $url);
     }
 
     /**

--- a/lib/EasyPost/Service/CarrierAccountService.php
+++ b/lib/EasyPost/Service/CarrierAccountService.php
@@ -81,9 +81,7 @@ class CarrierAccountService extends BaseService
         }
 
         $url = self::selectCarrierAccountCreationEndpoint($type);
-
-        $requestor = new Requestor($this->client);
-        $response = $requestor->request('post', $url, $params);
+        $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -96,8 +94,7 @@ class CarrierAccountService extends BaseService
      */
     public function types($params = null)
     {
-        $requestor = new Requestor($this->client);
-        $response = $requestor->request('get', '/carrier_types', $params);
+        $response = Requestor::request($this->client, 'get', '/carrier_types', $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }

--- a/lib/EasyPost/Service/OrderService.php
+++ b/lib/EasyPost/Service/OrderService.php
@@ -50,9 +50,8 @@ class OrderService extends BaseService
      */
     public function getRates($id, $params = null)
     {
-        $requestor = new Requestor($this->client);
         $url = $this->instanceUrl(self::$modelClass, $id) . '/rates';
-        $response = $requestor->request('get', $url, $params);
+        $response = Requestor::request($this->client, 'get', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -66,9 +65,6 @@ class OrderService extends BaseService
      */
     public function buy($id, $params = null)
     {
-        $requestor = new Requestor($this->client);
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/buy';
-
         if ($params instanceof Rate) {
             $clone = $params;
             unset($params);
@@ -76,7 +72,8 @@ class OrderService extends BaseService
             $params['service'] = $clone->service;
         }
 
-        $response = $requestor->request('post', $url, $params);
+        $url = $this->instanceUrl(self::$modelClass, $id) . '/buy';
+        $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }

--- a/lib/EasyPost/Service/PickupService.php
+++ b/lib/EasyPost/Service/PickupService.php
@@ -49,10 +49,8 @@ class PickupService extends BaseService
      */
     public function buy($id, $params = null)
     {
-        $requestor = new Requestor($this->client);
         $url = $this->instanceUrl(self::$modelClass, $id) . '/buy';
-
-        $response = $requestor->request('post', $url, $params);
+        $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -66,10 +64,8 @@ class PickupService extends BaseService
      */
     public function cancel($id, $params = null)
     {
-        $requestor = new Requestor($this->client);
         $url = $this->instanceUrl(self::$modelClass, $id) . '/cancel';
-
-        $response = $requestor->request('post', $url, $params);
+        $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }

--- a/lib/EasyPost/Service/ReferralCustomerService.php
+++ b/lib/EasyPost/Service/ReferralCustomerService.php
@@ -2,6 +2,7 @@
 
 namespace EasyPost\Service;
 
+use EasyPost\Constant\Constants;
 use EasyPost\EasyPostClient;
 use EasyPost\Exception\Error;
 use EasyPost\Http\Requestor;
@@ -58,8 +59,7 @@ class ReferralCustomerService extends BaseService
             ]
         ];
 
-        $requestor = new Requestor($this->client);
-        $requestor->request('put', "/referral_customers/{$userId}", $wrappedParams);
+        Requestor::request($this->client, 'put', "/referral_customers/{$userId}", $wrappedParams);
     }
 
     /**
@@ -99,8 +99,7 @@ class ReferralCustomerService extends BaseService
      */
     private function retrieveEasypostStripeApiKey()
     {
-        $requestor = new Requestor($this->client);
-        $response = $requestor->request('get', '/partners/stripe_public_key');
+        $response = Requestor::request($this->client, 'get', '/partners/stripe_public_key');
 
         return $response['public_key'] ?? '';
     }
@@ -131,8 +130,7 @@ class ReferralCustomerService extends BaseService
             ]
         ];
 
-        $requestor = new Requestor($this->client);
-        $formEncodedParams = $requestor->urlEncode($creditCardDetails);
+        $formEncodedParams = Requestor::urlEncode($creditCardDetails);
         $url = "https://api.stripe.com/v1/tokens?$formEncodedParams";
 
         $guzzleClient = new Client();
@@ -143,7 +141,7 @@ class ReferralCustomerService extends BaseService
         try {
             $response = $guzzleClient->request('POST', $url, $requestOptions);
         } catch (\GuzzleHttp\Exception\ConnectException $error) {
-            $message = "Unexpected error communicating with Stripe. If this problem persists please let us know at {$requestor->supportEmail}. {$error->getMessage()}";
+            $message = 'Unexpected error communicating with Stripe. If this problem persists please let us know at ' . Constants::SUPPORT_EMAIL . ".{$error->getMessage()}";
             throw new Error($message, null, null);
         }
 
@@ -154,7 +152,7 @@ class ReferralCustomerService extends BaseService
 
         $responseBody = $response->getBody();
         $httpStatus = $response->getStatusCode();
-        $response = $requestor->interpretResponse($responseBody, $httpStatus);
+        $response = Requestor::interpretResponse($responseBody, $httpStatus);
 
         return $response;
     }
@@ -177,9 +175,7 @@ class ReferralCustomerService extends BaseService
         ];
 
         $client = new EasyPostClient($referralApiKey);
-
-        $requestor = new Requestor($client);
-        $response = $requestor->request('post', '/credit_cards', $params);
+        $response = Requestor::request($client, 'post', '/credit_cards', $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }

--- a/lib/EasyPost/Service/ReportService.php
+++ b/lib/EasyPost/Service/ReportService.php
@@ -37,13 +37,9 @@ class ReportService extends BaseService
             throw new Error('Undetermined Report Type');
         } else {
             $type = $params['type'];
-
             self::validate($params);
-            $requestor = new Requestor($this->client);
-
             $url = self::reportUrl($type);
-
-            $response = $requestor->request('get', $url, $params);
+            $response = Requestor::request($this->client, 'get', $url, $params);
 
             return InternalUtil::convertToEasyPostObject($this->client, $response);
         }
@@ -62,11 +58,8 @@ class ReportService extends BaseService
         }
 
         $url = self::reportUrl($params['type']);
-
         self::validate($params);
-        $requestor = new Requestor($this->client);
-
-        $response = $requestor->request('post', $url, $params);
+        $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }

--- a/lib/EasyPost/Service/ShipmentService.php
+++ b/lib/EasyPost/Service/ShipmentService.php
@@ -64,10 +64,9 @@ class ShipmentService extends BaseService
      */
     public function regenerateRates($id, $params = null, $withCarbonOffset = false)
     {
-        $requestor = new Requestor($this->client);
         $url = $this->instanceUrl(self::$modelClass, $id) . '/rerate';
         $params['carbon_offset'] = $withCarbonOffset;
-        $response = $requestor->request('post', $url, $params);
+        $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -80,9 +79,8 @@ class ShipmentService extends BaseService
      */
     public function getSmartRates($id)
     {
-        $requestor = new Requestor($this->client);
         $url = $this->instanceUrl(self::$modelClass, $id) . '/smartrate';
-        $response = $requestor->request('get', $url);
+        $response = Requestor::request($this->client, 'get', $url);
 
         $result = isset($response['result']) ? $response['result'] : [];
 
@@ -100,22 +98,20 @@ class ShipmentService extends BaseService
      */
     public function buy($id, $params = null, $withCarbonOffset = false, $endShipperId = false)
     {
-        $requestor = new Requestor($this->client);
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/buy';
-
         if (isset($params['id']) && (!isset($params['rate']) || !is_array($params['rate']))) {
             $clone = $params;
             unset($params);
             $params['rate'] = $clone;
         }
 
+        $url = $this->instanceUrl(self::$modelClass, $id) . '/buy';
         $params['carbon_offset'] = $withCarbonOffset;
 
         if ($endShipperId !== false) {
             $params['end_shipper_id'] = $endShipperId;
         }
 
-        $response = $requestor->request('post', $url, $params);
+        $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -129,10 +125,8 @@ class ShipmentService extends BaseService
      */
     public function refund($id, $params = null)
     {
-        $requestor = new Requestor($this->client);
         $url = $this->instanceUrl(self::$modelClass, $id) . '/refund';
-
-        $response = $requestor->request('post', $url, $params);
+        $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -146,16 +140,14 @@ class ShipmentService extends BaseService
      */
     public function label($id, $params = null)
     {
-        $requestor = new Requestor($this->client);
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/label';
-
         if (!isset($params['file_format'])) {
             $clone = $params;
             unset($params);
             $params['file_format'] = $clone;
         }
 
-        $response = $requestor->request('get', $url, $params);
+        $url = $this->instanceUrl(self::$modelClass, $id) . '/label';
+        $response = Requestor::request($this->client, 'get', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -169,16 +161,14 @@ class ShipmentService extends BaseService
      */
     public function insure($id, $params = null)
     {
-        $requestor = new Requestor($this->client);
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/insure';
-
         if (!isset($params['amount'])) {
             $clone = $params;
             unset($params);
             $params['amount'] = $clone;
         }
 
-        $response = $requestor->request('post', $url, $params);
+        $url = $this->instanceUrl(self::$modelClass, $id) . '/insure';
+        $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -193,13 +183,12 @@ class ShipmentService extends BaseService
      */
     public function generateForm($id, $formType, $formOptions = null)
     {
-        $requestor = new Requestor($this->client);
         $url = $this->instanceUrl(self::$modelClass, $id) . '/forms';
         $formOptions['type'] = $formType;
 
         $params['form'] = $formOptions;
 
-        $response = $requestor->request('post', $url, $params);
+        $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }

--- a/lib/EasyPost/Service/TrackerService.php
+++ b/lib/EasyPost/Service/TrackerService.php
@@ -68,8 +68,8 @@ class TrackerService extends BaseService
             $params = ['trackers' => $clone];
         }
 
-        $requestor = new Requestor($this->client);
         $url = self::classUrl(self::$modelClass);
-        $requestor->request('post', $url . '/create_list', $params);
+
+        Requestor::request($this->client, 'post', $url . '/create_list', $params);
     }
 }

--- a/lib/EasyPost/Service/UserService.php
+++ b/lib/EasyPost/Service/UserService.php
@@ -85,8 +85,7 @@ class UserService extends BaseService
      */
     public function allApiKeys()
     {
-        $requestor = new Requestor($this->client);
-        $response = $requestor->request('get', '/api_keys');
+        $response = Requestor::request($this->client, 'get', '/api_keys');
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }
@@ -127,8 +126,7 @@ class UserService extends BaseService
      */
     public function updateBrand($id, $params = null)
     {
-        $requestor = new Requestor($this->client);
-        $response = $requestor->request('patch', $this->instanceUrl(self::$modelClass, $id) . '/brand', $params);
+        $response = Requestor::request($this->client, 'patch', $this->instanceUrl(self::$modelClass, $id) . '/brand', $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }

--- a/lib/easypost.php
+++ b/lib/easypost.php
@@ -20,7 +20,8 @@ require_once(dirname(__FILE__) . '/EasyPost/Http/Requestor.php');
 require_once(dirname(__FILE__) . '/EasyPost/Util/InternalUtil.php');
 require_once(dirname(__FILE__) . '/EasyPost/Util/Util.php');
 
-// EasyPost Lib
+// EasyPost Lib (order is important for this section)
+require_once(dirname(__FILE__) . '/EasyPost/Service/BaseService.php');
 require_once(dirname(__FILE__) . '/EasyPost/EasyPostClient.php');
 require_once(dirname(__FILE__) . '/EasyPost/EasyPostObject.php');
 
@@ -63,7 +64,6 @@ require_once(dirname(__FILE__) . '/EasyPost/Webhook.php');
 
 // Services
 require_once(dirname(__FILE__) . '/EasyPost/Service/AddressService.php');
-require_once(dirname(__FILE__) . '/EasyPost/Service/BaseService.php');
 require_once(dirname(__FILE__) . '/EasyPost/Service/BatchService.php');
 require_once(dirname(__FILE__) . '/EasyPost/Service/BillingService.php');
 require_once(dirname(__FILE__) . '/EasyPost/Service/CarrierAccountService.php');

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" bootstrap="test/bootstrap.php" cacheResultFile=".phpunit.cache/test-results" executionOrder="depends,defects" beStrictAboutCoversAnnotation="true" beStrictAboutOutputDuringTests="true" beStrictAboutTodoAnnotatedTests="true" failOnRisky="true" failOnWarning="true" verbose="true" colors="true">
+<phpunit bootstrap="test/bootstrap.php" cacheResultFile=".phpunit.cache/test-results" testdox="true" executionOrder="depends,defects" verbose="true" colors="true">
     <testsuites>
         <testsuite name="EasyPost Test Suite">
             <directory suffix="Test.php">./test/EasyPost/</directory>

--- a/test/EasyPost/EasyPostClientTest.php
+++ b/test/EasyPost/EasyPostClientTest.php
@@ -14,11 +14,11 @@ class EasyPostClientTest extends \PHPUnit\Framework\TestCase
     {
         $apiKey1 = '123';
         $client1 = new EasyPostClient($apiKey1);
-        $clientApiKey1 = $client1->apiKey;
+        $clientApiKey1 = $client1->getApiKey();
 
         $apiKey2 = '456';
         $client2 = new EasyPostClient($apiKey2);
-        $clientApiKey2 = $client2->apiKey;
+        $clientApiKey2 = $client2->getApiKey();
 
         $this->assertEquals($apiKey1, $clientApiKey1);
         $this->assertEquals($apiKey2, $clientApiKey2);
@@ -32,7 +32,7 @@ class EasyPostClientTest extends \PHPUnit\Framework\TestCase
         $apiBase = 'http://example.com';
 
         $client = new EasyPostClient(getenv('EASYPOST_TEST_API_KEY'), 60.0, $apiBase);
-        $clientApiBase = $client->apiBase;
+        $clientApiBase = $client->getApiBase();
 
         $this->assertEquals($apiBase, $clientApiBase);
     }
@@ -45,7 +45,7 @@ class EasyPostClientTest extends \PHPUnit\Framework\TestCase
         $timeout = 1.0;
 
         $client = new EasyPostClient(getenv('EASYPOST_TEST_API_KEY'), $timeout);
-        $clientTimeout = $client->timeout;
+        $clientTimeout = $client->getTimeout();
 
         $this->assertEquals($timeout, $clientTimeout);
     }


### PR DESCRIPTION
# Description

- Drops support for PHP 7.3 and adds CI checks for PHP 8.2.
- This PR also fixes the test config so it could be more helpful in debugging future issues and I corrected various deprecation issues that sprang up when running on PHP 8.2.
- Finally, this PR removes the need to instantiate a Requestor object since there is no need to do that on every request and instead passes down the client object as a param, making that whole class static. This helps performance and most likely the segfault issue in the long run that I'll be investigating later.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Tested PHP 8.2 with a scratch file and it worked as expected.

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
