### PR TITLE
fix: recursion issues with EasyPostClient, deprecation warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 ## coverage - Runs the test suite and generates a coverage report
 coverage:
 	composer coverage
-	bin/coverage-check build/logs/clover.xml 80 --only-percentage
+	bin/coverage-check build/logs/clover.xml 81 --only-percentage
 
 ## docs - Generate documentation for the library
 docs:

--- a/composer.lock
+++ b/composer.lock
@@ -1750,12 +1750,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "a9271310987d5cd362141476d9fff15c189dc204"
+                "reference": "648a1a2e7bb5d18dfaefe5f93da438127cebc5b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/a9271310987d5cd362141476d9fff15c189dc204",
-                "reference": "a9271310987d5cd362141476d9fff15c189dc204",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/648a1a2e7bb5d18dfaefe5f93da438127cebc5b2",
+                "reference": "648a1a2e7bb5d18dfaefe5f93da438127cebc5b2",
                 "shasum": ""
             },
             "conflict": {
@@ -1875,7 +1875,7 @@
                 "facade/ignition": "<1.16.15|>=2,<2.4.2|>=2.5,<2.5.2",
                 "facturascripts/facturascripts": "<=2022.8",
                 "feehi/cms": "<=2.1.1",
-                "feehi/feehicms": "<=2.0.1.1",
+                "feehi/feehicms": "<=2.1.1",
                 "fenom/fenom": "<=2.12.1",
                 "filegator/filegator": "<7.8",
                 "firebase/php-jwt": "<2",
@@ -2075,6 +2075,7 @@
                 "remdex/livehelperchat": "<3.99",
                 "rmccue/requests": ">=1.6,<1.8",
                 "robrichards/xmlseclibs": "<3.0.4",
+                "roots/soil": "<4.1",
                 "rudloff/alltube": "<3.0.3",
                 "s-cart/core": "<6.9",
                 "s-cart/s-cart": "<6.9",
@@ -2224,6 +2225,7 @@
                 "yiisoft/yii2-gii": "<2.0.4",
                 "yiisoft/yii2-jui": "<2.0.4",
                 "yiisoft/yii2-redis": "<2.0.8",
+                "yikesinc/yikes-inc-easy-mailchimp-extender": "<6.8.6",
                 "yoast-seo-for-typo3/yoast_seo": "<7.2.3",
                 "yourls/yourls": "<=1.8.2",
                 "zendesk/zendesk_api_client_php": "<2.2.11",
@@ -2287,7 +2289,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-13T18:04:19+00:00"
+            "time": "2022-12-16T00:14:52+00:00"
         },
         {
             "name": "rregeer/phpunit-coverage-check",

--- a/lib/EasyPost/EasyPostClient.php
+++ b/lib/EasyPost/EasyPostClient.php
@@ -3,6 +3,7 @@
 namespace EasyPost;
 
 use EasyPost\Constant\Constants;
+use EasyPost\Exception\General\EasyPostException;
 use EasyPost\Exception\General\MissingParameterException;
 use EasyPost\Service\AddressService;
 use EasyPost\Service\BaseService;
@@ -32,26 +33,26 @@ use EasyPost\Service\WebhookService;
  *
  * @package EasyPost
  * @property AddressService $address
- * @property BatchService $batch;
- * @property BillingService $billing;
- * @property CarrierAccountService $carrierAccount;
- * @property CustomsInfoService $customsInfo;
- * @property CustomsItemService $customsItem;
- * @property EndShipperService $endShipper;
- * @property EventService $event;
- * @property InsuranceService $insurance;
- * @property OrderService $order;
- * @property ParcelService $parcel;
- * @property PickupService $pickup;
- * @property RateService $rate;
- * @property ReferralCustomerService $referralCustomer;
- * @property RefundService $refund;
- * @property ReportService $report;
- * @property ScanFormService $scanForm;
- * @property ShipmentService $shipment;
- * @property TrackerService $tracker;
- * @property UserService $user;
- * @property WebhookService $webhook;
+ * @property BatchService $batch
+ * @property BillingService $billing
+ * @property CarrierAccountService $carrierAccount
+ * @property CustomsInfoService $customsInfo
+ * @property CustomsItemService $customsItem
+ * @property EndShipperService $endShipper
+ * @property EventService $event
+ * @property InsuranceService $insurance
+ * @property OrderService $order
+ * @property ParcelService $parcel
+ * @property PickupService $pickup
+ * @property RateService $rate
+ * @property ReferralCustomerService $referralCustomer
+ * @property RefundService $refund
+ * @property ReportService $report
+ * @property ScanFormService $scanForm
+ * @property ShipmentService $shipment
+ * @property TrackerService $tracker
+ * @property UserService $user
+ * @property WebhookService $webhook
  */
 class EasyPostClient extends BaseService
 {
@@ -59,29 +60,6 @@ class EasyPostClient extends BaseService
     private $apiKey;
     private $timeout;
     private $apiBase;
-
-    // Services
-    public $address;
-    public $batch;
-    public $billing;
-    public $carrierAccount;
-    public $customsInfo;
-    public $customsItem;
-    public $endShipper;
-    public $event;
-    public $insurance;
-    public $order;
-    public $parcel;
-    public $pickup;
-    public $rate;
-    public $referralCustomer;
-    public $refund;
-    public $report;
-    public $scanForm;
-    public $shipment;
-    public $tracker;
-    public $user;
-    public $webhook;
 
     /**
      * Constructor for an EasyPostClient.
@@ -97,32 +75,48 @@ class EasyPostClient extends BaseService
         $this->timeout = $timeout;
         $this->apiBase = $apiBase;
 
-        // Services
-        // TODO: Make these all read only when we support PHP >= 8.1
-        $this->address = new AddressService($this);
-        $this->batch = new BatchService($this);
-        $this->billing = new BillingService($this);
-        $this->carrierAccount = new CarrierAccountService($this);
-        $this->customsInfo = new CustomsInfoService($this);
-        $this->customsItem = new CustomsItemService($this);
-        $this->endShipper = new EndShipperService($this);
-        $this->event = new EventService($this);
-        $this->insurance = new InsuranceService($this);
-        $this->order = new OrderService($this);
-        $this->parcel = new ParcelService($this);
-        $this->pickup = new PickupService($this);
-        $this->rate = new RateService($this);
-        $this->referralCustomer = new ReferralCustomerService($this);
-        $this->refund = new RefundService($this);
-        $this->report = new ReportService($this);
-        $this->scanForm = new ScanFormService($this);
-        $this->shipment = new ShipmentService($this);
-        $this->tracker = new TrackerService($this);
-        $this->user = new UserService($this);
-        $this->webhook = new WebhookService($this);
-
         if (!$this->apiKey) {
             throw new MissingParameterException('No API key provided. See https://www.easypost.com/docs for details, or contact ' . Constants::SUPPORT_EMAIL . ' for assistance.');
+        }
+    }
+
+    /**
+     * Get a Service when calling a property of an EasyPostClient.
+     *
+     * @param string $serviceName
+     * @return BaseService
+     * @throws EasyPostException
+     */
+    public function __get($serviceName)
+    {
+        $serviceClassMap = [
+            'address' => AddressService::class,
+            'batch' => BatchService::class,
+            'billing' => BillingService::class,
+            'carrierAccount' => CarrierAccountService::class,
+            'customsInfo' => CustomsInfoService::class,
+            'customsItem' => CustomsItemService::class,
+            'endShipper' => EndShipperService::class,
+            'event' => EventService::class,
+            'insurance' => InsuranceService::class,
+            'order' => OrderService::class,
+            'parcel' => ParcelService::class,
+            'pickup' => PickupService::class,
+            'rate' => RateService::class,
+            'referralCustomer' => ReferralCustomerService::class,
+            'refund' => RefundService::class,
+            'report' => ReportService::class,
+            'scanForm' => ScanFormService::class,
+            'shipment' => ShipmentService::class,
+            'tracker' => TrackerService::class,
+            'user' => UserService::class,
+            'webhook' => WebhookService::class,
+        ];
+
+        if (array_key_exists($serviceName, $serviceClassMap)) {
+            return new $serviceClassMap[$serviceName]($this);
+        } else {
+            throw new EasyPostException(sprintf(Constants::UNDEFINED_PROPERTY_ERROR, 'EasyPostClient', $serviceName));
         }
     }
 

--- a/lib/EasyPost/Exception/Api/ApiException.php
+++ b/lib/EasyPost/Exception/Api/ApiException.php
@@ -25,7 +25,7 @@ class ApiException extends EasyPostException
      * @param int $httpStatus
      * @param string $httpBody
      */
-    public function __construct($message = null, $httpStatus = null, $httpBody = null)
+    public function __construct($message = null, $httpStatus = null, $httpBody = '')
     {
         parent::__construct($message);
         $this->httpStatus = $httpStatus;

--- a/lib/EasyPost/Http/Requestor.php
+++ b/lib/EasyPost/Http/Requestor.php
@@ -51,7 +51,7 @@ class Requestor
     public static function utf8($value)
     {
         if (is_string($value) && mb_detect_encoding($value, 'UTF-8', true) != 'UTF-8') {
-            return utf8_encode($value);
+            return mb_convert_encoding($value, 'UTF-8', 'ISO-8859-1');
         }
 
         return $value;

--- a/test/EasyPost/EasyPostClientTest.php
+++ b/test/EasyPost/EasyPostClientTest.php
@@ -3,6 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
+use EasyPost\Exception\General\EasyPostException;
 use EasyPost\Exception\General\MissingParameterException;
 
 class EasyPostClientTest extends \PHPUnit\Framework\TestCase
@@ -59,6 +60,19 @@ class EasyPostClientTest extends \PHPUnit\Framework\TestCase
             new EasyPostClient(null);
         } catch (MissingParameterException $error) {
             $this->assertEquals('No API key provided. See https://www.easypost.com/docs for details, or contact support@easypost.com for assistance.', $error->getMessage());
+        }
+    }
+
+    /**
+     * Test invalid property (service) called on an EasyPostClient.
+     */
+    public function testInvalidServiceProperty()
+    {
+        try {
+            $client = new EasyPostClient('123');
+            $client->invalidProperty;
+        } catch (EasyPostException $error) {
+            $this->assertEquals('EasyPost Notice: Undefined property of EasyPostClient instance: invalidProperty', $error->getMessage());
         }
     }
 }

--- a/test/EasyPost/Fixture.php
+++ b/test/EasyPost/Fixture.php
@@ -159,7 +159,7 @@ class Fixture
         $eventBytesFilepath = file("$currentDir/examples/official/fixtures/event-body.json");
         $data = $eventBytesFilepath[0];
 
-        return utf8_encode(json_encode(json_decode($data, true)));
+        return mb_convert_encoding(json_encode(json_decode($data, true)), 'UTF-8', mb_list_encodings());
     }
 
     // The credit card details below are for a valid proxy card usable


### PR DESCRIPTION
# Description

Fixes the recursion problems of the EasyPostClient object by only instantiating the service when needed instead of when a client is created and passing those infinitely down. 

Also fixes a few deprecation warnings that were missed previously due to suppressed output.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Dumped an EasyPostClient object to ensure the recursion was fixed, re-recorded a cassette locally to ensure that services/functions still get called as expected
<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
