### PR TITLE
test: add PHP 8.2 to CI to check for segfaults before recent changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        phpversion: ["7.3", "7.4", "8.0", "8.1"]
+        phpversion: ["7.3", "7.4", "8.0", "8.1", "8.2"]
     steps:
       - uses: actions/checkout@v3
       - name: set up php

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "rregeer/phpunit-coverage-check": "^0.3.1"
   },
   "scripts": {
-    "coverage": "XDEBUG_MODE=coverage ./bin/phpunit --coverage-html clover.html --coverage-clover build/logs/clover.xml",
+    "coverage": "XDEBUG_MODE=coverage gdb --args ./bin/phpunit --coverage-html clover.html --coverage-clover build/logs/clover.xml",
     "fix": "./bin/phpcbf",
     "lint": "./bin/phpcs",
     "scan": "composer update --dry-run roave/security-advisories",


### PR DESCRIPTION
Do not merge, test to see if recent changes broke PHP 8.2 on CI or if the segfaults are unrelated to recent changes. Will be closing once CI runs.