### PR TITLE
fix: cleanup convertToEasyPostObject

### DIFF
--- a/lib/EasyPost/EasyPostObject.php
+++ b/lib/EasyPost/EasyPostObject.php
@@ -143,7 +143,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
     public function convertEach($client, $values)
     {
         foreach ($values as $k => $v) {
-            $this->_values[$k] = InternalUtil::convertToEasyPostObject($client, $v, $this, $k);
+            $this->_values[$k] = InternalUtil::convertToEasyPostObject($client, $v);
         }
     }
 

--- a/lib/EasyPost/Service/AddressService.php
+++ b/lib/EasyPost/Service/AddressService.php
@@ -90,6 +90,6 @@ class AddressService extends BaseService
         $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/verify';
         $response = Requestor::request($this->client, 'get', $url, null);
 
-        return InternalUtil::convertToEasyPostObject($this->client, $response['address'], self::serviceModelClassName(self::class));
+        return InternalUtil::convertToEasyPostObject($this->client, $response['address']);
     }
 }

--- a/lib/EasyPost/Util/InternalUtil.php
+++ b/lib/EasyPost/Util/InternalUtil.php
@@ -65,11 +65,9 @@ abstract class InternalUtil
      *
      * @param EasyPostClient $client
      * @param mixed $response
-     * @param string $parent
-     * @param string $name
      * @return mixed
      */
-    public static function convertToEasyPostObject($client, $response, $parent = null, $name = null)
+    public static function convertToEasyPostObject($client, $response)
     {
         $objectMapping = [
             'Address'               => Address::class,
@@ -147,7 +145,7 @@ abstract class InternalUtil
                 if (is_string($object) && isset($objectMapping[$object])) {
                     $value['object'] = $object;
                 }
-                array_push($mapped, self::convertToEasyPostObject($client, $value, $parent, $name));
+                array_push($mapped, self::convertToEasyPostObject($client, $value));
             }
 
             return $mapped;


### PR DESCRIPTION
# Description

During a team convo about how we deserialize objects, I found there was still some leftover dead code from the rewrite that can safely be removed to simplify this function. These params are no longer used

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- Tests pass
<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
