### PR TITLE
fix: object mapping, required return types of PHP magic functions

### DIFF
--- a/lib/EasyPost/EasyPostObject.php
+++ b/lib/EasyPost/EasyPostObject.php
@@ -152,9 +152,9 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @param string $k
      * @param mixed $v
-     * @return void
      */
-    public function offsetSet($k, $v): void
+    #[\ReturnTypeWillChange]
+    public function offsetSet($k, $v)
     {
         $this->$k = $v;
     }
@@ -165,7 +165,8 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      * @param string $k
      * @return bool
      */
-    public function offsetExists($k): bool
+    #[\ReturnTypeWillChange]
+    public function offsetExists($k)
     {
         return array_key_exists($k, $this->_values);
     }
@@ -174,9 +175,9 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      * ArrayAccess methods.
      *
      * @param string $k
-     * @return void
      */
-    public function offsetUnset($k): void
+    #[\ReturnTypeWillChange]
+    public function offsetUnset($k)
     {
         unset($this->$k);
     }
@@ -187,7 +188,8 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      * @param string $k
      * @return mixed
      */
-    public function offsetGet($k): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k)
     {
         return array_key_exists($k, $this->_values) ? $this->_values[$k] : null;
     }
@@ -197,7 +199,8 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return void
      */
-    public function rewind(): void
+    #[\ReturnTypeWillChange]
+    public function rewind()
     {
         reset($this->_values);
     }
@@ -207,7 +210,8 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return current($this->_values);
     }
@@ -217,7 +221,8 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return mixed
      */
-    public function key(): mixed
+    #[\ReturnTypeWillChange]
+    public function key()
     {
         return key($this->_values);
     }
@@ -225,9 +230,10 @@ class EasyPostObject implements \ArrayAccess, \Iterator
     /**
      * Iterator methods.
      *
-     * @return void
+     * @return mixed
      */
-    public function next(): void
+    #[\ReturnTypeWillChange]
+    public function next()
     {
         return next($this->_values);
     }
@@ -237,7 +243,8 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return bool
      */
-    public function valid(): bool
+    #[\ReturnTypeWillChange]
+    public function valid()
     {
         $key = key($this->_values);
         return ($key !== null && $key !== false);

--- a/lib/EasyPost/EasyPostObject.php
+++ b/lib/EasyPost/EasyPostObject.php
@@ -152,9 +152,9 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @param string $k
      * @param mixed $v
+     * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($k, $v)
+    public function offsetSet($k, $v): void
     {
         $this->$k = $v;
     }
@@ -165,8 +165,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      * @param string $k
      * @return bool
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($k)
+    public function offsetExists($k): bool
     {
         return array_key_exists($k, $this->_values);
     }
@@ -175,9 +174,9 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      * ArrayAccess methods.
      *
      * @param string $k
+     * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($k)
+    public function offsetUnset($k): void
     {
         unset($this->$k);
     }
@@ -188,8 +187,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      * @param string $k
      * @return mixed
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($k)
+    public function offsetGet($k): mixed
     {
         return array_key_exists($k, $this->_values) ? $this->_values[$k] : null;
     }
@@ -199,8 +197,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->_values);
     }
@@ -210,8 +207,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return mixed
      */
-    #[\ReturnTypeWillChange]
-    public function current()
+    public function current(): mixed
     {
         return current($this->_values);
     }
@@ -221,8 +217,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return mixed
      */
-    #[\ReturnTypeWillChange]
-    public function key()
+    public function key(): mixed
     {
         return key($this->_values);
     }
@@ -230,10 +225,9 @@ class EasyPostObject implements \ArrayAccess, \Iterator
     /**
      * Iterator methods.
      *
-     * @return mixed
+     * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function next()
+    public function next(): void
     {
         return next($this->_values);
     }
@@ -243,8 +237,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         $key = key($this->_values);
         return ($key !== null && $key !== false);

--- a/lib/EasyPost/Util/InternalUtil.php
+++ b/lib/EasyPost/Util/InternalUtil.php
@@ -17,7 +17,6 @@ use EasyPost\Event;
 use EasyPost\Exception\General\FilteringException;
 use EasyPost\Fee;
 use EasyPost\Insurance;
-use EasyPost\Message;
 use EasyPost\Order;
 use EasyPost\Parcel;
 use EasyPost\Pickup;
@@ -38,6 +37,7 @@ const OBJECT_MAPPING = [
     'Address'               => Address::class,
     'ApiKey'                => ApiKey::class,
     'Batch'                 => Batch::class,
+    'Brand'                 => Brand::class,
     'CarrierAccount'        => CarrierAccount::class,
     'CarrierDetail'         => CarrierDetail::class,
     'CustomsInfo'           => CustomsInfo::class,
@@ -46,11 +46,9 @@ const OBJECT_MAPPING = [
     'Event'                 => Event::class,
     'Fee'                   => Fee::class,
     'Insurance'             => Insurance::class,
-    'Message'               => Message::class,
     'Order'                 => Order::class,
     'Parcel'                => Parcel::class,
     'PaymentLogReport'      => Report::class,
-    'PaymentMethod'         => PaymentMethod::class,
     'Pickup'                => Pickup::class,
     'PickupRate'            => PickupRate::class,
     'PostageLabel'          => PostageLabel::class,
@@ -68,9 +66,6 @@ const OBJECT_MAPPING = [
     'TrackingDetail'        => TrackingDetail::class,
     'TrackingLocation'      => TrackingLocation::class,
     'User'                  => User::class,
-    'Verification'          => Verification::class,
-    'VerificationDetails'   => VerificationDetails::class,
-    'Verifictions'          => Verifications::class,
     'Webhook'               => Webhook::class,
 ];
 


### PR DESCRIPTION
# Description

The object mapping list was missing `Brand` and had a few extra items in the list that never come back in an `object` field via a response. Although they are local classes in this lib, the constant list they were a part of is to lookup a value based on what we get back from the API, which in these cases would never happen. Removed to tighten up the possible options.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- Tests pass

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
