### PR TITLE
Exception overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `validateWebhook`, `getLowestSmartRate`, and `receiveEvent` are now under `EasyPost\Util\Util` as they do not make any API calls
   - Internal only utilities have been moved to `EasyPost\Util\InternalUtil`
 - The beta `EndShipper` class has been removed, please use the generally available `EndShipper` class
+- The `ecode` property of an `Error` is now just `code`
 
 ## v5.8.0 (2022-12-01)
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 ## coverage - Runs the test suite and generates a coverage report
 coverage:
 	composer coverage
-	bin/coverage-check build/logs/clover.xml 82 --only-percentage
+	bin/coverage-check build/logs/clover.xml 78 --only-percentage
 
 ## docs - Generate documentation for the library
 docs:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 ## coverage - Runs the test suite and generates a coverage report
 coverage:
 	composer coverage
-	bin/coverage-check build/logs/clover.xml 78 --only-percentage
+	bin/coverage-check build/logs/clover.xml 80 --only-percentage
 
 ## docs - Generate documentation for the library
 docs:

--- a/lib/EasyPost/Constant/Constants.php
+++ b/lib/EasyPost/Constant/Constants.php
@@ -19,4 +19,20 @@ abstract class Constants
         'FedexAccount',
         'UpsAccount'
     ];
+
+    // Exception messages (many of these are intended to be used with `sprintf()`)
+    const ARRAY_REQUIRED_ERROR = 'You must pass an array as the first argument to EasyPost API method calls.';
+    const COMMUNICATION_ERROR = 'Unexpected error communicating with %s. If this problem persists please let us know at ' . self::SUPPORT_EMAIL . '. %s';
+    const DECODE_WEBHOOK_ERROR = 'There was a problem decoding the webhook.';
+    const INVALID_PARAMETER_ERROR_WITH_SUGGESTION = 'Invalid %s value, must be one of: %s';
+    const INVALID_PAYMENT_METHOD_ERROR = 'The chosen payment method is not valid. Please try again.';
+    const INVALID_SIGNATURE_ERROR = 'Webhook received does not contain an HMAC signature.';
+    const INVALID_WEBHOOK_VALIDATION_ERROR = 'Webhook received did not originate from EasyPost or had a webhook secret mismatch.';
+    const MISSING_PARAMETER_ERROR = '%s is required.';
+    const NO_BILLING_ERROR = 'Billing has not been setup for this user. Please add a payment method.';
+    const NO_ID_URL_ERROR = 'Could not determine which URL to request: %s instance has invalid ID: %s';
+    const NO_RATES_ERROR = 'No rates found.';
+    const NO_RESPONSE_ERROR = 'Did not receive a response from %s.';
+    const SEND_STRIPE_DETAILS_ERROR = 'Could not send card details to Stripe, please try again later.';
+    const UNDEFINED_PROPERTY_ERROR = 'EasyPost Notice: Undefined property of %s instance: %s';
 }

--- a/lib/EasyPost/EasyPostClient.php
+++ b/lib/EasyPost/EasyPostClient.php
@@ -3,7 +3,7 @@
 namespace EasyPost;
 
 use EasyPost\Constant\Constants;
-use EasyPost\Exception\Error;
+use EasyPost\Exception\General\MissingParameterException;
 use EasyPost\Service\AddressService;
 use EasyPost\Service\BaseService;
 use EasyPost\Service\BatchService;
@@ -122,7 +122,7 @@ class EasyPostClient extends BaseService
         $this->webhook = new WebhookService($this);
 
         if (!$this->apiKey) {
-            throw new Error('No API key provided. See https://www.easypost.com/docs for details, or contact ' . Constants::SUPPORT_EMAIL . ' for assistance.');
+            throw new MissingParameterException('No API key provided. See https://www.easypost.com/docs for details, or contact ' . Constants::SUPPORT_EMAIL . ' for assistance.');
         }
     }
 

--- a/lib/EasyPost/EasyPostObject.php
+++ b/lib/EasyPost/EasyPostObject.php
@@ -2,6 +2,7 @@
 
 namespace EasyPost;
 
+use EasyPost\Constant\Constants;
 use EasyPost\Util\InternalUtil;
 use EasyPost\Util\Util;
 
@@ -111,7 +112,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
             return $this->_values[$k];
         } else {
             $class = get_class($this);
-            error_log("EasyPost Notice: Undefined property of {$class} instance: {$k}");
+            error_log(sprintf(Constants::UNDEFINED_PROPERTY_ERROR, $class, $k));
 
             return null;
         }

--- a/lib/EasyPost/Exception/Api/ApiException.php
+++ b/lib/EasyPost/Exception/Api/ApiException.php
@@ -1,25 +1,25 @@
 <?php
 
-namespace EasyPost\Exception;
+namespace EasyPost\Exception\Api;
+
+use EasyPost\Exception\General\EasyPostException;
 
 /**
  * @package EasyPost
  * @property string $code
- * @property string $message
  * @property FieldError[] $errors
  */
-class Error extends \Exception
+class ApiException extends EasyPostException
 {
-    private $httpBody;
-    private $httpStatus;
-    private $jsonBody;
+    protected $httpBody;
+    protected $httpStatus;
+    protected $jsonBody;
+    protected $message;
     public $code;
-    public $ecode;
     public $errors;
-    public $message;
 
     /**
-     * Constructor.
+     * EasyPostException constructor.
      *
      * @param string $message
      * @param int $httpStatus
@@ -33,16 +33,19 @@ class Error extends \Exception
 
         try {
             $this->jsonBody = json_decode($httpBody, true);
+
+            // Setup `errors` property
             if (isset($this->jsonBody) && !empty($this->jsonBody['error']['errors'])) {
                 $this->errors = $this->jsonBody['error']['errors'];
             } else {
                 $this->errors = null;
             }
 
+            // Setup `code` property
             if (isset($this->jsonBody) && !empty($this->jsonBody['error']['code'])) {
-                $this->ecode = $this->jsonBody['error']['code'];
+                $this->code = $this->jsonBody['error']['code'];
             } else {
-                $this->ecode = null;
+                $this->code = null;
             }
         } catch (\Exception $e) {
             $this->jsonBody = null;
@@ -76,7 +79,7 @@ class Error extends \Exception
      */
     public function prettyPrint()
     {
-        print($this->ecode . ' (' . $this->getHttpStatus() . '): ' .
+        print($this->code . ' (' . $this->getHttpStatus() . '): ' .
             $this->getMessage() . "\n");
         if (!empty($this->errors)) {
             print("Field errors:\n");

--- a/lib/EasyPost/Exception/Api/ApiException.php
+++ b/lib/EasyPost/Exception/Api/ApiException.php
@@ -19,7 +19,7 @@ class ApiException extends EasyPostException
     public $errors;
 
     /**
-     * EasyPostException constructor.
+     * ApiException constructor.
      *
      * @param string $message
      * @param int $httpStatus

--- a/lib/EasyPost/Exception/Api/ApiException.php
+++ b/lib/EasyPost/Exception/Api/ApiException.php
@@ -11,12 +11,12 @@ use EasyPost\Exception\General\EasyPostException;
  */
 class ApiException extends EasyPostException
 {
-    protected $httpBody;
-    protected $httpStatus;
-    protected $jsonBody;
-    protected $message;
     public $code;
     public $errors;
+    protected $message;
+    private $httpBody;
+    private $httpStatus;
+    private $jsonBody;
 
     /**
      * ApiException constructor.

--- a/lib/EasyPost/Exception/Api/EncodingException.php
+++ b/lib/EasyPost/Exception/Api/EncodingException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class EncodingException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/Api/ExternalApiException.php
+++ b/lib/EasyPost/Exception/Api/ExternalApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class ExternalApiException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/Api/ForbiddenException.php
+++ b/lib/EasyPost/Exception/Api/ForbiddenException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class ForbiddenException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/Api/GatewayTimeoutException.php
+++ b/lib/EasyPost/Exception/Api/GatewayTimeoutException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class GatewayTimeoutException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/Api/HttpException.php
+++ b/lib/EasyPost/Exception/Api/HttpException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class HttpException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/Api/InternalServerException.php
+++ b/lib/EasyPost/Exception/Api/InternalServerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class InternalServerException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/Api/InvalidRequestException.php
+++ b/lib/EasyPost/Exception/Api/InvalidRequestException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class InvalidRequestException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/Api/JsonException.php
+++ b/lib/EasyPost/Exception/Api/JsonException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class JsonException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/Api/MethodNotAllowedException.php
+++ b/lib/EasyPost/Exception/Api/MethodNotAllowedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class MethodNotAllowedException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/Api/NotFoundException.php
+++ b/lib/EasyPost/Exception/Api/NotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class NotFoundException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/Api/PaymentException.php
+++ b/lib/EasyPost/Exception/Api/PaymentException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class PaymentException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/Api/RateLimitException.php
+++ b/lib/EasyPost/Exception/Api/RateLimitException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class RateLimitException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/Api/RedirectException.php
+++ b/lib/EasyPost/Exception/Api/RedirectException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class RedirectException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/Api/ServiceUnavailableException.php
+++ b/lib/EasyPost/Exception/Api/ServiceUnavailableException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class ServiceUnavailableException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/Api/TimeoutException.php
+++ b/lib/EasyPost/Exception/Api/TimeoutException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class TimeoutException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/Api/UnauthorizedException.php
+++ b/lib/EasyPost/Exception/Api/UnauthorizedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class UnauthorizedException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/Api/UnknownApiException.php
+++ b/lib/EasyPost/Exception/Api/UnknownApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\Api;
+
+class UnknownApiException extends ApiException
+{
+}

--- a/lib/EasyPost/Exception/General/EasyPostException.php
+++ b/lib/EasyPost/Exception/General/EasyPostException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace EasyPost\Exception\General;
+
+class EasyPostException extends \Exception
+{
+    /**
+     * EasyPostException constructor.
+     *
+     * @param string $message
+     */
+    public function __construct($message = null)
+    {
+        parent::__construct($message);
+    }
+}

--- a/lib/EasyPost/Exception/General/FilteringException.php
+++ b/lib/EasyPost/Exception/General/FilteringException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\General;
+
+class FilteringException extends EasyPostException
+{
+}

--- a/lib/EasyPost/Exception/General/InvalidObjectException.php
+++ b/lib/EasyPost/Exception/General/InvalidObjectException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\General;
+
+class InvalidObjectException extends EasyPostException
+{
+}

--- a/lib/EasyPost/Exception/General/InvalidParameterException.php
+++ b/lib/EasyPost/Exception/General/InvalidParameterException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\General;
+
+class InvalidParameterException extends EasyPostException
+{
+}

--- a/lib/EasyPost/Exception/General/MissingParameterException.php
+++ b/lib/EasyPost/Exception/General/MissingParameterException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\General;
+
+class MissingParameterException extends EasyPostException
+{
+}

--- a/lib/EasyPost/Exception/General/SignatureVerificationException.php
+++ b/lib/EasyPost/Exception/General/SignatureVerificationException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EasyPost\Exception\General;
+
+class SignatureVerificationException extends EasyPostException
+{
+}

--- a/lib/EasyPost/Http/Requestor.php
+++ b/lib/EasyPost/Http/Requestor.php
@@ -255,46 +255,11 @@ class Requestor
             $message = $response['error'];
         }
 
+        if ($httpStatus >= 300 && $httpStatus < 400) {
+            throw new RedirectException($message, $httpStatus, $httpBody);
+        }
+
         switch ($httpStatus) {
-            case 100:
-                $errorType = UnknownApiException::class;
-                break;
-            case 101:
-                $errorType = UnknownApiException::class;
-                break;
-            case 102:
-                $errorType = UnknownApiException::class;
-                break;
-            case 103:
-                $errorType = UnknownApiException::class;
-                break;
-            case 300:
-                $errorType = RedirectException::class;
-                break;
-            case 301:
-                $errorType = RedirectException::class;
-                break;
-            case 302:
-                $errorType = RedirectException::class;
-                break;
-            case 303:
-                $errorType = RedirectException::class;
-                break;
-            case 304:
-                $errorType = RedirectException::class;
-                break;
-            case 305:
-                $errorType = RedirectException::class;
-                break;
-            case 306:
-                $errorType = RedirectException::class;
-                break;
-            case 307:
-                $errorType = RedirectException::class;
-                break;
-            case 308:
-                $errorType = RedirectException::class;
-                break;
             case 401:
                 $errorType = UnauthorizedException::class;
                 break;

--- a/lib/EasyPost/Order.php
+++ b/lib/EasyPost/Order.php
@@ -31,7 +31,6 @@ class Order extends EasyPostObject
      * @param array $carriers
      * @param array $services
      * @return Rate
-     * @throws \EasyPost\Exception\Error
      */
     public function lowestRate($carriers = [], $services = [])
     {

--- a/lib/EasyPost/Pickup.php
+++ b/lib/EasyPost/Pickup.php
@@ -34,7 +34,6 @@ class Pickup extends EasyPostObject
      * @param array $carriers
      * @param array $services
      * @return Rate
-     * @throws \EasyPost\Exception\Error
      */
     public function lowestRate($carriers = [], $services = [])
     {

--- a/lib/EasyPost/Service/BaseService.php
+++ b/lib/EasyPost/Service/BaseService.php
@@ -2,7 +2,9 @@
 
 namespace EasyPost\Service;
 
-use EasyPost\Exception\Error;
+use EasyPost\Constant\Constants;
+use EasyPost\Exception\General\InvalidObjectException;
+use EasyPost\Exception\General\InvalidParameterException;
 use EasyPost\Http\Requestor;
 use EasyPost\Util\InternalUtil;
 
@@ -65,12 +67,12 @@ class BaseService
      * @param string $class
      * @param string $id
      * @return string
-     * @throws \EasyPost\Exception\Error
+     * @throws InvalidObjectException
      */
     protected function instanceUrl($class, $id)
     {
         if (!$id) {
-            throw new Error("Could not determine which URL to request: {$class} instance has invalid ID: {$id}");
+            throw new InvalidObjectException(sprintf(Constants::NO_ID_URL_ERROR), $class, $id);
         }
         $id = Requestor::utf8($id);
         $classUrl = self::classUrl($class);
@@ -82,12 +84,12 @@ class BaseService
      * Validate library usage.
      *
      * @param array $params
-     * @throws \EasyPost\Exception\Error
+     * @throws InvalidParameterException
      */
     protected static function validate($params = null)
     {
         if ($params && !is_array($params)) {
-            throw new Error('You must pass an array as the first argument to EasyPost API method calls.');
+            throw new InvalidParameterException(Constants::ARRAY_REQUIRED_ERROR);
         }
     }
 

--- a/lib/EasyPost/Service/CarrierAccountService.php
+++ b/lib/EasyPost/Service/CarrierAccountService.php
@@ -3,7 +3,7 @@
 namespace EasyPost\Service;
 
 use EasyPost\Constant\Constants;
-use EasyPost\Exception\Error;
+use EasyPost\Exception\General\MissingParameterException;
 use EasyPost\Http\Requestor;
 use EasyPost\Util\InternalUtil;
 
@@ -65,7 +65,7 @@ class CarrierAccountService extends BaseService
      *
      * @param mixed $params
      * @return mixed
-     * @throws Error
+     * @throws MissingParameterException
      */
     public function create($params = null)
     {
@@ -75,12 +75,11 @@ class CarrierAccountService extends BaseService
             $params['carrier_account'] = $clone;
         }
 
-        $type = $params['carrier_account']['type'];
-        if (!isset($type)) {
-            throw new Error('type is required');
+        if (!isset($params['carrier_account']['type'])) {
+            throw new MissingParameterException(sprintf(Constants::MISSING_PARAMETER_ERROR, 'type'));
         }
 
-        $url = self::selectCarrierAccountCreationEndpoint($type);
+        $url = self::selectCarrierAccountCreationEndpoint($params['carrier_account']['type']);
         $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);

--- a/lib/EasyPost/Service/ReportService.php
+++ b/lib/EasyPost/Service/ReportService.php
@@ -2,7 +2,8 @@
 
 namespace EasyPost\Service;
 
-use EasyPost\Exception\Error;
+use EasyPost\Constant\Constants;
+use EasyPost\Exception\General\MissingParameterException;
 use EasyPost\Http\Requestor;
 use EasyPost\Util\InternalUtil;
 
@@ -29,12 +30,12 @@ class ReportService extends BaseService
      *
      * @param mixed $params
      * @return mixed
-     * @throws Error
+     * @throws MissingParameterException
      */
     public function all($params = null)
     {
         if (!isset($params) || !isset($params['type'])) {
-            throw new Error('Undetermined Report Type');
+            throw new MissingParameterException(Constants::MISSING_PARAMETER_ERROR);
         } else {
             $type = $params['type'];
             self::validate($params);
@@ -50,11 +51,12 @@ class ReportService extends BaseService
      *
      * @param mixed $params
      * @return mixed
+     * @throws MissingParameterException
      */
     public function create($params = null)
     {
         if (!isset($params['type'])) {
-            throw new Error('Undetermined Report Type');
+            throw new MissingParameterException(Constants::MISSING_PARAMETER_ERROR);
         }
 
         $url = self::reportUrl($params['type']);

--- a/lib/EasyPost/Shipment.php
+++ b/lib/EasyPost/Shipment.php
@@ -47,7 +47,6 @@ class Shipment extends EasyPostObject
      * @param array $carriers
      * @param array $services
      * @return Rate
-     * @throws \EasyPost\Exception\Error
      */
     public function lowestRate($carriers = [], $services = [])
     {

--- a/lib/EasyPost/Util/InternalUtil.php
+++ b/lib/EasyPost/Util/InternalUtil.php
@@ -2,8 +2,9 @@
 
 namespace EasyPost\Util;
 
+use EasyPost\Constant\Constants;
 use EasyPost\EasyPostObject;
-use EasyPost\Exception\Error;
+use EasyPost\Exception\General\FilteringException;
 
 abstract class InternalUtil
 {
@@ -148,7 +149,7 @@ abstract class InternalUtil
      * @param array $services
      * @param string $ratesKey
      * @return Rate
-     * @throws \EasyPost\Exception\Error
+     * @throws \EasyPost\Exception\EasyPostException
      */
     public static function getLowestObjectRate($easypostObject, $carriers = [], $services = [], $ratesKey = 'rates')
     {
@@ -205,7 +206,7 @@ abstract class InternalUtil
         }
 
         if ($lowestRate == false) {
-            throw new Error('No rates found.');
+            throw new FilteringException(Constants::NO_RATES_ERROR);
         }
 
         return $lowestRate;

--- a/lib/easypost.php
+++ b/lib/easypost.php
@@ -7,8 +7,36 @@ if (!function_exists('json_decode')) {
     throw new Exception('EasyPost needs the JSON PHP extension.');
 }
 
-// Exceptions
-require_once(dirname(__FILE__) . '/EasyPost/Exception/Error.php');
+// Exception Base Classes
+require_once(dirname(__FILE__) . '/EasyPost/Exception/General/EasyPostException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/ApiException.php');
+
+// API Exceptions
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/ApiException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/EncodingException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/ExternalApiException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/ForbiddenException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/GatewayTimeoutException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/HttpException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/InternalServerException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/InvalidRequestException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/JsonException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/MethodNotAllowedException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/NotFoundException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/PaymentException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/RateLimitException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/RedirectException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/ServiceUnavailableException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/TimeoutException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/UnauthorizedException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/Api/UnknownApiException.php');
+
+// General Exceptions
+require_once(dirname(__FILE__) . '/EasyPost/Exception/General/FilteringException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/General/InvalidObjectException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/General/InvalidParameterException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/General/MissingParameterException.php');
+require_once(dirname(__FILE__) . '/EasyPost/Exception/General/SignatureVerificationException.php');
 
 // Constants
 require_once(dirname(__FILE__) . '/EasyPost/Constant/Constants.php');

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,9 +10,5 @@
         <include>
             <directory suffix=".php">./lib/EasyPost/</directory>
         </include>
-        <exclude>
-            <!-- We exclude the Billing module because it cannot be easily tested. -->
-            <directory>./lib/EasyPost/Billing.php</directory>
-        </exclude>
     </coverage>
 </phpunit>

--- a/test/EasyPost/AddressTest.php
+++ b/test/EasyPost/AddressTest.php
@@ -3,7 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
-use EasyPost\Exception\Error;
+use EasyPost\Exception\Api\ApiException;
 
 class AddressTest extends \PHPUnit\Framework\TestCase
 {
@@ -174,7 +174,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
         try {
             $address = self::$client->address->create(['street1' => 'invalid']);
             self::$client->address->verify($address->id);
-        } catch (Error $error) {
+        } catch (ApiException $error) {
             $this->assertEquals('Unable to verify address.', $error->getMessage());
         }
     }

--- a/test/EasyPost/BatchTest.php
+++ b/test/EasyPost/BatchTest.php
@@ -3,7 +3,6 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
-use EasyPost\Shipment;
 
 class BatchTest extends \PHPUnit\Framework\TestCase
 {

--- a/test/EasyPost/EasyPostClientTest.php
+++ b/test/EasyPost/EasyPostClientTest.php
@@ -3,7 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
-use EasyPost\Exception\Error;
+use EasyPost\Exception\General\MissingParameterException;
 
 class EasyPostClientTest extends \PHPUnit\Framework\TestCase
 {
@@ -57,7 +57,7 @@ class EasyPostClientTest extends \PHPUnit\Framework\TestCase
     {
         try {
             new EasyPostClient(null);
-        } catch (Error $error) {
+        } catch (MissingParameterException $error) {
             $this->assertEquals('No API key provided. See https://www.easypost.com/docs for details, or contact support@easypost.com for assistance.', $error->getMessage());
         }
     }

--- a/test/EasyPost/ErrorTest.php
+++ b/test/EasyPost/ErrorTest.php
@@ -3,7 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
-use EasyPost\Exception\Error;
+use EasyPost\Exception\Api\ApiException;
 
 class ErrorTest extends \PHPUnit\Framework\TestCase
 {
@@ -36,9 +36,9 @@ class ErrorTest extends \PHPUnit\Framework\TestCase
         // Create a bad shipment so we can work with errors
         try {
             self::$client->shipment->create();
-        } catch (Error $error) {
+        } catch (ApiException $error) {
             $this->assertEquals(422, $error->getHttpStatus());
-            $this->assertEquals('PARAMETER.REQUIRED', $error->ecode);
+            $this->assertEquals('PARAMETER.REQUIRED', $error->code);
             $this->assertEquals('Missing required parameter.', $error->getMessage());
             $this->assertEquals(['field' => 'shipment', 'message' => 'cannot be blank'], $error->errors[0]);
             $this->assertEquals('{"error":{"code":"PARAMETER.REQUIRED","message":"Missing required parameter.","errors":[{"field":"shipment","message":"cannot be blank"}]}}', $error->getHttpBody());

--- a/test/EasyPost/EventTest.php
+++ b/test/EasyPost/EventTest.php
@@ -3,7 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
-use EasyPost\Exception\Error;
+use EasyPost\Exception\General\EasyPostException;
 use EasyPost\Util\Util;
 
 class EventTest extends \PHPUnit\Framework\TestCase
@@ -78,7 +78,7 @@ class EventTest extends \PHPUnit\Framework\TestCase
      */
     public function testReceiveBadInput()
     {
-        $this->expectException(Error::class);
+        $this->expectException(EasyPostException::class);
 
         Util::receiveEvent('bad input');
     }
@@ -88,7 +88,7 @@ class EventTest extends \PHPUnit\Framework\TestCase
      */
     public function testReceiveNoInput()
     {
-        $this->expectException(Error::class);
+        $this->expectException(EasyPostException::class);
 
         Util::receiveEvent();
     }

--- a/test/EasyPost/InsuranceTest.php
+++ b/test/EasyPost/InsuranceTest.php
@@ -3,7 +3,6 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
-use EasyPost\Shipment;
 
 class InsuranceTest extends \PHPUnit\Framework\TestCase
 {

--- a/test/EasyPost/OrderTest.php
+++ b/test/EasyPost/OrderTest.php
@@ -3,7 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
-use EasyPost\Exception\Error;
+use EasyPost\Exception\General\FilteringException;
 
 class OrderTest extends \PHPUnit\Framework\TestCase
 {
@@ -138,7 +138,7 @@ class OrderTest extends \PHPUnit\Framework\TestCase
         // Test lowest rate with carrier filter (should error due to bad carrier)
         try {
             $lowestRate = $order->lowestRate(['BAD CARRIER'], []);
-        } catch (Error $error) {
+        } catch (FilteringException $error) {
             $this->assertEquals('No rates found.', $error->getMessage());
         }
     }

--- a/test/EasyPost/PickupTest.php
+++ b/test/EasyPost/PickupTest.php
@@ -3,7 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
-use EasyPost\Exception\Error;
+use EasyPost\Exception\General\FilteringException;
 
 class PickupTest extends \PHPUnit\Framework\TestCase
 {
@@ -144,14 +144,14 @@ class PickupTest extends \PHPUnit\Framework\TestCase
         // Test lowest rate with service filter (should error due to bad service)
         try {
             $lowestRate = $pickup->lowestRate([], ['BAD SERVICE']);
-        } catch (Error $error) {
+        } catch (FilteringException $error) {
             $this->assertEquals('No rates found.', $error->getMessage());
         }
 
         // Test lowest rate with carrier filter (should error due to bad carrier)
         try {
             $lowestRate = $pickup->lowestRate(['BAD CARRIER'], []);
-        } catch (Error $error) {
+        } catch (FilteringException $error) {
             $this->assertEquals('No rates found.', $error->getMessage());
         }
     }

--- a/test/EasyPost/ReportTest.php
+++ b/test/EasyPost/ReportTest.php
@@ -3,6 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
+use EasyPost\Exception\General\MissingParameterException;
 
 class ReportTest extends \PHPUnit\Framework\TestCase
 {
@@ -126,7 +127,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateNoType()
     {
-        $this->expectException(\EasyPost\Exception\Error::class);
+        $this->expectException(MissingParameterException::class);
 
         self::$client->report->create();
     }
@@ -136,7 +137,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
      */
     public function testAllNoType()
     {
-        $this->expectException(\EasyPost\Exception\Error::class);
+        $this->expectException(MissingParameterException::class);
 
         self::$client->report->all();
     }

--- a/test/EasyPost/ShipmentTest.php
+++ b/test/EasyPost/ShipmentTest.php
@@ -3,7 +3,8 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
-use EasyPost\Exception\Error;
+use EasyPost\Exception\General\FilteringException;
+use EasyPost\Exception\General\InvalidParameterException;
 use EasyPost\Util\Util;
 
 class ShipmentTest extends \PHPUnit\Framework\TestCase
@@ -331,7 +332,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
         // Test lowestRate with carrier filter (should error due to bad carrier)
         try {
             $lowestRate = $shipment->lowestRate(['BAD CARRIER'], []);
-        } catch (Error $error) {
+        } catch (FilteringException $error) {
             $this->assertEquals('No rates found.', $error->getMessage());
         }
     }
@@ -378,14 +379,14 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
         // Test lowestSmartRate with invalid filters (should error due to strict delivery_days)
         try {
             self::$client->shipment->lowestSmartRate($shipment->id, 0, 'percentile_85');
-        } catch (Error $error) {
+        } catch (FilteringException $error) {
             $this->assertEquals('No rates found.', $error->getMessage());
         }
 
         // Test lowestSmartRate with invalid filters (should error due to invalid delivery_accuracy)
         try {
             self::$client->shipment->lowestSmartRate($shipment->id, 3, 'BAD_ACCURACY');
-        } catch (Error $error) {
+        } catch (InvalidParameterException $error) {
             $this->assertEquals(
                 'Invalid delivery_accuracy value, must be one of: ["percentile_50","percentile_75","percentile_85","percentile_90","percentile_95","percentile_97","percentile_99"]',
                 $error->getMessage()
@@ -414,22 +415,20 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
         // Test lowestSmartRate with invalid filters (should error due to strict delivery_days)
         try {
             Util::getLowestSmartRate($smartRates, 0, 'percentile_90');
-        } catch (Error $error) {
+        } catch (FilteringException $error) {
             $this->assertEquals('No rates found.', $error->getMessage());
         }
 
         // Test lowestSmartRate with invalid filters (should error due to invalid delivery_accuracy)
         try {
             Util::getLowestSmartRate($smartRates, 3, 'BAD_ACCURACY');
-        } catch (Error $error) {
+        } catch (InvalidParameterException $error) {
             $this->assertEquals('Invalid delivery_accuracy value, must be one of: ["percentile_50","percentile_75","percentile_85","percentile_90","percentile_95","percentile_97","percentile_99"]', $error->getMessage());
         }
     }
 
     /**
      * Tests generating a form for a shipment.
-     *
-     * @throws Error
      */
     public function testGenerateForm()
     {

--- a/test/EasyPost/WebhookTest.php
+++ b/test/EasyPost/WebhookTest.php
@@ -3,7 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
-use EasyPost\Exception\Error;
+use EasyPost\Exception\General\SignatureVerificationException;
 use EasyPost\Util\Util;
 
 class WebhookTest extends \PHPUnit\Framework\TestCase
@@ -148,7 +148,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
 
         try {
             Util::validateWebhook(Fixture::eventBytes(), $headers, $webhookSecret);
-        } catch (Error $error) {
+        } catch (SignatureVerificationException $error) {
             $this->assertEquals('Webhook received did not originate from EasyPost or had a webhook secret mismatch.', $error->getMessage());
         }
     }
@@ -165,7 +165,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
 
         try {
             Util::validateWebhook(Fixture::eventBytes(), $headers, $webhookSecret);
-        } catch (Error $error) {
+        } catch (SignatureVerificationException $error) {
             $this->assertEquals('Webhook received does not contain an HMAC signature.', $error->getMessage());
         }
     }


### PR DESCRIPTION
# Description

Overhauls Exceptions by adding ~2 dozen new exception types. Exceptions from our API will extend `ApiException` (previously EasyPostException) and errors originating directly from the library now extend `EasyPostException` which extends `\Exception`.

I will add the CHANGELOG for these in the next PR which is to package up the release candidate.

Closes #7 

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Updates various test assertions to assure the right tests are being raised.

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
