### PR TITLE
fix: safer class names by using class builtins instead of strings

### DIFF
--- a/lib/EasyPost/Address.php
+++ b/lib/EasyPost/Address.php
@@ -2,8 +2,6 @@
 
 namespace EasyPost;
 
-use EasyPost\EasyPostObject;
-
 /**
  * @package EasyPost
  * @property string $id

--- a/lib/EasyPost/Service/AddressService.php
+++ b/lib/EasyPost/Service/AddressService.php
@@ -10,8 +10,6 @@ use EasyPost\Util\InternalUtil;
  */
 class AddressService extends BaseService
 {
-    private static $modelClass = 'Address';
-
     /**
      * Retrieve an address.
      *
@@ -20,7 +18,7 @@ class AddressService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -31,7 +29,7 @@ class AddressService extends BaseService
      */
     public function all($params = null)
     {
-        return self::allResources(self::$modelClass, $params);
+        return self::allResources(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -58,7 +56,7 @@ class AddressService extends BaseService
 
         $wrappedParams['address'] = $params;
 
-        return self::createResource(self::$modelClass, $wrappedParams);
+        return self::createResource(self::serviceModelClassName(self::class), $wrappedParams);
     }
 
     /**
@@ -75,7 +73,7 @@ class AddressService extends BaseService
             $params['address'] = $clone;
         }
 
-        $url = self::classUrl(self::$modelClass);
+        $url = self::classUrl(self::serviceModelClassName(self::class));
         $response = Requestor::request($this->client, 'post', $url . '/create_and_verify', $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response['address']);
@@ -89,9 +87,9 @@ class AddressService extends BaseService
      */
     public function verify($id)
     {
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/verify';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/verify';
         $response = Requestor::request($this->client, 'get', $url, null);
 
-        return InternalUtil::convertToEasyPostObject($this->client, $response['address'], self::$modelClass);
+        return InternalUtil::convertToEasyPostObject($this->client, $response['address'], self::serviceModelClassName(self::class));
     }
 }

--- a/lib/EasyPost/Service/BaseService.php
+++ b/lib/EasyPost/Service/BaseService.php
@@ -46,6 +46,17 @@ class BaseService
     }
 
     /**
+     * Gets the class name of a Service's model.
+     *
+     * @param string $serviceClassName
+     * @return string
+     */
+    protected static function serviceModelClassName($serviceClassName)
+    {
+        return str_replace('Service', '', $serviceClassName);
+    }
+
+    /**
      * The class URL of an object.
      *
      * @param string $class

--- a/lib/EasyPost/Service/BatchService.php
+++ b/lib/EasyPost/Service/BatchService.php
@@ -10,8 +10,6 @@ use EasyPost\Util\InternalUtil;
  */
 class BatchService extends BaseService
 {
-    private static $modelClass = 'Batch';
-
     /**
      * Retrieve a batch.
      *
@@ -20,7 +18,7 @@ class BatchService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -31,7 +29,7 @@ class BatchService extends BaseService
      */
     public function all($params = null)
     {
-        return self::allResources(self::$modelClass, $params);
+        return self::allResources(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -48,7 +46,7 @@ class BatchService extends BaseService
             $params['batch'] = $clone;
         }
 
-        return self::createResource(self::$modelClass, $params);
+        return self::createResource(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -76,7 +74,7 @@ class BatchService extends BaseService
             ];
         }
 
-        $url = self::classUrl(self::$modelClass);
+        $url = self::classUrl(self::serviceModelClassName(self::class));
         $response = Requestor::request($this->client, 'post', $url . '/create_and_buy', $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
@@ -91,7 +89,7 @@ class BatchService extends BaseService
      */
     public function buy($id, $params = null)
     {
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/buy';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/buy';
         $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
@@ -106,7 +104,7 @@ class BatchService extends BaseService
      */
     public function label($id, $params = null)
     {
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/label';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/label';
         $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
@@ -121,7 +119,7 @@ class BatchService extends BaseService
      */
     public function removeShipments($id, $params = null)
     {
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/remove_shipments';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/remove_shipments';
         $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
@@ -136,7 +134,7 @@ class BatchService extends BaseService
      */
     public function addShipments($id, $params = null)
     {
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/add_shipments';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/add_shipments';
         $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
@@ -151,7 +149,7 @@ class BatchService extends BaseService
      */
     public function createScanForm($id, $params = null)
     {
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/scan_form';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/scan_form';
         $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);

--- a/lib/EasyPost/Service/BillingService.php
+++ b/lib/EasyPost/Service/BillingService.php
@@ -12,6 +12,7 @@ use EasyPost\Util\InternalUtil;
  */
 class BillingService extends BaseService
 {
+    // Overridden here because the logic we need is tied to PaymentMethod
     private static $modelClass = 'PaymentMethod';
 
     /**

--- a/lib/EasyPost/Service/CarrierAccountService.php
+++ b/lib/EasyPost/Service/CarrierAccountService.php
@@ -12,8 +12,6 @@ use EasyPost\Util\InternalUtil;
  */
 class CarrierAccountService extends BaseService
 {
-    private static $modelClass = 'CarrierAccount';
-
     /**
      * Retrieve a carrier account.
      *
@@ -22,7 +20,7 @@ class CarrierAccountService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -33,7 +31,7 @@ class CarrierAccountService extends BaseService
      */
     public function all($params = null)
     {
-        return self::allResources(self::$modelClass, $params);
+        return self::allResources(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -45,7 +43,7 @@ class CarrierAccountService extends BaseService
      */
     public function update($id, $params)
     {
-        return self::updateResource(self::$modelClass, $id, $params);
+        return self::updateResource(self::serviceModelClassName(self::class), $id, $params);
     }
 
     /**
@@ -57,7 +55,7 @@ class CarrierAccountService extends BaseService
      */
     public function delete($id, $params = null)
     {
-        self::deleteResource(self::$modelClass, $id, $params);
+        self::deleteResource(self::serviceModelClassName(self::class), $id, $params);
     }
 
     /**

--- a/lib/EasyPost/Service/CustomsInfoService.php
+++ b/lib/EasyPost/Service/CustomsInfoService.php
@@ -7,8 +7,6 @@ namespace EasyPost\Service;
  */
 class CustomsInfoService extends BaseService
 {
-    private static $modelClass = 'CustomsInfo';
-
     /**
      * Retrieve a customs info.
      *
@@ -17,7 +15,7 @@ class CustomsInfoService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -34,6 +32,6 @@ class CustomsInfoService extends BaseService
             $params['customs_info'] = $clone;
         }
 
-        return self::createResource(self::$modelClass, $params);
+        return self::createResource(self::serviceModelClassName(self::class), $params);
     }
 }

--- a/lib/EasyPost/Service/CustomsItemService.php
+++ b/lib/EasyPost/Service/CustomsItemService.php
@@ -7,8 +7,6 @@ namespace EasyPost\Service;
  */
 class CustomsItemService extends BaseService
 {
-    private static $modelClass = 'CustomsItem';
-
     /**
      * Retrieve a customs item.
      *
@@ -17,7 +15,7 @@ class CustomsItemService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -34,6 +32,6 @@ class CustomsItemService extends BaseService
             $params['customs_item'] = $clone;
         }
 
-        return self::createResource(self::$modelClass, $params);
+        return self::createResource(self::serviceModelClassName(self::class), $params);
     }
 }

--- a/lib/EasyPost/Service/EndShipperService.php
+++ b/lib/EasyPost/Service/EndShipperService.php
@@ -7,8 +7,6 @@ namespace EasyPost\Service;
  */
 class EndShipperService extends BaseService
 {
-    private static $modelClass = 'EndShipper';
-
     /**
      * Create an EndShipper object.
      *
@@ -23,7 +21,7 @@ class EndShipperService extends BaseService
             $params['address'] = $clone;
         }
 
-        return self::createResource(self::$modelClass, $params);
+        return self::createResource(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -34,7 +32,7 @@ class EndShipperService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -45,7 +43,7 @@ class EndShipperService extends BaseService
      */
     public function all($params = null)
     {
-        return self::allResources(self::$modelClass, $params);
+        return self::allResources(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -63,6 +61,6 @@ class EndShipperService extends BaseService
             $params['address'] = $clone;
         }
 
-        return self::updateResource(self::$modelClass, $id, $params, 'put');
+        return self::updateResource(self::serviceModelClassName(self::class), $id, $params, 'put');
     }
 }

--- a/lib/EasyPost/Service/EventService.php
+++ b/lib/EasyPost/Service/EventService.php
@@ -7,8 +7,6 @@ namespace EasyPost\Service;
  */
 class EventService extends BaseService
 {
-    private static $modelClass = 'Event';
-
     /**
      * Retrieve an event.
      *
@@ -17,7 +15,7 @@ class EventService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -28,6 +26,6 @@ class EventService extends BaseService
      */
     public function all($params = null)
     {
-        return self::allResources(self::$modelClass, $params);
+        return self::allResources(self::serviceModelClassName(self::class), $params);
     }
 }

--- a/lib/EasyPost/Service/InsuranceService.php
+++ b/lib/EasyPost/Service/InsuranceService.php
@@ -7,8 +7,6 @@ namespace EasyPost\Service;
  */
 class InsuranceService extends BaseService
 {
-    private static $modelClass = 'Insurance';
-
     /**
      * Retrieve an insurance object.
      *
@@ -17,7 +15,7 @@ class InsuranceService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -28,7 +26,7 @@ class InsuranceService extends BaseService
      */
     public function all($params = null)
     {
-        return self::allResources(self::$modelClass, $params);
+        return self::allResources(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -45,6 +43,6 @@ class InsuranceService extends BaseService
             $params['insurance'] = $clone;
         }
 
-        return self::createResource(self::$modelClass, $params);
+        return self::createResource(self::serviceModelClassName(self::class), $params);
     }
 }

--- a/lib/EasyPost/Service/OrderService.php
+++ b/lib/EasyPost/Service/OrderService.php
@@ -11,8 +11,6 @@ use EasyPost\Util\InternalUtil;
  */
 class OrderService extends BaseService
 {
-    private static $modelClass = 'Order';
-
     /**
      * Retrieve an order.
      *
@@ -21,7 +19,7 @@ class OrderService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -38,7 +36,7 @@ class OrderService extends BaseService
             $params['order'] = $clone;
         }
 
-        return self::createResource(self::$modelClass, $params);
+        return self::createResource(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -50,7 +48,7 @@ class OrderService extends BaseService
      */
     public function getRates($id, $params = null)
     {
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/rates';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/rates';
         $response = Requestor::request($this->client, 'get', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
@@ -72,7 +70,7 @@ class OrderService extends BaseService
             $params['service'] = $clone->service;
         }
 
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/buy';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/buy';
         $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);

--- a/lib/EasyPost/Service/ParcelService.php
+++ b/lib/EasyPost/Service/ParcelService.php
@@ -7,8 +7,6 @@ namespace EasyPost\Service;
  */
 class ParcelService extends BaseService
 {
-    private static $modelClass = 'Parcel';
-
     /**
      * Retrieve a parcel.
      *
@@ -17,7 +15,7 @@ class ParcelService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -34,6 +32,6 @@ class ParcelService extends BaseService
             $params['parcel'] = $clone;
         }
 
-        return self::createResource(self::$modelClass, $params);
+        return self::createResource(self::serviceModelClassName(self::class), $params);
     }
 }

--- a/lib/EasyPost/Service/PickupService.php
+++ b/lib/EasyPost/Service/PickupService.php
@@ -10,8 +10,6 @@ use EasyPost\Util\InternalUtil;
  */
 class PickupService extends BaseService
 {
-    private static $modelClass = 'Pickup';
-
     /**
      * Retrieve a pickup.
      *
@@ -20,7 +18,7 @@ class PickupService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -37,7 +35,7 @@ class PickupService extends BaseService
             $params['pickup'] = $clone;
         }
 
-        return self::createResource(self::$modelClass, $params);
+        return self::createResource(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -49,7 +47,7 @@ class PickupService extends BaseService
      */
     public function buy($id, $params = null)
     {
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/buy';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/buy';
         $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
@@ -64,7 +62,7 @@ class PickupService extends BaseService
      */
     public function cancel($id, $params = null)
     {
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/cancel';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/cancel';
         $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);

--- a/lib/EasyPost/Service/RateService.php
+++ b/lib/EasyPost/Service/RateService.php
@@ -7,8 +7,6 @@ namespace EasyPost\Service;
  */
 class RateService extends BaseService
 {
-    private static $modelClass = 'Rate';
-
     /**
      * Retrieve a rate.
      *
@@ -17,6 +15,6 @@ class RateService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 }

--- a/lib/EasyPost/Service/ReferralCustomerService.php
+++ b/lib/EasyPost/Service/ReferralCustomerService.php
@@ -16,8 +16,6 @@ use GuzzleHttp\Client;
  */
 class ReferralCustomerService extends BaseService
 {
-    private static $modelClass = 'ReferralCustomer';
-
     /**
      * Retrieve all referrals.
      *
@@ -26,7 +24,7 @@ class ReferralCustomerService extends BaseService
      */
     public function all($params = null)
     {
-        return self::allResources(self::$modelClass, $params);
+        return self::allResources(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -43,7 +41,7 @@ class ReferralCustomerService extends BaseService
             $params['user'] = $clone;
         }
 
-        return self::createResource(self::$modelClass, $params);
+        return self::createResource(self::serviceModelClassName(self::class), $params);
     }
 
     /**

--- a/lib/EasyPost/Service/RefundService.php
+++ b/lib/EasyPost/Service/RefundService.php
@@ -7,8 +7,6 @@ namespace EasyPost\Service;
  */
 class RefundService extends BaseService
 {
-    private static $modelClass = 'Refund';
-
     /**
      * Retrieve a refund.
      *
@@ -17,7 +15,7 @@ class RefundService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -28,7 +26,7 @@ class RefundService extends BaseService
      */
     public function all($params = null)
     {
-        return self::allResources(self::$modelClass, $params);
+        return self::allResources(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -45,6 +43,6 @@ class RefundService extends BaseService
             $params['refund'] = $clone;
         }
 
-        return self::createResource(self::$modelClass, $params);
+        return self::createResource(self::serviceModelClassName(self::class), $params);
     }
 }

--- a/lib/EasyPost/Service/ReportService.php
+++ b/lib/EasyPost/Service/ReportService.php
@@ -12,8 +12,6 @@ use EasyPost\Util\InternalUtil;
  */
 class ReportService extends BaseService
 {
-    private static $modelClass = 'Report';
-
     /**
      * Retrieve a report.
      *
@@ -22,7 +20,7 @@ class ReportService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**

--- a/lib/EasyPost/Service/ScanFormService.php
+++ b/lib/EasyPost/Service/ScanFormService.php
@@ -7,8 +7,6 @@ namespace EasyPost\Service;
  */
 class ScanFormService extends BaseService
 {
-    private static $modelClass = 'ScanForm';
-
     /**
      * Retrieve a scanform.
      *
@@ -17,7 +15,7 @@ class ScanFormService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -28,7 +26,7 @@ class ScanFormService extends BaseService
      */
     public function all($params = null)
     {
-        return self::allResources(self::$modelClass, $params);
+        return self::allResources(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -39,6 +37,6 @@ class ScanFormService extends BaseService
      */
     public function create($params = null)
     {
-        return self::createResource(self::$modelClass, $params);
+        return self::createResource(self::serviceModelClassName(self::class), $params);
     }
 }

--- a/lib/EasyPost/Service/ShipmentService.php
+++ b/lib/EasyPost/Service/ShipmentService.php
@@ -11,7 +11,6 @@ use EasyPost\Util\Util;
  */
 class ShipmentService extends BaseService
 {
-    private static $modelClass = 'Shipment';
     /**
      * Retrieve a shipment.
      *
@@ -20,7 +19,7 @@ class ShipmentService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -31,7 +30,7 @@ class ShipmentService extends BaseService
      */
     public function all($params = null)
     {
-        return self::allResources(self::$modelClass, $params);
+        return self::allResources(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -51,7 +50,7 @@ class ShipmentService extends BaseService
 
         $params['carbon_offset'] = $withCarbonOffset;
 
-        return self::createResource(self::$modelClass, $params);
+        return self::createResource(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -64,7 +63,7 @@ class ShipmentService extends BaseService
      */
     public function regenerateRates($id, $params = null, $withCarbonOffset = false)
     {
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/rerate';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/rerate';
         $params['carbon_offset'] = $withCarbonOffset;
         $response = Requestor::request($this->client, 'post', $url, $params);
 
@@ -79,7 +78,7 @@ class ShipmentService extends BaseService
      */
     public function getSmartRates($id)
     {
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/smartrate';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/smartrate';
         $response = Requestor::request($this->client, 'get', $url);
 
         $result = isset($response['result']) ? $response['result'] : [];
@@ -104,7 +103,7 @@ class ShipmentService extends BaseService
             $params['rate'] = $clone;
         }
 
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/buy';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/buy';
         $params['carbon_offset'] = $withCarbonOffset;
 
         if ($endShipperId !== false) {
@@ -125,7 +124,7 @@ class ShipmentService extends BaseService
      */
     public function refund($id, $params = null)
     {
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/refund';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/refund';
         $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
@@ -146,7 +145,7 @@ class ShipmentService extends BaseService
             $params['file_format'] = $clone;
         }
 
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/label';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/label';
         $response = Requestor::request($this->client, 'get', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
@@ -167,7 +166,7 @@ class ShipmentService extends BaseService
             $params['amount'] = $clone;
         }
 
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/insure';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/insure';
         $response = Requestor::request($this->client, 'post', $url, $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
@@ -183,7 +182,7 @@ class ShipmentService extends BaseService
      */
     public function generateForm($id, $formType, $formOptions = null)
     {
-        $url = $this->instanceUrl(self::$modelClass, $id) . '/forms';
+        $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/forms';
         $formOptions['type'] = $formType;
 
         $params['form'] = $formOptions;

--- a/lib/EasyPost/Service/TrackerService.php
+++ b/lib/EasyPost/Service/TrackerService.php
@@ -9,8 +9,6 @@ use EasyPost\Http\Requestor;
  */
 class TrackerService extends BaseService
 {
-    private static $modelClass = 'Tracker';
-
     /**
      * Retrieve a tracker.
      *
@@ -19,7 +17,7 @@ class TrackerService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -30,7 +28,7 @@ class TrackerService extends BaseService
      */
     public function all($params = null)
     {
-        return self::allResources(self::$modelClass, $params);
+        return self::allResources(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -51,7 +49,7 @@ class TrackerService extends BaseService
             $params['tracker'] = $clone;
         }
 
-        return self::createResource(self::$modelClass, $params);
+        return self::createResource(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -68,7 +66,7 @@ class TrackerService extends BaseService
             $params = ['trackers' => $clone];
         }
 
-        $url = self::classUrl(self::$modelClass);
+        $url = self::classUrl(self::serviceModelClassName(self::class));
 
         Requestor::request($this->client, 'post', $url . '/create_list', $params);
     }

--- a/lib/EasyPost/Service/UserService.php
+++ b/lib/EasyPost/Service/UserService.php
@@ -10,8 +10,6 @@ use EasyPost\Util\InternalUtil;
  */
 class UserService extends BaseService
 {
-    private static $modelClass = 'User';
-
     /**
      * Retrieve a user.
      *
@@ -20,7 +18,7 @@ class UserService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -36,7 +34,7 @@ class UserService extends BaseService
             $params['user'] = $clone;
         }
 
-        return $this->updateResource(self::$modelClass, $id, $params);
+        return $this->updateResource(self::serviceModelClassName(self::class), $id, $params);
     }
 
     /**
@@ -53,7 +51,7 @@ class UserService extends BaseService
             $params['user'] = $clone;
         }
 
-        return self::createResource(self::$modelClass, $params);
+        return self::createResource(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -63,7 +61,7 @@ class UserService extends BaseService
      */
     public function retrieveMe()
     {
-        return self::allResources(self::$modelClass);
+        return self::allResources(self::serviceModelClassName(self::class));
     }
 
     /**
@@ -75,7 +73,7 @@ class UserService extends BaseService
      */
     public function delete($id, $params = null)
     {
-        return $this->deleteResource(self::$modelClass, $id, $params);
+        return $this->deleteResource(self::serviceModelClassName(self::class), $id, $params);
     }
 
     /**
@@ -126,7 +124,7 @@ class UserService extends BaseService
      */
     public function updateBrand($id, $params = null)
     {
-        $response = Requestor::request($this->client, 'patch', $this->instanceUrl(self::$modelClass, $id) . '/brand', $params);
+        $response = Requestor::request($this->client, 'patch', $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/brand', $params);
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }

--- a/lib/EasyPost/Service/WebhookService.php
+++ b/lib/EasyPost/Service/WebhookService.php
@@ -7,8 +7,6 @@ namespace EasyPost\Service;
  */
 class WebhookService extends BaseService
 {
-    private static $modelClass = 'Webhook';
-
     /**
      * Retrieve a webhook.
      *
@@ -17,7 +15,7 @@ class WebhookService extends BaseService
      */
     public function retrieve($id)
     {
-        return self::retrieveResource(self::$modelClass, $id);
+        return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
 
     /**
@@ -28,7 +26,7 @@ class WebhookService extends BaseService
      */
     public function all($params = null)
     {
-        return self::allResources(self::$modelClass, $params);
+        return self::allResources(self::serviceModelClassName(self::class), $params);
     }
 
     /**
@@ -40,7 +38,7 @@ class WebhookService extends BaseService
      */
     public function delete($id, $params = null)
     {
-        self::deleteResource(self::$modelClass, $id, $params);
+        self::deleteResource(self::serviceModelClassName(self::class), $id, $params);
     }
 
     /**
@@ -58,7 +56,7 @@ class WebhookService extends BaseService
             $params['webhook'] = $clone;
         }
 
-        return self::updateResource(self::$modelClass, $id, $params);
+        return self::updateResource(self::serviceModelClassName(self::class), $id, $params);
     }
 
     /**
@@ -75,6 +73,6 @@ class WebhookService extends BaseService
             $params['webhook'] = $clone;
         }
 
-        return self::createResource(self::$modelClass, $params);
+        return self::createResource(self::serviceModelClassName(self::class), $params);
     }
 }

--- a/lib/EasyPost/Util/InternalUtil.php
+++ b/lib/EasyPost/Util/InternalUtil.php
@@ -2,9 +2,37 @@
 
 namespace EasyPost\Util;
 
+use EasyPost\Address;
+use EasyPost\ApiKey;
+use EasyPost\Batch;
+use EasyPost\Brand;
+use EasyPost\CarrierAccount;
+use EasyPost\CarrierDetail;
 use EasyPost\Constant\Constants;
+use EasyPost\CustomsInfo;
+use EasyPost\CustomsItem;
 use EasyPost\EasyPostObject;
+use EasyPost\EndShipper;
+use EasyPost\Event;
 use EasyPost\Exception\General\FilteringException;
+use EasyPost\Fee;
+use EasyPost\Insurance;
+use EasyPost\Message;
+use EasyPost\Order;
+use EasyPost\Parcel;
+use EasyPost\Pickup;
+use EasyPost\PickupRate;
+use EasyPost\PostageLabel;
+use EasyPost\Rate;
+use EasyPost\Refund;
+use EasyPost\Report;
+use EasyPost\ScanForm;
+use EasyPost\Shipment;
+use EasyPost\Tracker;
+use EasyPost\TrackingDetail;
+use EasyPost\TrackingLocation;
+use EasyPost\User;
+use EasyPost\Webhook;
 
 abstract class InternalUtil
 {
@@ -44,73 +72,73 @@ abstract class InternalUtil
     public static function convertToEasyPostObject($client, $response, $parent = null, $name = null)
     {
         $objectMapping = [
-            'Address'               => '\EasyPost\Address',
-            'ApiKey'                => '\EasyPost\ApiKey',
-            'Batch'                 => '\EasyPost\Batch',
-            'CarrierAccount'        => '\EasyPost\CarrierAccount',
-            'CarrierDetail'         => '\EasyPost\CarrierDetail',
-            'CustomsInfo'           => '\EasyPost\CustomsInfo',
-            'CustomsItem'           => '\EasyPost\CustomsItem',
-            'EndShipper'            => '\EasyPost\EndShipper',
-            'Event'                 => '\EasyPost\Event',
-            'Fee'                   => '\EasyPost\Fee',
-            'Insurance'             => '\EasyPost\Insurance',
-            'Message'               => '\EasyPost\Message',
-            'Order'                 => '\EasyPost\Order',
-            'Parcel'                => '\EasyPost\Parcel',
-            'PaymentLogReport'      => '\EasyPost\Report',
-            'PaymentMethod'         => '\EasyPost\PaymentMethod',
-            'Pickup'                => '\EasyPost\Pickup',
-            'PickupRate'            => '\EasyPost\PickupRate',
-            'PostageLabel'          => '\EasyPost\PostageLabel',
-            'Rate'                  => '\EasyPost\Rate',
-            'Refund'                => '\EasyPost\Refund',
-            'RefundReport'          => '\EasyPost\Report',
-            'Report'                => '\EasyPost\Report',
-            'ScanForm'              => '\EasyPost\ScanForm',
-            'Shipment'              => '\EasyPost\Shipment',
-            'ShipmentInvoiceReport' => '\EasyPost\Report',
-            'ShipmentReport'        => '\EasyPost\Report',
-            'TaxIdentifier'         => '\EasyPost\TaxIdentifier',
-            'Tracker'               => '\EasyPost\Tracker',
-            'TrackerReport'         => '\EasyPost\Report',
-            'TrackingDetail'        => '\EasyPost\TrackingDetail',
-            'TrackingLocation'      => '\EasyPost\TrackingLocation',
-            'User'                  => '\EasyPost\User',
-            'Verification'          => '\EasyPost\Verification',
-            'VerificationDetails'   => '\EasyPost\VerificationDetails',
-            'Verifictions'          => '\EasyPost\Verifications',
-            'Webhook'               => '\EasyPost\Webhook',
+            'Address'               => Address::class,
+            'ApiKey'                => ApiKey::class,
+            'Batch'                 => Batch::class,
+            'CarrierAccount'        => CarrierAccount::class,
+            'CarrierDetail'         => CarrierDetail::class,
+            'CustomsInfo'           => CustomsInfo::class,
+            'CustomsItem'           => CustomsItem::class,
+            'EndShipper'            => EndShipper::class,
+            'Event'                 => Event::class,
+            'Fee'                   => Fee::class,
+            'Insurance'             => Insurance::class,
+            'Message'               => Message::class,
+            'Order'                 => Order::class,
+            'Parcel'                => Parcel::class,
+            'PaymentLogReport'      => Report::class,
+            'PaymentMethod'         => PaymentMethod::class,
+            'Pickup'                => Pickup::class,
+            'PickupRate'            => PickupRate::class,
+            'PostageLabel'          => PostageLabel::class,
+            'Rate'                  => Rate::class,
+            'Refund'                => Refund::class,
+            'RefundReport'          => Report::class,
+            'Report'                => Report::class,
+            'ScanForm'              => ScanForm::class,
+            'Shipment'              => Shipment::class,
+            'ShipmentInvoiceReport' => Report::class,
+            'ShipmentReport'        => Report::class,
+            'TaxIdentifier'         => TaxIdentifier::class,
+            'Tracker'               => Tracker::class,
+            'TrackerReport'         => Report::class,
+            'TrackingDetail'        => TrackingDetail::class,
+            'TrackingLocation'      => TrackingLocation::class,
+            'User'                  => User::class,
+            'Verification'          => Verification::class,
+            'VerificationDetails'   => VerificationDetails::class,
+            'Verifictions'          => Verifications::class,
+            'Webhook'               => Webhook::class,
         ];
 
         $objectIdPrefixes = [
-            'adr'       => '\EasyPost\Address',
-            'ak'        => '\EasyPost\ApiKey',
-            'batch'     => '\EasyPost\Batch',
-            'brd'       => '\EasyPost\Brand',
-            'ca'        => '\EasyPost\CarrierAccount',
-            'cstinfo'   => '\EasyPost\CustomsInfo',
-            'cstitem'   => '\EasyPost\CustomsItem',
-            'es'        => '\EasyPost\EndShipper',
-            'evt'       => '\EasyPost\Event',
-            'fee'       => '\EasyPost\Fee',
-            'hook'      => '\EasyPost\Webhook',
-            'ins'       => '\EasyPost\Insurance',
-            'order'     => '\EasyPost\Order',
-            'pickup'    => '\EasyPost\Pickup',
-            'pl'        => '\EasyPost\PostageLabel',
-            'plrep'     => '\EasyPost\Report',
-            'prcl'      => '\EasyPost\Parcel',
-            'rate'      => '\EasyPost\Rate',
-            'refrep'    => '\EasyPost\Report',
-            'rfnd'      => '\EasyPost\Refund',
-            'sf'        => '\EasyPost\ScanForm',
-            'shp'       => '\EasyPost\Shipment',
-            'shpinvrep' => '\EasyPost\Report',
-            'shprep'    => '\EasyPost\Report',
-            'trk'       => '\EasyPost\Tracker',
-            'trkrep'    => '\EasyPost\Report',
-            'user'      => '\EasyPost\User',
+            'adr'       => Address::class,
+            'ak'        => ApiKey::class,
+            'batch'     => Batch::class,
+            'brd'       => Brand::class,
+            'ca'        => CarrierAccount::class,
+            'cstinfo'   => CustomsInfo::class,
+            'cstitem'   => CustomsItem::class,
+            'es'        => EndShipper::class,
+            'evt'       => Event::class,
+            'fee'       => Fee::class,
+            'hook'      => Webhook::class,
+            'ins'       => Insurance::class,
+            'order'     => Order::class,
+            'pickup'    => Pickup::class,
+            'pl'        => PostageLabel::class,
+            'plrep'     => Report::class,
+            'prcl'      => Parcel::class,
+            'rate'      => Rate::class,
+            'refrep'    => Report::class,
+            'rfnd'      => Refund::class,
+            'sf'        => ScanForm::class,
+            'shp'       => Shipment::class,
+            'shpinvrep' => Report::class,
+            'shprep'    => Report::class,
+            'trk'       => Tracker::class,
+            'trkrep'    => Report::class,
+            'user'      => User::class,
         ];
 
         if (InternalUtil::isList($response)) {

--- a/test/EasyPost/AddressTest.php
+++ b/test/EasyPost/AddressTest.php
@@ -2,6 +2,7 @@
 
 namespace EasyPost\Test;
 
+use EasyPost\Address;
 use EasyPost\EasyPostClient;
 use EasyPost\Exception\Api\ApiException;
 
@@ -35,7 +36,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
         $address = self::$client->address->create(Fixture::caAddress1());
 
-        $this->assertInstanceOf('\EasyPost\Address', $address);
+        $this->assertInstanceOf(Address::class, $address);
         $this->assertStringMatchesFormat('adr_%s', $address->id);
         $this->assertEquals('388 Townsend St', $address->street1);
     }
@@ -54,7 +55,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
         $address = self::$client->address->create($addressData);
 
-        $this->assertInstanceOf('\EasyPost\Address', $address);
+        $this->assertInstanceOf(Address::class, $address);
         $this->assertStringMatchesFormat('adr_%s', $address->id);
         $this->assertEquals('417 MONTGOMERY ST FL 5', $address->street1);
         $this->assertEquals('Invalid secondary information(Apt/Suite#)', $address->verifications->zip4->errors[0]->message);
@@ -72,7 +73,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
         $address = self::$client->address->create($addressData);
 
-        $this->assertInstanceOf('\EasyPost\Address', $address);
+        $this->assertInstanceOf(Address::class, $address);
         $this->assertStringMatchesFormat('adr_%s', $address->id);
         $this->assertEquals('388 TOWNSEND ST APT 20', $address->street1);
     }
@@ -91,7 +92,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
         $address = self::$client->address->create($addressData);
 
-        $this->assertInstanceOf('\EasyPost\Address', $address);
+        $this->assertInstanceOf(Address::class, $address);
         $this->assertStringMatchesFormat('adr_%s', $address->id);
         $this->assertEquals('417 MONTGOMERY ST FL 5', $address->street1);
         $this->assertEquals('Invalid secondary information(Apt/Suite#)', $address->verifications->zip4->errors[0]->message);
@@ -108,7 +109,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
         $retrievedAddress = self::$client->address->retrieve($address->id);
 
-        $this->assertInstanceOf('\EasyPost\Address', $retrievedAddress);
+        $this->assertInstanceOf(Address::class, $retrievedAddress);
         $this->assertEquals($address, $retrievedAddress);
     }
 
@@ -127,7 +128,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($addressesArray, Fixture::pageSize());
         $this->assertNotNull($addresses['has_more']);
-        $this->assertContainsOnlyInstancesOf('\EasyPost\Address', $addressesArray);
+        $this->assertContainsOnlyInstancesOf(Address::class, $addressesArray);
     }
 
     /**
@@ -143,7 +144,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
         $address = self::$client->address->createAndVerify($addressData);
 
-        $this->assertInstanceOf('\EasyPost\Address', $address);
+        $this->assertInstanceOf(Address::class, $address);
         $this->assertStringMatchesFormat('adr_%s', $address->id);
         $this->assertEquals('417 MONTGOMERY ST FL 5', $address->street1);
     }
@@ -159,7 +160,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
         self::$client->address->verify($address->id);
 
-        $this->assertInstanceOf('\EasyPost\Address', $address);
+        $this->assertInstanceOf(Address::class, $address);
         $this->assertStringMatchesFormat('adr_%s', $address->id);
         $this->assertEquals('388 Townsend St', $address->street1);
     }

--- a/test/EasyPost/BatchTest.php
+++ b/test/EasyPost/BatchTest.php
@@ -2,6 +2,7 @@
 
 namespace EasyPost\Test;
 
+use EasyPost\Batch;
 use EasyPost\EasyPostClient;
 
 class BatchTest extends \PHPUnit\Framework\TestCase
@@ -36,7 +37,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
             'shipments' => [Fixture::basicShipment()],
         ]);
 
-        $this->assertInstanceOf('\EasyPost\Batch', $batch);
+        $this->assertInstanceOf(Batch::class, $batch);
         $this->assertStringMatchesFormat('batch_%s', $batch->id);
         $this->assertNotNull($batch->shipments);
     }
@@ -54,7 +55,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
 
         $retrievedBatch = self::$client->batch->retrieve($batch->id);
 
-        $this->assertInstanceOf('\EasyPost\Batch', $retrievedBatch);
+        $this->assertInstanceOf(Batch::class, $retrievedBatch);
         $this->assertEquals($batch->id, $retrievedBatch->id);
     }
 
@@ -73,7 +74,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($batchesArray, Fixture::pageSize());
         $this->assertNotNull($batches['has_more']);
-        $this->assertContainsOnlyInstancesOf('\EasyPost\Batch', $batchesArray);
+        $this->assertContainsOnlyInstancesOf(Batch::class, $batchesArray);
     }
 
     /**
@@ -88,7 +89,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
             Fixture::oneCallBuyShipment(),
         ]);
 
-        $this->assertInstanceOf('\EasyPost\Batch', $batch);
+        $this->assertInstanceOf(Batch::class, $batch);
         $this->assertStringMatchesFormat('batch_%s', $batch->id);
         $this->assertEquals(2, $batch->num_shipments);
     }
@@ -108,7 +109,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
 
         $boughtBatch = self::$client->batch->buy($batch->id);
 
-        $this->assertInstanceOf('\EasyPost\Batch', $boughtBatch);
+        $this->assertInstanceOf(Batch::class, $boughtBatch);
         $this->assertEquals(1, $boughtBatch->num_shipments);
     }
 
@@ -134,7 +135,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
         $scanformBatch = self::$client->batch->createScanForm($boughtBatch->id);
 
         // We can't assert anything meaningful here because the scanform gets queued for generation and may not be immediately available
-        $this->assertInstanceOf('\EasyPost\Batch', $scanformBatch);
+        $this->assertInstanceOf(Batch::class, $scanformBatch);
     }
 
     /**
@@ -186,6 +187,6 @@ class BatchTest extends \PHPUnit\Framework\TestCase
         );
 
         // We can't assert anything meaningful here because the label gets queued for generation and may not be immediately available
-        $this->assertInstanceOf('\EasyPost\Batch', $labelBatch);
+        $this->assertInstanceOf(Batch::class, $labelBatch);
     }
 }

--- a/test/EasyPost/CarrierAccountTest.php
+++ b/test/EasyPost/CarrierAccountTest.php
@@ -2,6 +2,7 @@
 
 namespace EasyPost\Test;
 
+use EasyPost\CarrierAccount;
 use EasyPost\EasyPostClient;
 use EasyPost\Exception\Api\ApiException;
 use EasyPost\Exception\General\MissingParameterException;
@@ -39,7 +40,7 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
         $carrierAccount = self::$client->carrierAccount->create(Fixture::basicCarrierAccount());
 
         $this->assertEquals('DhlEcsAccount', $carrierAccount->type);
-        $this->assertInstanceOf('\EasyPost\CarrierAccount', $carrierAccount);
+        $this->assertInstanceOf(CarrierAccount::class, $carrierAccount);
         $this->assertStringMatchesFormat('ca_%s', $carrierAccount->id);
 
         self::$client->carrierAccount->delete($carrierAccount->id); // Delete the carrier account once it's done being tested.
@@ -114,7 +115,7 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
 
         $retrievedCarrierAccount = self::$client->carrierAccount->retrieve($carrierAccount->id);
 
-        $this->assertInstanceOf('\EasyPost\CarrierAccount', $retrievedCarrierAccount);
+        $this->assertInstanceOf(CarrierAccount::class, $retrievedCarrierAccount);
         $this->assertEquals($carrierAccount, $retrievedCarrierAccount);
 
         self::$client->carrierAccount->delete($retrievedCarrierAccount->id); // Delete the carrier account once it's done being tested.
@@ -131,7 +132,7 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
 
         $carrierAccounts = self::$client->carrierAccount->all();
 
-        $this->assertContainsOnlyInstancesOf('\EasyPost\CarrierAccount', $carrierAccounts);
+        $this->assertContainsOnlyInstancesOf(CarrierAccount::class, $carrierAccounts);
     }
 
     /**
@@ -150,7 +151,7 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
 
         $updatedCarrierAccount = self::$client->carrierAccount->update($carrierAccount->id, $params);
 
-        $this->assertInstanceOf('\EasyPost\CarrierAccount', $updatedCarrierAccount);
+        $this->assertInstanceOf(CarrierAccount::class, $updatedCarrierAccount);
         $this->assertStringMatchesFormat('ca_%s', $updatedCarrierAccount->id);
         $this->assertEquals($testDescription, $updatedCarrierAccount->description);
 

--- a/test/EasyPost/CustomsInfoTest.php
+++ b/test/EasyPost/CustomsInfoTest.php
@@ -2,6 +2,7 @@
 
 namespace EasyPost\Test;
 
+use EasyPost\CustomsInfo;
 use EasyPost\EasyPostClient;
 
 class CustomsInfoTest extends \PHPUnit\Framework\TestCase
@@ -34,7 +35,7 @@ class CustomsInfoTest extends \PHPUnit\Framework\TestCase
 
         $customsInfo = self::$client->customsInfo->create(Fixture::basicCustomsInfo());
 
-        $this->assertInstanceOf('\EasyPost\CustomsInfo', $customsInfo);
+        $this->assertInstanceOf(CustomsInfo::class, $customsInfo);
         $this->assertStringMatchesFormat('cstinfo_%s', $customsInfo->id);
         $this->assertEquals('NOEEI 30.37(a)', $customsInfo->eel_pfc);
     }
@@ -50,7 +51,7 @@ class CustomsInfoTest extends \PHPUnit\Framework\TestCase
 
         $retrievedCustomsInfo = self::$client->customsInfo->retrieve($customsInfo->id);
 
-        $this->assertInstanceOf('\EasyPost\CustomsInfo', $retrievedCustomsInfo);
+        $this->assertInstanceOf(CustomsInfo::class, $retrievedCustomsInfo);
         $this->assertEquals($customsInfo, $retrievedCustomsInfo);
     }
 }

--- a/test/EasyPost/CustomsItemTest.php
+++ b/test/EasyPost/CustomsItemTest.php
@@ -2,6 +2,7 @@
 
 namespace EasyPost\Test;
 
+use EasyPost\CustomsItem;
 use EasyPost\EasyPostClient;
 
 class CustomsItemTest extends \PHPUnit\Framework\TestCase
@@ -34,7 +35,7 @@ class CustomsItemTest extends \PHPUnit\Framework\TestCase
 
         $customsItem = self::$client->customsItem->create(Fixture::basicCustomsItem());
 
-        $this->assertInstanceOf('\EasyPost\CustomsItem', $customsItem);
+        $this->assertInstanceOf(CustomsItem::class, $customsItem);
         $this->assertStringMatchesFormat('cstitem_%s', $customsItem->id);
         $this->assertEquals('23.25', $customsItem->value);
     }
@@ -50,7 +51,7 @@ class CustomsItemTest extends \PHPUnit\Framework\TestCase
 
         $retrievedCustomsItem = self::$client->customsItem->retrieve($customsItem->id);
 
-        $this->assertInstanceOf('\EasyPost\CustomsItem', $retrievedCustomsItem);
+        $this->assertInstanceOf(CustomsItem::class, $retrievedCustomsItem);
         $this->assertEquals($customsItem, $retrievedCustomsItem);
     }
 }

--- a/test/EasyPost/EndShipperTest.php
+++ b/test/EasyPost/EndShipperTest.php
@@ -3,6 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
+use EasyPost\EndShipper;
 
 class EndShipperTest extends \PHPUnit\Framework\TestCase
 {
@@ -34,7 +35,7 @@ class EndShipperTest extends \PHPUnit\Framework\TestCase
 
         $endShipper = self::$client->endShipper->create(Fixture::caAddress1());
 
-        $this->assertInstanceOf('\EasyPost\EndShipper', $endShipper);
+        $this->assertInstanceOf(EndShipper::class, $endShipper);
         $this->assertStringMatchesFormat('es_%s', $endShipper->id);
         $this->assertEquals('388 TOWNSEND ST APT 20', $endShipper->street1);
     }
@@ -50,7 +51,7 @@ class EndShipperTest extends \PHPUnit\Framework\TestCase
 
         $retrievedEndShipper = self::$client->endShipper->retrieve($endShipper->id);
 
-        $this->assertInstanceOf('\EasyPost\EndShipper', $retrievedEndShipper);
+        $this->assertInstanceOf(EndShipper::class, $retrievedEndShipper);
         $this->assertEquals($endShipper->street1, $retrievedEndShipper->street1);
     }
 
@@ -69,7 +70,7 @@ class EndShipperTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($endShipperArray, Fixture::pageSize());
         $this->assertNotNull($endShippers['has_more']);
-        $this->assertContainsOnlyInstancesOf('\EasyPost\EndShipper', $endShipperArray);
+        $this->assertContainsOnlyInstancesOf(EndShipper::class, $endShipperArray);
     }
 
     /**
@@ -99,7 +100,7 @@ class EndShipperTest extends \PHPUnit\Framework\TestCase
 
         $updatedEndShipper = self::$client->endShipper->update($endShipper->id, $params);
 
-        $this->assertInstanceOf('\EasyPost\EndShipper', $updatedEndShipper);
+        $this->assertInstanceOf(EndShipper::class, $updatedEndShipper);
         $this->assertStringMatchesFormat('es_%s', $updatedEndShipper->id);
         $this->assertEquals($newName, $updatedEndShipper->name);
     }

--- a/test/EasyPost/EventTest.php
+++ b/test/EasyPost/EventTest.php
@@ -3,6 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
+use EasyPost\Event;
 use EasyPost\Exception\General\EasyPostException;
 use EasyPost\Util\Util;
 
@@ -42,7 +43,7 @@ class EventTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($eventsArray, Fixture::pageSize());
         $this->assertNotNull($events['has_more']);
-        $this->assertContainsOnlyInstancesOf('\EasyPost\Event', $eventsArray);
+        $this->assertContainsOnlyInstancesOf(Event::class, $eventsArray);
     }
 
     /**
@@ -58,7 +59,7 @@ class EventTest extends \PHPUnit\Framework\TestCase
 
         $event = self::$client->event->retrieve($events['events'][0]['id']);
 
-        $this->assertInstanceOf('\EasyPost\Event', $event);
+        $this->assertInstanceOf(Event::class, $event);
         $this->assertStringMatchesFormat('evt_%s', $event->id);
     }
 
@@ -69,7 +70,7 @@ class EventTest extends \PHPUnit\Framework\TestCase
     {
         $event = Util::receiveEvent(Fixture::eventJson());
 
-        $this->assertInstanceOf('\EasyPost\Event', $event);
+        $this->assertInstanceOf(Event::class, $event);
         $this->assertStringMatchesFormat('evt_%s', $event->id);
     }
 

--- a/test/EasyPost/InsuranceTest.php
+++ b/test/EasyPost/InsuranceTest.php
@@ -3,6 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
+use EasyPost\Insurance;
 
 class InsuranceTest extends \PHPUnit\Framework\TestCase
 {
@@ -39,7 +40,7 @@ class InsuranceTest extends \PHPUnit\Framework\TestCase
 
         $insurance = self::$client->insurance->create($insuranceData);
 
-        $this->assertInstanceOf('\EasyPost\Insurance', $insurance);
+        $this->assertInstanceOf(Insurance::class, $insurance);
         $this->assertStringMatchesFormat('ins_%s', $insurance->id);
         $this->assertEquals('100.00000', $insurance->amount);
     }
@@ -60,7 +61,7 @@ class InsuranceTest extends \PHPUnit\Framework\TestCase
 
         $retrievedInsurance = self::$client->insurance->retrieve($insurance->id);
 
-        $this->assertInstanceOf('\EasyPost\Insurance', $retrievedInsurance);
+        $this->assertInstanceOf(Insurance::class, $retrievedInsurance);
         $this->assertEquals($insurance, $retrievedInsurance);
     }
 
@@ -79,6 +80,6 @@ class InsuranceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($insuranceArray, Fixture::pageSize());
         $this->assertNotNull($insurance['has_more']);
-        $this->assertContainsOnlyInstancesOf('\EasyPost\Insurance', $insuranceArray);
+        $this->assertContainsOnlyInstancesOf(Insurance::class, $insuranceArray);
     }
 }

--- a/test/EasyPost/OrderTest.php
+++ b/test/EasyPost/OrderTest.php
@@ -4,6 +4,8 @@ namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
 use EasyPost\Exception\General\FilteringException;
+use EasyPost\Order;
+use EasyPost\Rate;
 
 class OrderTest extends \PHPUnit\Framework\TestCase
 {
@@ -35,7 +37,7 @@ class OrderTest extends \PHPUnit\Framework\TestCase
 
         $order = self::$client->order->create(Fixture::basicOrder());
 
-        $this->assertInstanceOf('\EasyPost\Order', $order);
+        $this->assertInstanceOf(Order::class, $order);
         $this->assertStringMatchesFormat('order_%s', $order->id);
         $this->assertNotNull($order->rates);
     }
@@ -51,7 +53,7 @@ class OrderTest extends \PHPUnit\Framework\TestCase
 
         $retrievedOrder = self::$client->order->retrieve($order->id);
 
-        $this->assertInstanceOf('\EasyPost\Order', $retrievedOrder);
+        $this->assertInstanceOf(Order::class, $retrievedOrder);
         $this->assertEquals($order->id, $retrievedOrder->id);
     }
 
@@ -69,7 +71,7 @@ class OrderTest extends \PHPUnit\Framework\TestCase
         $ratesArray = $rates['rates'];
 
         $this->assertIsArray($ratesArray);
-        $this->assertContainsOnlyInstancesOf('\EasyPost\Rate', $ratesArray);
+        $this->assertContainsOnlyInstancesOf(Rate::class, $ratesArray);
     }
 
     /**

--- a/test/EasyPost/ParcelTest.php
+++ b/test/EasyPost/ParcelTest.php
@@ -3,6 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
+use EasyPost\Parcel;
 
 class ParcelTest extends \PHPUnit\Framework\TestCase
 {
@@ -34,7 +35,7 @@ class ParcelTest extends \PHPUnit\Framework\TestCase
 
         $parcel = self::$client->parcel->create(Fixture::basicParcel());
 
-        $this->assertInstanceOf('\EasyPost\Parcel', $parcel);
+        $this->assertInstanceOf(Parcel::class, $parcel);
         $this->assertStringMatchesFormat('prcl_%s', $parcel->id);
         $this->assertEquals(15.4, $parcel->weight);
     }
@@ -50,7 +51,7 @@ class ParcelTest extends \PHPUnit\Framework\TestCase
 
         $retrievedParcel = self::$client->parcel->retrieve($parcel->id);
 
-        $this->assertInstanceOf('\EasyPost\Parcel', $retrievedParcel);
+        $this->assertInstanceOf(Parcel::class, $retrievedParcel);
         $this->assertEquals($parcel, $retrievedParcel);
     }
 }

--- a/test/EasyPost/PickupTest.php
+++ b/test/EasyPost/PickupTest.php
@@ -4,6 +4,7 @@ namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
 use EasyPost\Exception\General\FilteringException;
+use EasyPost\Pickup;
 
 class PickupTest extends \PHPUnit\Framework\TestCase
 {
@@ -40,7 +41,7 @@ class PickupTest extends \PHPUnit\Framework\TestCase
 
         $pickup = self::$client->pickup->create($pickupData);
 
-        $this->assertInstanceOf('\EasyPost\Pickup', $pickup);
+        $this->assertInstanceOf(Pickup::class, $pickup);
         $this->assertStringMatchesFormat('pickup_%s', $pickup->id);
         $this->assertNotNull($pickup->pickup_rates);
     }
@@ -60,7 +61,7 @@ class PickupTest extends \PHPUnit\Framework\TestCase
         $pickup = self::$client->pickup->create($pickupData);
         $retrievedPickup = self::$client->pickup->retrieve($pickup->id);
 
-        $this->assertInstanceOf('\EasyPost\Pickup', $retrievedPickup);
+        $this->assertInstanceOf(Pickup::class, $retrievedPickup);
         $this->assertEquals($pickup, $retrievedPickup);
     }
 
@@ -86,7 +87,7 @@ class PickupTest extends \PHPUnit\Framework\TestCase
             ]
         );
 
-        $this->assertInstanceOf('\EasyPost\Pickup', $boughtPickup);
+        $this->assertInstanceOf(Pickup::class, $boughtPickup);
         $this->assertStringMatchesFormat('pickup_%s', $boughtPickup->id);
         $this->assertNotNull($boughtPickup->confirmation);
         $this->assertEquals('scheduled', $boughtPickup->status);
@@ -116,7 +117,7 @@ class PickupTest extends \PHPUnit\Framework\TestCase
 
         $cancelledPickup = self::$client->pickup->cancel($boughtPickup->id);
 
-        $this->assertInstanceOf('\EasyPost\Pickup', $cancelledPickup);
+        $this->assertInstanceOf(Pickup::class, $cancelledPickup);
         $this->assertStringMatchesFormat('pickup_%s', $cancelledPickup->id);
         $this->assertEquals('canceled', $cancelledPickup->status);
     }

--- a/test/EasyPost/RateTest.php
+++ b/test/EasyPost/RateTest.php
@@ -3,6 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
+use EasyPost\Rate;
 
 class RateTest extends \PHPUnit\Framework\TestCase
 {
@@ -36,7 +37,7 @@ class RateTest extends \PHPUnit\Framework\TestCase
 
         $rate = self::$client->rate->retrieve($shipment->rates[0]['id']);
 
-        $this->assertInstanceOf('\EasyPost\Rate', $rate);
+        $this->assertInstanceOf(Rate::class, $rate);
         $this->assertStringMatchesFormat('rate_%s', $rate->id);
     }
 }

--- a/test/EasyPost/ReferralCustomerTest.php
+++ b/test/EasyPost/ReferralCustomerTest.php
@@ -3,6 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
+use EasyPost\User;
 
 class ReferralCustomerTest extends \PHPUnit\Framework\TestCase
 {
@@ -41,7 +42,7 @@ class ReferralCustomerTest extends \PHPUnit\Framework\TestCase
             'phone' => '8888888888'
         ]);
 
-        $this->assertInstanceOf('\EasyPost\User', $referral);
+        $this->assertInstanceOf(User::class, $referral);
         $this->assertStringMatchesFormat('user_%s', $referral->id);
         $this->assertEquals('Test Referral', $referral->name);
     }
@@ -61,7 +62,7 @@ class ReferralCustomerTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($referralUsersArray, Fixture::pageSize());
         $this->assertNotNull($referralUsers['has_more']);
-        $this->assertContainsOnlyInstancesOf('\EasyPost\User', $referralUsersArray);
+        $this->assertContainsOnlyInstancesOf(User::class, $referralUsersArray);
     }
 
     /**

--- a/test/EasyPost/RefundTest.php
+++ b/test/EasyPost/RefundTest.php
@@ -3,6 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
+use EasyPost\Refund;
 
 class RefundTest extends \PHPUnit\Framework\TestCase
 {
@@ -59,7 +60,7 @@ class RefundTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($refundsArray, Fixture::pageSize());
         $this->assertNotNull($refunds['has_more']);
-        $this->assertContainsOnlyInstancesOf('\EasyPost\Refund', $refundsArray);
+        $this->assertContainsOnlyInstancesOf(Refund::class, $refundsArray);
 
         // Return so other tests can reuse these objects
         return $refunds;
@@ -78,7 +79,7 @@ class RefundTest extends \PHPUnit\Framework\TestCase
 
         $retrievedRefund = self::$client->refund->retrieve($refunds['refunds'][0]->id);
 
-        $this->assertInstanceOf('\EasyPost\Refund', $retrievedRefund);
+        $this->assertInstanceOf(Refund::class, $retrievedRefund);
         $this->assertEquals($refunds['refunds'][0]->id, $retrievedRefund->id);
     }
 }

--- a/test/EasyPost/ReportTest.php
+++ b/test/EasyPost/ReportTest.php
@@ -4,6 +4,7 @@ namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
 use EasyPost\Exception\General\MissingParameterException;
+use EasyPost\Report;
 
 class ReportTest extends \PHPUnit\Framework\TestCase
 {
@@ -39,7 +40,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
             'type' => Fixture::reportType(),
         ]);
 
-        $this->assertInstanceOf('\EasyPost\Report', $report);
+        $this->assertInstanceOf(Report::class, $report);
         $this->assertStringMatchesFormat('shprep_%s', $report->id);
     }
 
@@ -60,7 +61,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         // Reports are queued, so we can't retrieve it immediately.
         // Verifying columns would require parsing the CSV.
         // Verify parameters sent correctly by checking the URL in the cassette.
-        $this->assertInstanceOf('\EasyPost\Report', $report);
+        $this->assertInstanceOf(Report::class, $report);
     }
 
     /**
@@ -80,7 +81,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
         // Reports are queued, so we can't retrieve it immediately.
         // Verifying columns would require parsing the CSV.
         // Verify parameters sent correctly by checking the URL in the cassette.
-        $this->assertInstanceOf('\EasyPost\Report', $report);
+        $this->assertInstanceOf(Report::class, $report);
     }
 
     /**
@@ -98,7 +99,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
 
         $retrievedReport = self::$client->report->retrieve($report->id);
 
-        $this->assertInstanceOf('\EasyPost\Report', $retrievedReport);
+        $this->assertInstanceOf(Report::class, $retrievedReport);
         $this->assertEquals($report->start_date, $retrievedReport->start_date);
         $this->assertEquals($report->end_date, $retrievedReport->end_date);
     }
@@ -119,7 +120,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($reportsArray, Fixture::pageSize());
         $this->assertNotNull($reports['has_more']);
-        $this->assertContainsOnlyInstancesOf('\EasyPost\Report', $reportsArray);
+        $this->assertContainsOnlyInstancesOf(Report::class, $reportsArray);
     }
 
     /**

--- a/test/EasyPost/ScanFormTest.php
+++ b/test/EasyPost/ScanFormTest.php
@@ -3,6 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
+use EasyPost\ScanForm;
 
 class ScanFormTest extends \PHPUnit\Framework\TestCase
 {
@@ -38,7 +39,7 @@ class ScanFormTest extends \PHPUnit\Framework\TestCase
             'shipments' => [$shipment],
         ]);
 
-        $this->assertInstanceOf('\EasyPost\ScanForm', $scanForm);
+        $this->assertInstanceOf(ScanForm::class, $scanForm);
         $this->assertStringMatchesFormat('sf_%s', $scanForm->id);
     }
 
@@ -57,7 +58,7 @@ class ScanFormTest extends \PHPUnit\Framework\TestCase
 
         $retrievedScanform = self::$client->scanForm->retrieve($scanForm->id);
 
-        $this->assertInstanceOf('\EasyPost\ScanForm', $retrievedScanform);
+        $this->assertInstanceOf(ScanForm::class, $retrievedScanform);
         $this->assertEquals($scanForm, $retrievedScanform);
     }
 
@@ -76,6 +77,6 @@ class ScanFormTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($scanformsArray, Fixture::pageSize());
         $this->assertNotNull($scanForms['has_more']);
-        $this->assertContainsOnlyInstancesOf('\EasyPost\ScanForm', $scanformsArray);
+        $this->assertContainsOnlyInstancesOf(ScanForm::class, $scanformsArray);
     }
 }

--- a/test/EasyPost/ShipmentTest.php
+++ b/test/EasyPost/ShipmentTest.php
@@ -5,6 +5,8 @@ namespace EasyPost\Test;
 use EasyPost\EasyPostClient;
 use EasyPost\Exception\General\FilteringException;
 use EasyPost\Exception\General\InvalidParameterException;
+use EasyPost\Rate;
+use EasyPost\Shipment;
 use EasyPost\Util\Util;
 
 class ShipmentTest extends \PHPUnit\Framework\TestCase
@@ -37,7 +39,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
         $shipment = self::$client->shipment->create(Fixture::fullShipment());
 
-        $this->assertInstanceOf('\EasyPost\Shipment', $shipment);
+        $this->assertInstanceOf(Shipment::class, $shipment);
         $this->assertStringMatchesFormat('shp_%s', $shipment->id);
         $this->assertNotNull($shipment->rates);
         $this->assertEquals('PNG', $shipment->options->label_format);
@@ -56,7 +58,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
         $retrievedShipment = self::$client->shipment->retrieve($shipment->id);
 
-        $this->assertInstanceOf('\EasyPost\Shipment', $retrievedShipment);
+        $this->assertInstanceOf(Shipment::class, $retrievedShipment);
         $this->assertEquals($shipment->id, $retrievedShipment->id);
     }
 
@@ -75,7 +77,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($shipmentsArray, Fixture::pageSize());
         $this->assertNotNull($shipments['has_more']);
-        $this->assertContainsOnlyInstancesOf('\EasyPost\Shipment', $shipmentsArray);
+        $this->assertContainsOnlyInstancesOf(Shipment::class, $shipmentsArray);
     }
 
     /**
@@ -124,7 +126,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
         $this->assertIsArray($ratesArray);
         foreach ($ratesArray as $rate) {
-            $this->assertInstanceOf('\EasyPost\Rate', $rate);
+            $this->assertInstanceOf(Rate::class, $rate);
         }
     }
 
@@ -259,7 +261,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
         $shipment = self::$client->shipment->create($shipmentData);
 
-        $this->assertInstanceOf('\EasyPost\Shipment', $shipment);
+        $this->assertInstanceOf(Shipment::class, $shipment);
         $this->assertStringMatchesFormat('shp_%s', $shipment->id);
         $this->assertNotEmpty($shipment->options); // The EasyPost API populates some default values here
         $this->assertEmpty($shipment->customs_info);
@@ -278,7 +280,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
         $shipment = self::$client->shipment->create($shipmentData);
 
-        $this->assertInstanceOf('\EasyPost\Shipment', $shipment);
+        $this->assertInstanceOf(Shipment::class, $shipment);
         $this->assertStringMatchesFormat('shp_%s', $shipment->id);
         $this->assertEquals('IOSS', $shipment->tax_identifiers[0]['tax_id_type']);
     }
@@ -300,7 +302,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
             'parcel' => ['id' => $parcel->id],
         ]);
 
-        $this->assertInstanceOf('\EasyPost\Shipment', $shipment);
+        $this->assertInstanceOf(Shipment::class, $shipment);
         $this->assertStringMatchesFormat('shp_%s', $shipment->id);
         $this->assertStringMatchesFormat('adr_%s', $shipment->from_address->id);
         $this->assertStringMatchesFormat('adr_%s', $shipment->to_address->id);
@@ -460,7 +462,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
         $shipment = self::$client->shipment->create(Fixture::basicShipment(), true);
 
-        $this->assertInstanceOf('\EasyPost\Shipment', $shipment);
+        $this->assertInstanceOf(Shipment::class, $shipment);
 
         foreach ($shipment->rates as $rate) {
             $this->assertNotNull($rate->carbon_offset);
@@ -482,7 +484,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
             true,
         );
 
-        $this->assertInstanceOf('\EasyPost\Shipment', $boughtShipment);
+        $this->assertInstanceOf(Shipment::class, $boughtShipment);
 
         $foundCarbonOffset = false;
 
@@ -504,7 +506,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
         $shipment = self::$client->shipment->create(Fixture::oneCallBuyShipment(), true);
 
-        $this->assertInstanceOf('\EasyPost\Shipment', $shipment);
+        $this->assertInstanceOf(Shipment::class, $shipment);
 
         foreach ($shipment->rates as $rate) {
             $this->assertNotNull($rate->carbon_offset);

--- a/test/EasyPost/TrackerTest.php
+++ b/test/EasyPost/TrackerTest.php
@@ -3,6 +3,7 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
+use EasyPost\Tracker;
 
 class TrackerTest extends \PHPUnit\Framework\TestCase
 {
@@ -36,7 +37,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
             'tracking_code' => 'EZ1000000001',
         ]);
 
-        $this->assertInstanceOf('\EasyPost\Tracker', $tracker);
+        $this->assertInstanceOf(Tracker::class, $tracker);
         $this->assertStringMatchesFormat('trk_%s', $tracker->id);
         $this->assertEquals('pre_transit', $tracker->status);
     }
@@ -50,7 +51,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
 
         $tracker = self::$client->tracker->create('EZ1000000001');
 
-        $this->assertInstanceOf('\EasyPost\Tracker', $tracker);
+        $this->assertInstanceOf(Tracker::class, $tracker);
         $this->assertStringMatchesFormat('trk_%s', $tracker->id);
         $this->assertEquals('pre_transit', $tracker->status);
     }
@@ -69,7 +70,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
         // Test trackers cycle through their "dummy" statuses automatically, the created and retrieved objects may differ
         $retrievedTracker = self::$client->tracker->retrieve($tracker->id);
 
-        $this->assertInstanceOf('\EasyPost\Tracker', $retrievedTracker);
+        $this->assertInstanceOf(Tracker::class, $retrievedTracker);
         $this->assertEquals($tracker->id, $retrievedTracker->id);
     }
 
@@ -88,7 +89,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
 
         $this->assertLessThanOrEqual($trackersArray, Fixture::pageSize());
         $this->assertNotNull($trackers['has_more']);
-        $this->assertContainsOnlyInstancesOf('\EasyPost\Tracker', $trackersArray);
+        $this->assertContainsOnlyInstancesOf(Tracker::class, $trackersArray);
     }
 
     /**

--- a/test/EasyPost/UserTest.php
+++ b/test/EasyPost/UserTest.php
@@ -2,7 +2,9 @@
 
 namespace EasyPost\Test;
 
+use EasyPost\ApiKey;
 use EasyPost\EasyPostClient;
+use EasyPost\User;
 
 class UserTest extends \PHPUnit\Framework\TestCase
 {
@@ -36,7 +38,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
             'name' => 'Test User',
         ]);
 
-        $this->assertInstanceOf('\EasyPost\User', $user);
+        $this->assertInstanceOf(User::class, $user);
         $this->assertStringMatchesFormat('user_%s', $user->id);
         $this->assertEquals('Test User', $user->name);
 
@@ -54,7 +56,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
         $user = self::$client->user->retrieve($authenticatedUser->id);
 
-        $this->assertInstanceOf('\EasyPost\User', $user);
+        $this->assertInstanceOf(User::class, $user);
         $this->assertStringMatchesFormat('user_%s', $user->id);
     }
 
@@ -67,7 +69,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
         $user = self::$client->user->retrieveMe();
 
-        $this->assertInstanceOf('\EasyPost\User', $user);
+        $this->assertInstanceOf(User::class, $user);
         $this->assertStringMatchesFormat('user_%s', $user->id);
     }
 
@@ -86,7 +88,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
         $updatedUser = self::$client->user->update($user->id, $params);
 
-        $this->assertInstanceOf('\EasyPost\User', $updatedUser);
+        $this->assertInstanceOf(User::class, $updatedUser);
         $this->assertStringMatchesFormat('user_%s', $updatedUser->id);
         $this->assertEquals($testName, $updatedUser->name);
     }
@@ -119,9 +121,9 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
         $apiKeys = self::$client->user->allApiKeys();
 
-        $this->assertContainsOnlyInstancesOf('\EasyPost\ApiKey', $apiKeys['keys']);
+        $this->assertContainsOnlyInstancesOf(ApiKey::class, $apiKeys['keys']);
         foreach ($apiKeys['children'] as $child) {
-            $this->assertContainsOnlyInstancesOf('\EasyPost\ApiKey', $child['keys']);
+            $this->assertContainsOnlyInstancesOf(ApiKey::class, $child['keys']);
         }
     }
 
@@ -136,7 +138,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
         $apiKeys = self::$client->user->apiKeys($user->id);
 
-        $this->assertContainsOnlyInstancesOf('\EasyPost\ApiKey', $apiKeys);
+        $this->assertContainsOnlyInstancesOf(ApiKey::class, $apiKeys);
     }
 
     /**
@@ -153,7 +155,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
         $apiKeys = self::$client->user->apiKeys($childUser->id);
 
-        $this->assertContainsOnlyInstancesOf('\EasyPost\ApiKey', $apiKeys);
+        $this->assertContainsOnlyInstancesOf(ApiKey::class, $apiKeys);
 
         self::$client->user->delete($childUser->id); // Delete the user once done so we don't pollute with hundreds of child users
     }

--- a/test/EasyPost/WebhookTest.php
+++ b/test/EasyPost/WebhookTest.php
@@ -5,6 +5,7 @@ namespace EasyPost\Test;
 use EasyPost\EasyPostClient;
 use EasyPost\Exception\General\SignatureVerificationException;
 use EasyPost\Util\Util;
+use EasyPost\Webhook;
 
 class WebhookTest extends \PHPUnit\Framework\TestCase
 {
@@ -38,7 +39,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
             'url' => Fixture::webhookUrl(),
         ]);
 
-        $this->assertInstanceOf('\EasyPost\Webhook', $webhook);
+        $this->assertInstanceOf(Webhook::class, $webhook);
         $this->assertStringMatchesFormat('hook_%s', $webhook->id);
         $this->assertEquals(Fixture::webhookUrl(), $webhook->url);
 
@@ -58,7 +59,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
 
         $retrievedWebhook = self::$client->webhook->retrieve($webhook->id);
 
-        $this->assertInstanceOf('\EasyPost\Webhook', $retrievedWebhook);
+        $this->assertInstanceOf(Webhook::class, $retrievedWebhook);
         $this->assertEquals($webhook, $retrievedWebhook);
 
         self::$client->webhook->delete($retrievedWebhook->id); // We are deleting the webhook here so we don't keep sending events to a dead webhook.
@@ -78,7 +79,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         $webhookArray = $webhooks['webhooks'];
 
         $this->assertLessThanOrEqual($webhookArray, Fixture::pageSize());
-        $this->assertContainsOnlyInstancesOf('\EasyPost\Webhook', $webhookArray);
+        $this->assertContainsOnlyInstancesOf(Webhook::class, $webhookArray);
     }
 
     /**
@@ -95,7 +96,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         $updatedWebhook = self::$client->webhook->update($webhook->id);
 
         // The response here won't differ since we don't update any data, just check we get the object back
-        $this->assertInstanceOf('\EasyPost\Webhook', $updatedWebhook);
+        $this->assertInstanceOf(Webhook::class, $updatedWebhook);
 
         self::$client->webhook->delete($webhook->id); // We are deleting the webhook here so we don't keep sending events to a dead webhook.
     }


### PR DESCRIPTION
# Description

After staring at this code for awhile, I realized that we should be using builtin class selectors instead of loose strings. This provides a much safer binding between services, tests, and models. It also helps IDE's know what in the world the class points to.
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Tests pass with changes
<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
