### PR TITLE
fix: event type param, payload test sleep

### DIFF
--- a/lib/EasyPost/Service/ReportService.php
+++ b/lib/EasyPost/Service/ReportService.php
@@ -38,6 +38,7 @@ class ReportService extends BaseService
             $type = $params['type'];
             self::validate($params);
             $url = self::reportUrl($type);
+            unset($params['type']);
             $response = Requestor::request($this->client, 'get', $url, $params);
 
             return InternalUtil::convertToEasyPostObject($this->client, $response);
@@ -86,6 +87,6 @@ class ReportService extends BaseService
         $type = str_replace('_report', '', $type);
         $name = urlencode($type);
 
-        return "/reports/{$name}/";
+        return "/reports/{$name}";
     }
 }

--- a/test/EasyPost/EventTest.php
+++ b/test/EasyPost/EventTest.php
@@ -100,10 +100,10 @@ class EventTest extends \PHPUnit\Framework\TestCase
      */
     public function testRetrieveAllPayloads()
     {
-        $cassetteName = 'batches/retrieve_all_payloads.yml';
+        $cassetteName = 'events/retrieve_all_payloads.yml';
         $testRequiresWait = true ? file_exists(dirname(__DIR__, 1) . "/cassettes/$cassetteName") === false : false;
 
-        TestUtil::setupCassette('events/retrieve_all_payloads.yml');
+        TestUtil::setupCassette($cassetteName);
 
         // Create a webhook to receive the event.
         $webhook = self::$client->webhook->create([
@@ -140,10 +140,10 @@ class EventTest extends \PHPUnit\Framework\TestCase
      */
     public function testRetrievePayload()
     {
-        $cassetteName = 'batches/retrieve_all_payloads.yml';
+        $cassetteName = 'events/retrieve_payload.yml';
         $testRequiresWait = true ? file_exists(dirname(__DIR__, 1) . "/cassettes/$cassetteName") === false : false;
 
-        TestUtil::setupCassette('events/retrieve_payload.yml');
+        TestUtil::setupCassette($cassetteName);
 
         // Create a webhook to receive the event.
         $webhook = self::$client->webhook->create([
@@ -166,10 +166,10 @@ class EventTest extends \PHPUnit\Framework\TestCase
 
         // Payload does not exist due to queueing, so this will throw en exception.
         try {
-             self::$client->event->retrievePayload(
-                 $event->id,
-                 'payload_11111111111111111111111111111111',
-             );
+            self::$client->event->retrievePayload(
+                $event->id,
+                'payload_11111111111111111111111111111111',
+            );
         } catch (EasyPostException $error) {
             $this->assertEquals(404, $error->getHttpStatus());
         }

--- a/test/cassettes/events/retrieve_all_payloads.yml
+++ b/test/cassettes/events/retrieve_all_payloads.yml
@@ -24,58 +24,60 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 1604568363c1c841e7995cc0000e1e4c
+            x-ep-request-uuid: d6e2ffc663ee9a40e788f709000cb2c0
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '161'
-            etag: 'W/"ebf7172a6ecce4cac02cf2c87d0873ac"'
-            x-runtime: '0.154199'
-            x-node: bigweb5nuq
-            x-version-label: easypost-202301131832-957dabd382-master
+            etag: 'W/"87b68addf45e9333a00af88a51328f4b"'
+            x-runtime: '0.156331'
+            x-node: bigweb7nuq
+            x-version-label: easypost-202302162055-7880f76dd6-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 29913d444b', 'extlb1nuq 29913d444b']
+            x-canary: direct
+            x-proxied: ['intlb2nuq a40ea751fd', 'extlb1nuq a40ea751fd']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"hook_66e9c630938611ed830415bd454a0c89","object":"Webhook","mode":"test","url":"http:\/\/example.com","created_at":"2023-01-13T21:08:18Z","disabled_at":null}'
+        body: '{"id":"hook_6f934636ae3d11eda2af43b1204ad17b","object":"Webhook","mode":"test","url":"http:\/\/example.com","created_at":"2023-02-16T21:04:01Z","disabled_at":null}'
         curl_info:
             url: 'https://api.easypost.com/v2/webhooks'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 736
-            request_size: 349
+            header_size: 754
+            request_size: 348
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.55275
-            namelookup_time: 0.006802
-            connect_time: 0.20609
-            pretransfer_time: 0.306029
+            total_time: 0.506434
+            namelookup_time: 0.001299
+            connect_time: 0.206432
+            pretransfer_time: 0.281948
             size_upload: 42.0
             size_download: 161.0
-            speed_download: 291.0
-            speed_upload: 75.0
+            speed_download: 317.0
+            speed_upload: 82.0
             download_content_length: 161.0
             upload_content_length: 42.0
-            starttransfer_time: 0.552567
+            starttransfer_time: 0.50638
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.15
-            local_port: 61507
+            local_ip: 10.130.6.31
+            local_port: 54874
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 512023
-            connect_time_us: 206090
-            namelookup_time_us: 6802
-            pretransfer_time_us: 306029
+            appconnect_time_us: 488294
+            connect_time_us: 206432
+            namelookup_time_us: 1299
+            pretransfer_time_us: 281948
             redirect_time_us: 0
-            starttransfer_time_us: 552567
-            total_time_us: 552750
+            starttransfer_time_us: 506380
+            total_time_us: 506434
+    index: 0
 -
     request:
         method: POST
@@ -101,58 +103,59 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 1604568263c1c842e7995cc1000e1e83
+            x-ep-request-uuid: d6e2ffc863ee9a41e788f70a000cb300
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '384'
-            etag: 'W/"e47823c3961bb7bbdbcd4215fc2a64df"'
-            x-runtime: '0.108305'
-            x-node: bigweb1nuq
-            x-version-label: easypost-202301131832-957dabd382-master
+            etag: 'W/"dce2de891a3c900f7fd0c3efcdb786ac"'
+            x-runtime: '0.038607'
+            x-node: bigweb4nuq
+            x-version-label: easypost-202302161858-5b15c0a595-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 29913d444b', 'extlb1nuq 29913d444b']
+            x-proxied: ['intlb1nuq a40ea751fd', 'extlb1nuq a40ea751fd']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"batch_756a82b02b874ee496985b95d5d8b8be","object":"Batch","mode":"test","state":"creating","num_shipments":1,"reference":null,"created_at":"2023-01-13T21:08:18Z","updated_at":"2023-01-13T21:08:18Z","scan_form":null,"shipments":[],"status":{"created":0,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":0,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
+        body: '{"id":"batch_c63ce55a7d45411b8f6691663dc6cbc3","object":"Batch","mode":"test","state":"creating","num_shipments":1,"reference":null,"created_at":"2023-02-16T21:04:01Z","updated_at":"2023-02-16T21:04:01Z","scan_form":null,"shipments":[],"status":{"created":0,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":0,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
         curl_info:
             url: 'https://api.easypost.com/v2/batches'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 731
-            request_size: 779
+            request_size: 778
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.494716
-            namelookup_time: 0.001224
-            connect_time: 0.204894
-            pretransfer_time: 0.295222
+            total_time: 0.40403
+            namelookup_time: 0.003743
+            connect_time: 0.208181
+            pretransfer_time: 0.294423
             size_upload: 472.0
             size_download: 384.0
-            speed_download: 776.0
-            speed_upload: 954.0
+            speed_download: 950.0
+            speed_upload: 1168.0
             download_content_length: 384.0
             upload_content_length: 472.0
-            starttransfer_time: 0.494683
+            starttransfer_time: 0.403974
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.15
-            local_port: 61508
+            local_ip: 10.130.6.31
+            local_port: 54875
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 500074
-            connect_time_us: 204894
-            namelookup_time_us: 1224
-            pretransfer_time_us: 295222
+            appconnect_time_us: 502560
+            connect_time_us: 208181
+            namelookup_time_us: 3743
+            pretransfer_time_us: 294423
             redirect_time_us: 0
-            starttransfer_time_us: 494683
-            total_time_us: 494716
+            starttransfer_time_us: 403974
+            total_time_us: 404030
+    index: 0
 -
     request:
         method: GET
@@ -176,63 +179,63 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 1604567f63c1c848e7995cc2000e1ff9
+            x-ep-request-uuid: d6e2ffc763ee9a46e788f70c000cb51f
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
-            content-length: '1114'
-            etag: 'W/"d33db64aa12039812203e31a1ed26a22"'
-            x-runtime: '0.203418'
-            x-node: bigweb7nuq
-            x-version-label: easypost-202301131832-957dabd382-master
+            content-length: '1107'
+            etag: 'W/"518d99f46ed2e6f522d066781880da85"'
+            x-runtime: '0.239130'
+            x-node: bigweb12nuq
+            x-version-label: easypost-202302161858-5b15c0a595-master
             x-backend: easypost
-            x-canary: direct
-            x-proxied: ['intlb1nuq 29913d444b', 'extlb1nuq 29913d444b']
+            x-proxied: ['intlb2nuq a40ea751fd', 'extlb1nuq a40ea751fd']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"events":[{"description":"batch.updated","id":"evt_676fa688938611ed8211671d54df5040","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"pending","created_at":"2023-01-13T21:08:18.862Z","mode":"test","object":"Event"},{"description":"batch.created","id":"evt_674f9c94938611ed9fb503330901e8e4","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"pending","created_at":"2023-01-13T21:08:18.652Z","mode":"test","object":"Event"},{"description":"batch.updated","id":"evt_46274634938611ed844b23b72c6364fc","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"completed","created_at":"2023-01-13T21:07:23.023Z","mode":"test","object":"Event"},{"description":"batch.created","id":"evt_46174946938611ed93d67f9fc0424099","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"completed","created_at":"2023-01-13T21:07:22.918Z","mode":"test","object":"Event"},{"description":"batch.updated","id":"evt_677cb7ca938511ed9564555bc23f01ad","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"completed","created_at":"2023-01-13T21:01:09.451Z","mode":"test","object":"Event"}],"has_more":true}'
+        body: '{"events":[{"description":"batch.updated","id":"evt_6ff9609cae3d11ed99a53bf09e5c2d9e","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"pending","created_at":"2023-02-16T21:04:01.320Z","mode":"test","object":"Event"},{"description":"batch.created","id":"evt_6fea3ba8ae3d11ed97df3dbff882a5b8","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"pending","created_at":"2023-02-16T21:04:01.221Z","mode":"test","object":"Event"},{"description":"batch.updated","id":"evt_6b4a298cae3d11eda42f73b25f47b42d","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"pending","created_at":"2023-02-16T21:03:53.461Z","mode":"test","object":"Event"},{"description":"batch.created","id":"evt_6b3b1712ae3d11ed927239cea1be5304","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"pending","created_at":"2023-02-16T21:03:53.362Z","mode":"test","object":"Event"},{"description":"report.empty","id":"evt_368b58f6ae3d11ed96a85370e35525a5","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"pending","created_at":"2023-02-16T21:02:24.969Z","mode":"test","object":"Event"}],"has_more":true}'
         curl_info:
             url: 'https://api.easypost.com/v2/events?page_size=5'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 750
-            request_size: 296
+            header_size: 733
+            request_size: 295
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.586054
-            namelookup_time: 0.001139
-            connect_time: 0.203484
-            pretransfer_time: 0.287031
+            total_time: 0.597769
+            namelookup_time: 0.002629
+            connect_time: 0.206828
+            pretransfer_time: 0.290725
             size_upload: 0.0
-            size_download: 1114.0
-            speed_download: 1900.0
+            size_download: 1107.0
+            speed_download: 1851.0
             speed_upload: 0.0
-            download_content_length: 1114.0
+            download_content_length: 1107.0
             upload_content_length: 0.0
-            starttransfer_time: 0.585989
+            starttransfer_time: 0.597702
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.15
-            local_port: 61509
+            local_ip: 10.130.6.31
+            local_port: 54877
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 490469
-            connect_time_us: 203484
-            namelookup_time_us: 1139
-            pretransfer_time_us: 287031
+            appconnect_time_us: 497495
+            connect_time_us: 206828
+            namelookup_time_us: 2629
+            pretransfer_time_us: 290725
             redirect_time_us: 0
-            starttransfer_time_us: 585989
-            total_time_us: 586054
+            starttransfer_time_us: 597702
+            total_time_us: 597769
+    index: 0
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/events/evt_676fa688938611ed8211671d54df5040/payloads'
+        url: 'https://api.easypost.com/v2/events/evt_6ff9609cae3d11ed99a53bf09e5c2d9e/payloads'
         headers:
             Host: api.easypost.com
             Accept-Encoding: ''
@@ -252,62 +255,63 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 1604567f63c1c848e7995cda000e201f
+            x-ep-request-uuid: d6e2ffca63ee9a47e788f70d000cb55e
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '15'
             etag: 'W/"b5e6dd0a7b95afc23c69e9e95aa4ce47"'
-            x-runtime: '0.031544'
-            x-node: bigweb9nuq
-            x-version-label: easypost-202301131832-957dabd382-master
+            x-runtime: '0.030597'
+            x-node: bigweb5nuq
+            x-version-label: easypost-202302161858-5b15c0a595-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 29913d444b', 'extlb1nuq 29913d444b']
+            x-proxied: ['intlb2nuq a40ea751fd', 'extlb1nuq a40ea751fd']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
         body: '{"payloads":[]}'
         curl_info:
-            url: 'https://api.easypost.com/v2/events/evt_676fa688938611ed8211671d54df5040/payloads'
+            url: 'https://api.easypost.com/v2/events/evt_6ff9609cae3d11ed99a53bf09e5c2d9e/payloads'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 730
-            request_size: 330
+            request_size: 329
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.412393
-            namelookup_time: 0.001304
-            connect_time: 0.20475
-            pretransfer_time: 0.299075
+            total_time: 0.386612
+            namelookup_time: 0.002544
+            connect_time: 0.206703
+            pretransfer_time: 0.289411
             size_upload: 0.0
             size_download: 15.0
-            speed_download: 36.0
+            speed_download: 38.0
             speed_upload: 0.0
             download_content_length: 15.0
             upload_content_length: 0.0
-            starttransfer_time: 0.412369
+            starttransfer_time: 0.386556
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.15
-            local_port: 61510
+            local_ip: 10.130.6.31
+            local_port: 54878
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 503728
-            connect_time_us: 204750
-            namelookup_time_us: 1304
-            pretransfer_time_us: 299075
+            appconnect_time_us: 496060
+            connect_time_us: 206703
+            namelookup_time_us: 2544
+            pretransfer_time_us: 289411
             redirect_time_us: 0
-            starttransfer_time_us: 412369
-            total_time_us: 412393
+            starttransfer_time_us: 386556
+            total_time_us: 386612
+    index: 0
 -
     request:
         method: DELETE
-        url: 'https://api.easypost.com/v2/webhooks/hook_66e9c630938611ed830415bd454a0c89'
+        url: 'https://api.easypost.com/v2/webhooks/hook_6f934636ae3d11eda2af43b1204ad17b'
         headers:
             Host: api.easypost.com
             Accept-Encoding: ''
@@ -327,55 +331,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 1604567f63c1c848e7995cdb000e2043
+            x-ep-request-uuid: d6e2ffc563ee9a47e788f70e000cb595
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '2'
             etag: 'W/"44136fa355b3678a1146ad16f7e8649e"'
-            x-runtime: '0.424119'
+            x-runtime: '0.542242'
             x-node: bigweb12nuq
-            x-version-label: easypost-202301131832-957dabd382-master
+            x-version-label: easypost-202302161858-5b15c0a595-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 29913d444b', 'extlb1nuq 29913d444b']
+            x-proxied: ['intlb1nuq a40ea751fd', 'extlb1nuq a40ea751fd']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
         body: '[]'
         curl_info:
-            url: 'https://api.easypost.com/v2/webhooks/hook_66e9c630938611ed830415bd454a0c89'
+            url: 'https://api.easypost.com/v2/webhooks/hook_6f934636ae3d11eda2af43b1204ad17b'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 730
-            request_size: 327
+            request_size: 326
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.764562
-            namelookup_time: 0.001186
-            connect_time: 0.202605
-            pretransfer_time: 0.27399
+            total_time: 0.900174
+            namelookup_time: 0.001894
+            connect_time: 0.207046
+            pretransfer_time: 0.290262
             size_upload: 0.0
             size_download: 2.0
             speed_download: 2.0
             speed_upload: 0.0
             download_content_length: 2.0
             upload_content_length: 0.0
-            starttransfer_time: 0.764504
+            starttransfer_time: 0.900097
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.15
-            local_port: 61511
+            local_ip: 10.130.6.31
+            local_port: 54879
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 476557
-            connect_time_us: 202605
-            namelookup_time_us: 1186
-            pretransfer_time_us: 273990
+            appconnect_time_us: 497240
+            connect_time_us: 207046
+            namelookup_time_us: 1894
+            pretransfer_time_us: 290262
             redirect_time_us: 0
-            starttransfer_time_us: 764504
-            total_time_us: 764562
+            starttransfer_time_us: 900097
+            total_time_us: 900174
+    index: 0

--- a/test/cassettes/events/retrieve_payload.yml
+++ b/test/cassettes/events/retrieve_payload.yml
@@ -24,58 +24,59 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3ac9ec2e63c1c9f6e79960fb000f935b
+            x-ep-request-uuid: d6e2ffcb63ee9a38e788f6ed000caf29
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '161'
-            etag: 'W/"7c4cfae1a35ca994ad1429a0d91292c9"'
-            x-runtime: '0.109099'
-            x-node: bigweb3nuq
-            x-version-label: easypost-202301131832-957dabd382-master
+            etag: 'W/"a66a6c9809ad7029771dd1d048fe0a62"'
+            x-runtime: '0.191216'
+            x-node: bigweb12nuq
+            x-version-label: easypost-202302161858-5b15c0a595-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 29913d444b', 'extlb2nuq 29913d444b']
+            x-proxied: ['intlb1nuq a40ea751fd', 'extlb1nuq a40ea751fd']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"hook_6b3e4c28938711edbb3647b657f41c41","object":"Webhook","mode":"test","url":"http:\/\/example.com","created_at":"2023-01-13T21:15:35Z","disabled_at":null}'
+        body: '{"id":"hook_6addd368ae3d11eda4f52bf02f8bb846","object":"Webhook","mode":"test","url":"http:\/\/example.com","created_at":"2023-02-16T21:03:53Z","disabled_at":null}'
         curl_info:
             url: 'https://api.easypost.com/v2/webhooks'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 736
-            request_size: 349
+            header_size: 737
+            request_size: 348
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.536937
-            namelookup_time: 0.050491
-            connect_time: 0.254498
-            pretransfer_time: 0.347643
+            total_time: 0.55689
+            namelookup_time: 0.00677
+            connect_time: 0.211393
+            pretransfer_time: 0.296818
             size_upload: 42.0
             size_download: 161.0
-            speed_download: 299.0
-            speed_upload: 78.0
+            speed_download: 289.0
+            speed_upload: 75.0
             download_content_length: 161.0
             upload_content_length: 42.0
-            starttransfer_time: 0.53689
+            starttransfer_time: 0.556813
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.15
-            local_port: 61601
+            local_ip: 10.130.6.31
+            local_port: 54869
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 602107
-            connect_time_us: 254498
-            namelookup_time_us: 50491
-            pretransfer_time_us: 347643
+            appconnect_time_us: 508162
+            connect_time_us: 211393
+            namelookup_time_us: 6770
+            pretransfer_time_us: 296818
             redirect_time_us: 0
-            starttransfer_time_us: 536890
-            total_time_us: 536937
+            starttransfer_time_us: 556813
+            total_time_us: 556890
+    index: 0
 -
     request:
         method: POST
@@ -101,58 +102,59 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 3ac9ec2b63c1c9f7e79960fc000f93b3
+            x-ep-request-uuid: d6e2ffc663ee9a39e788f705000caf65
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '384'
-            etag: 'W/"1fef09818846a7ceb6c2c0d4d6789c6a"'
-            x-runtime: '0.039591'
+            etag: 'W/"4ce41f3f970a535d2a9f643356f0240a"'
+            x-runtime: '0.041029'
             x-node: bigweb8nuq
-            x-version-label: easypost-202301131832-957dabd382-master
+            x-version-label: easypost-202302161858-5b15c0a595-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 29913d444b', 'extlb2nuq 29913d444b']
+            x-proxied: ['intlb1nuq a40ea751fd', 'extlb1nuq a40ea751fd']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"batch_47beedd89120434c8092ed25268073ac","object":"Batch","mode":"test","state":"creating","num_shipments":1,"reference":null,"created_at":"2023-01-13T21:15:35Z","updated_at":"2023-01-13T21:15:35Z","scan_form":null,"shipments":[],"status":{"created":0,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":0,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
+        body: '{"id":"batch_5f3d0bba3e44453f8f93fe12026de13c","object":"Batch","mode":"test","state":"creating","num_shipments":1,"reference":null,"created_at":"2023-02-16T21:03:53Z","updated_at":"2023-02-16T21:03:53Z","scan_form":null,"shipments":[],"status":{"created":0,"queued_for_purchase":0,"creation_failed":0,"postage_purchased":0,"postage_purchase_failed":0},"pickup":null,"label_url":null}'
         curl_info:
             url: 'https://api.easypost.com/v2/batches'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 731
-            request_size: 779
+            request_size: 778
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.668179
-            namelookup_time: 0.001115
-            connect_time: 0.20546
-            pretransfer_time: 0.564544
+            total_time: 0.398482
+            namelookup_time: 0.002325
+            connect_time: 0.206533
+            pretransfer_time: 0.290594
             size_upload: 472.0
             size_download: 384.0
-            speed_download: 574.0
-            speed_upload: 706.0
+            speed_download: 963.0
+            speed_upload: 1184.0
             download_content_length: 384.0
             upload_content_length: 472.0
-            starttransfer_time: 0.668151
+            starttransfer_time: 0.398389
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.15
-            local_port: 61602
+            local_ip: 10.130.6.31
+            local_port: 54870
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 769950
-            connect_time_us: 205460
-            namelookup_time_us: 1115
-            pretransfer_time_us: 564544
+            appconnect_time_us: 497072
+            connect_time_us: 206533
+            namelookup_time_us: 2325
+            pretransfer_time_us: 290594
             redirect_time_us: 0
-            starttransfer_time_us: 668151
-            total_time_us: 668179
+            starttransfer_time_us: 398389
+            total_time_us: 398482
+    index: 0
 -
     request:
         method: GET
@@ -176,62 +178,63 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 1604568163c1c9fce79960fd000ea1e7
+            x-ep-request-uuid: d6e2ffc863ee9a3ee788f706000cb1c0
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
-            content-length: '1111'
-            etag: 'W/"33783a58775340da7cd67bb0ffe3abcf"'
-            x-runtime: '0.178211'
-            x-node: bigweb6nuq
-            x-version-label: easypost-202301131832-957dabd382-master
+            content-length: '1105'
+            etag: 'W/"46a9c8718cff64a289bd9f5b31663121"'
+            x-runtime: '0.258032'
+            x-node: bigweb12nuq
+            x-version-label: easypost-202302161858-5b15c0a595-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 29913d444b', 'extlb1nuq 29913d444b']
+            x-proxied: ['intlb2nuq a40ea751fd', 'extlb1nuq a40ea751fd']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"events":[{"description":"batch.updated","id":"evt_6bd289e2938711edbdb171f40a3e19c0","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"pending","created_at":"2023-01-13T21:15:35.718Z","mode":"test","object":"Event"},{"description":"batch.created","id":"evt_6bb625ae938711edb4eb4b18c418a5ca","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"pending","created_at":"2023-01-13T21:15:35.532Z","mode":"test","object":"Event"},{"description":"batch.updated","id":"evt_0d146b46938711ed9cf11bb604a21a25","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"completed","created_at":"2023-01-13T21:12:56.766Z","mode":"test","object":"Event"},{"description":"batch.created","id":"evt_0cf28c56938711edbf576163068b840a","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"completed","created_at":"2023-01-13T21:12:56.544Z","mode":"test","object":"Event"},{"description":"batch.updated","id":"evt_676fa688938611ed8211671d54df5040","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"failed","created_at":"2023-01-13T21:08:18.862Z","mode":"test","object":"Event"}],"has_more":true}'
+        body: '{"events":[{"description":"batch.updated","id":"evt_6b4a298cae3d11eda42f73b25f47b42d","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"pending","created_at":"2023-02-16T21:03:53.461Z","mode":"test","object":"Event"},{"description":"batch.created","id":"evt_6b3b1712ae3d11ed927239cea1be5304","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"pending","created_at":"2023-02-16T21:03:53.362Z","mode":"test","object":"Event"},{"description":"report.empty","id":"evt_368b58f6ae3d11ed96a85370e35525a5","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"pending","created_at":"2023-02-16T21:02:24.969Z","mode":"test","object":"Event"},{"description":"report.empty","id":"evt_368b4b0eae3d11edb69409c09ed86ca8","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"pending","created_at":"2023-02-16T21:02:24.968Z","mode":"test","object":"Event"},{"description":"report.empty","id":"evt_368b4668ae3d11edb7137f9b16807606","user_id":"user_465eab8bb86844108100be2d4d5288ab","status":"pending","created_at":"2023-02-16T21:02:24.968Z","mode":"test","object":"Event"}],"has_more":true}'
         curl_info:
             url: 'https://api.easypost.com/v2/events?page_size=5'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 732
-            request_size: 296
+            header_size: 733
+            request_size: 295
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.510577
-            namelookup_time: 0.001132
-            connect_time: 0.204384
-            pretransfer_time: 0.273581
+            total_time: 0.619216
+            namelookup_time: 0.00213
+            connect_time: 0.207356
+            pretransfer_time: 0.29266
             size_upload: 0.0
-            size_download: 1111.0
-            speed_download: 2175.0
+            size_download: 1105.0
+            speed_download: 1784.0
             speed_upload: 0.0
-            download_content_length: 1111.0
+            download_content_length: 1105.0
             upload_content_length: 0.0
-            starttransfer_time: 0.510543
+            starttransfer_time: 0.619094
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.15
-            local_port: 61603
+            local_ip: 10.130.6.31
+            local_port: 54871
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 477911
-            connect_time_us: 204384
-            namelookup_time_us: 1132
-            pretransfer_time_us: 273581
+            appconnect_time_us: 499825
+            connect_time_us: 207356
+            namelookup_time_us: 2130
+            pretransfer_time_us: 292660
             redirect_time_us: 0
-            starttransfer_time_us: 510543
-            total_time_us: 510577
+            starttransfer_time_us: 619094
+            total_time_us: 619216
+    index: 0
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/events/evt_6bd289e2938711edbdb171f40a3e19c0/payloads/payload_11111111111111111111111111111111'
+        url: 'https://api.easypost.com/v2/events/evt_6b4a298cae3d11eda42f73b25f47b42d/payloads/payload_11111111111111111111111111111111'
         headers:
             Host: api.easypost.com
             Accept-Encoding: ''
@@ -251,136 +254,62 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 1604567d63c1c9fde79960fe000ea21d
+            x-ep-request-uuid: d6e2ffca63ee9a3fe788f707000cb23c
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '97'
-            x-runtime: '0.031213'
-            x-node: bigweb2nuq
-            x-version-label: easypost-202301131832-957dabd382-master
+            x-runtime: '0.033379'
+            x-node: bigweb6nuq
+            x-version-label: easypost-202302161858-5b15c0a595-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 29913d444b', 'extlb1nuq 29913d444b']
+            x-proxied: ['intlb1nuq a40ea751fd', 'extlb1nuq a40ea751fd']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
         body: '{"error":{"code":"PAYLOAD.NOT_FOUND","message":"The payload(s) could not be found.","errors":[]}}'
         curl_info:
-            url: 'https://api.easypost.com/v2/events/evt_6bd289e2938711edbdb171f40a3e19c0/payloads/payload_11111111111111111111111111111111'
+            url: 'https://api.easypost.com/v2/events/evt_6b4a298cae3d11eda42f73b25f47b42d/payloads/payload_11111111111111111111111111111111'
             content_type: 'application/json; charset=utf-8'
             http_code: 404
             header_size: 693
-            request_size: 371
+            request_size: 370
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.503588
-            namelookup_time: 0.001249
-            connect_time: 0.200398
-            pretransfer_time: 0.343533
+            total_time: 0.397546
+            namelookup_time: 0.002268
+            connect_time: 0.206444
+            pretransfer_time: 0.291438
             size_upload: 0.0
             size_download: 97.0
-            speed_download: 192.0
+            speed_download: 243.0
             speed_upload: 0.0
             download_content_length: 97.0
             upload_content_length: 0.0
-            starttransfer_time: 0.503555
+            starttransfer_time: 0.39748
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.15
-            local_port: 61604
+            local_ip: 10.130.6.31
+            local_port: 54872
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 543891
-            connect_time_us: 200398
-            namelookup_time_us: 1249
-            pretransfer_time_us: 343533
+            appconnect_time_us: 497839
+            connect_time_us: 206444
+            namelookup_time_us: 2268
+            pretransfer_time_us: 291438
             redirect_time_us: 0
-            starttransfer_time_us: 503555
-            total_time_us: 503588
--
-    request:
-        method: GET
-        url: 'https://api.easypost.com/v2/events/evt_6bd289e2938711edbdb171f40a3e19c0/payloads/payload_123'
-        headers:
-            Host: api.easypost.com
-            Accept-Encoding: ''
-            Accept: application/json
-            Authorization: ''
-            Content-Type: application/json
-            User-Agent: ''
-    response:
-        status:
-            http_version: '1.1'
-            code: '500'
-            message: 'Internal Server Error'
-        headers:
-            x-frame-options: SAMEORIGIN
-            x-xss-protection: '1; mode=block'
-            x-content-type-options: nosniff
-            x-download-options: noopen
-            x-permitted-cross-domain-policies: none
-            referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 1604568263c1c9fee79960ff000ea264
-            cache-control: 'private, no-cache, no-store'
-            pragma: no-cache
-            expires: '0'
-            content-type: 'application/json; charset=utf-8'
-            content-length: '149'
-            x-runtime: '0.235055'
-            x-node: bigweb7nuq
-            x-version-label: easypost-202301131832-957dabd382-master
-            x-backend: easypost
-            x-canary: direct
-            x-proxied: ['intlb2nuq 29913d444b', 'extlb1nuq 29913d444b']
-            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"error":{"code":"INTERNAL_SERVER_ERROR","message":"We''re sorry, something went wrong. If the problem persists please contact Support.","errors":[]}}'
-        curl_info:
-            url: 'https://api.easypost.com/v2/events/evt_6bd289e2938711edbdb171f40a3e19c0/payloads/payload_123'
-            content_type: 'application/json; charset=utf-8'
-            http_code: 500
-            header_size: 724
-            request_size: 342
-            filetime: -1
-            ssl_verify_result: 0
-            redirect_count: 0
-            total_time: 1.026012
-            namelookup_time: 0.001167
-            connect_time: 0.204975
-            pretransfer_time: 0.705564
-            size_upload: 0.0
-            size_download: 149.0
-            speed_download: 145.0
-            speed_upload: 0.0
-            download_content_length: 149.0
-            upload_content_length: 0.0
-            starttransfer_time: 1.025978
-            redirect_time: 0.0
-            redirect_url: ''
-            primary_ip: 169.62.110.131
-            certinfo: {  }
-            primary_port: 443
-            local_ip: 10.130.6.15
-            local_port: 61605
-            http_version: 2
-            protocol: 2
-            ssl_verifyresult: 0
-            scheme: HTTPS
-            appconnect_time_us: 910484
-            connect_time_us: 204975
-            namelookup_time_us: 1167
-            pretransfer_time_us: 705564
-            redirect_time_us: 0
-            starttransfer_time_us: 1025978
-            total_time_us: 1026012
+            starttransfer_time_us: 397480
+            total_time_us: 397546
+    index: 0
 -
     request:
         method: DELETE
-        url: 'https://api.easypost.com/v2/webhooks/hook_6b3e4c28938711edbb3647b657f41c41'
+        url: 'https://api.easypost.com/v2/webhooks/hook_6addd368ae3d11eda4f52bf02f8bb846'
         headers:
             Host: api.easypost.com
             Accept-Encoding: ''
@@ -400,56 +329,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 1604568163c1c9fee7996102000ea299
+            x-ep-request-uuid: d6e2ffc563ee9a3fe788f708000cb271
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '2'
             etag: 'W/"44136fa355b3678a1146ad16f7e8649e"'
-            x-runtime: '0.410054'
-            x-node: bigweb7nuq
-            x-version-label: easypost-202301131832-957dabd382-master
+            x-runtime: '0.388620'
+            x-node: bigweb1nuq
+            x-version-label: easypost-202302161858-5b15c0a595-master
             x-backend: easypost
-            x-canary: direct
-            x-proxied: ['intlb2nuq 29913d444b', 'extlb1nuq 29913d444b']
+            x-proxied: ['intlb2nuq a40ea751fd', 'extlb1nuq a40ea751fd']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
         body: '[]'
         curl_info:
-            url: 'https://api.easypost.com/v2/webhooks/hook_6b3e4c28938711edbb3647b657f41c41'
+            url: 'https://api.easypost.com/v2/webhooks/hook_6addd368ae3d11eda4f52bf02f8bb846'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 747
-            request_size: 327
+            header_size: 729
+            request_size: 326
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.786272
-            namelookup_time: 0.001051
-            connect_time: 0.203139
-            pretransfer_time: 0.297929
+            total_time: 0.749041
+            namelookup_time: 0.001843
+            connect_time: 0.20596
+            pretransfer_time: 0.291521
             size_upload: 0.0
             size_download: 2.0
             speed_download: 2.0
             speed_upload: 0.0
             download_content_length: 2.0
             upload_content_length: 0.0
-            starttransfer_time: 0.786236
+            starttransfer_time: 0.748955
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.15
-            local_port: 61608
+            local_ip: 10.130.6.31
+            local_port: 54873
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 501032
-            connect_time_us: 203139
-            namelookup_time_us: 1051
-            pretransfer_time_us: 297929
+            appconnect_time_us: 497446
+            connect_time_us: 205960
+            namelookup_time_us: 1843
+            pretransfer_time_us: 291521
             redirect_time_us: 0
-            starttransfer_time_us: 786236
-            total_time_us: 786272
+            starttransfer_time_us: 748955
+            total_time_us: 749041
+    index: 0

--- a/test/cassettes/reports/all.yml
+++ b/test/cassettes/reports/all.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/reports/shipment/?type=shipment&page_size=5'
+        url: 'https://api.easypost.com/v2/reports/shipment?page_size=5'
         headers:
             Host: api.easypost.com
             Accept-Encoding: ''
@@ -22,55 +22,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: e26b982b6391145ee78b0a05001e3a03
+            x-ep-request-uuid: d6e2ffca63ee99dae788f686000c8906
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '1455'
-            etag: 'W/"fd89aa9e989fe006319c6197cb68858b"'
-            x-runtime: '0.035502'
-            x-node: bigweb12nuq
-            x-version-label: easypost-202212072114-cbd87d5dd7-master
+            etag: 'W/"15dbb583f1f8a94afb48fc16f37dd135"'
+            x-runtime: '0.037367'
+            x-node: bigweb9nuq
+            x-version-label: easypost-202302161858-5b15c0a595-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 29913d444b', 'extlb2nuq 29913d444b']
+            x-proxied: ['intlb1nuq a40ea751fd', 'extlb1nuq a40ea751fd']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"reports":[{"id":"shprep_5848cfcfb43d4636bde8821d0c835038","object":"ShipmentReport","created_at":"2022-12-07T22:31:58Z","updated_at":"2022-12-07T22:31:58Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false},{"id":"shprep_24af19ebda5c4fd49d12f89fb61017b1","object":"ShipmentReport","created_at":"2022-12-07T22:31:57Z","updated_at":"2022-12-07T22:31:57Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false},{"id":"shprep_ef9ee94f596c4922a55f2df4a9f0defd","object":"ShipmentReport","created_at":"2022-12-07T20:12:12Z","updated_at":"2022-12-07T20:12:14Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false},{"id":"shprep_fec63099453e46458afcdf552f2b22e1","object":"ShipmentReport","created_at":"2022-12-07T20:12:11Z","updated_at":"2022-12-07T20:12:16Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false},{"id":"shprep_94f4987b270f472d8b4feca7525ea7f8","object":"ShipmentReport","created_at":"2022-12-07T20:12:10Z","updated_at":"2022-12-07T20:12:15Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false}],"has_more":true}'
+        body: '{"reports":[{"id":"shprep_21ef6f782bbb4d66adbd14fd3e5f5789","object":"ShipmentReport","created_at":"2023-02-16T21:02:18Z","updated_at":"2023-02-16T21:02:18Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false},{"id":"shprep_744fbf60b16044498b8c023c3b50c40b","object":"ShipmentReport","created_at":"2023-02-16T21:02:17Z","updated_at":"2023-02-16T21:02:17Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false},{"id":"shprep_5cdc56cd4bb44bc8a41e50dd8d746f0c","object":"ShipmentReport","created_at":"2022-12-07T22:31:59Z","updated_at":"2022-12-07T22:32:05Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false},{"id":"shprep_9ba818aecc7b43c796eff121ad5f1c92","object":"ShipmentReport","created_at":"2022-12-07T22:31:58Z","updated_at":"2022-12-07T22:32:05Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false},{"id":"shprep_5848cfcfb43d4636bde8821d0c835038","object":"ShipmentReport","created_at":"2022-12-07T22:31:58Z","updated_at":"2022-12-07T22:32:05Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false}],"has_more":true}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shipment/?type=shipment&page_size=5'
+            url: 'https://api.easypost.com/v2/reports/shipment?page_size=5'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 733
-            request_size: 320
+            header_size: 732
+            request_size: 305
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.24686
-            namelookup_time: 0.002193
-            connect_time: 0.068876
-            pretransfer_time: 0.143156
+            total_time: 0.391535
+            namelookup_time: 0.001709
+            connect_time: 0.206922
+            pretransfer_time: 0.287313
             size_upload: 0.0
             size_download: 1455.0
-            speed_download: 5894.0
+            speed_download: 3716.0
             speed_upload: 0.0
             download_content_length: 1455.0
             upload_content_length: 0.0
-            starttransfer_time: 0.246823
+            starttransfer_time: 0.391507
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.25
-            local_port: 58119
+            local_ip: 10.130.6.31
+            local_port: 54835
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 143133
-            connect_time_us: 68876
-            namelookup_time_us: 2193
-            pretransfer_time_us: 143156
+            appconnect_time_us: 494137
+            connect_time_us: 206922
+            namelookup_time_us: 1709
+            pretransfer_time_us: 287313
             redirect_time_us: 0
-            starttransfer_time_us: 246823
-            total_time_us: 246860
+            starttransfer_time_us: 391507
+            total_time_us: 391535
+    index: 0

--- a/test/cassettes/reports/createCustomAdditionalColumnReport.yml
+++ b/test/cassettes/reports/createCustomAdditionalColumnReport.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: POST
-        url: 'https://api.easypost.com/v2/reports/shipment/'
+        url: 'https://api.easypost.com/v2/reports/shipment'
         headers:
             Host: api.easypost.com
             Expect: ''
@@ -24,55 +24,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: e26b98326391145fe78b0a1f001e3a4c
+            x-ep-request-uuid: d6e2ffcc63ee99dbe788f687000c8939
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '283'
-            etag: 'W/"74f0bbb8358cc75bca2c49f29ce79982"'
-            x-runtime: '0.130866'
+            etag: 'W/"657274d96bdacdc2fd1e69a5f36dde99"'
+            x-runtime: '0.040074'
             x-node: bigweb5nuq
-            x-version-label: easypost-202212072114-cbd87d5dd7-master
+            x-version-label: easypost-202302161858-5b15c0a595-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 29913d444b', 'extlb2nuq 29913d444b']
+            x-proxied: ['intlb1nuq a40ea751fd', 'extlb1nuq a40ea751fd']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_5cdc56cd4bb44bc8a41e50dd8d746f0c","object":"ShipmentReport","created_at":"2022-12-07T22:31:59Z","updated_at":"2022-12-07T22:31:59Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shprep_563b7e11f01e4097a9f55c70856a9f64","object":"ShipmentReport","created_at":"2023-02-16T21:02:19Z","updated_at":"2023-02-16T21:02:19Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shipment/'
+            url: 'https://api.easypost.com/v2/reports/shipment'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
             header_size: 736
-            request_size: 435
+            request_size: 434
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.364622
-            namelookup_time: 0.002165
-            connect_time: 0.068203
-            pretransfer_time: 0.164838
+            total_time: 0.399121
+            namelookup_time: 0.001738
+            connect_time: 0.20592
+            pretransfer_time: 0.290159
             size_upload: 119.0
             size_download: 283.0
-            speed_download: 776.0
-            speed_upload: 326.0
+            speed_download: 709.0
+            speed_upload: 298.0
             download_content_length: 283.0
             upload_content_length: 119.0
-            starttransfer_time: 0.364552
+            starttransfer_time: 0.399043
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.25
-            local_port: 58122
+            local_ip: 10.130.6.31
+            local_port: 54836
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 164773
-            connect_time_us: 68203
-            namelookup_time_us: 2165
-            pretransfer_time_us: 164838
+            appconnect_time_us: 495925
+            connect_time_us: 205920
+            namelookup_time_us: 1738
+            pretransfer_time_us: 290159
             redirect_time_us: 0
-            starttransfer_time_us: 364552
-            total_time_us: 364622
+            starttransfer_time_us: 399043
+            total_time_us: 399121
+    index: 0

--- a/test/cassettes/reports/createCustomColumnReport.yml
+++ b/test/cassettes/reports/createCustomColumnReport.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: POST
-        url: 'https://api.easypost.com/v2/reports/shipment/'
+        url: 'https://api.easypost.com/v2/reports/shipment'
         headers:
             Host: api.easypost.com
             Expect: ''
@@ -24,55 +24,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: e26b982e6391145de78b0a03001e39d4
+            x-ep-request-uuid: d6e2ffcc63ee99dae788f685000c88dc
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '283'
-            etag: 'W/"08fbbc9bc3b0214fdd7eba72f9a08c67"'
-            x-runtime: '0.043267'
-            x-node: bigweb5nuq
-            x-version-label: easypost-202212072114-cbd87d5dd7-master
+            etag: 'W/"7a49a0bfe61a3128890bd01ce8d748de"'
+            x-runtime: '0.040103'
+            x-node: bigweb12nuq
+            x-version-label: easypost-202302161858-5b15c0a595-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 29913d444b', 'extlb2nuq 29913d444b']
+            x-proxied: ['intlb2nuq a40ea751fd', 'extlb1nuq a40ea751fd']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_24af19ebda5c4fd49d12f89fb61017b1","object":"ShipmentReport","created_at":"2022-12-07T22:31:57Z","updated_at":"2022-12-07T22:31:57Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shprep_21ef6f782bbb4d66adbd14fd3e5f5789","object":"ShipmentReport","created_at":"2023-02-16T21:02:18Z","updated_at":"2023-02-16T21:02:18Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shipment/'
+            url: 'https://api.easypost.com/v2/reports/shipment'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
-            header_size: 736
-            request_size: 408
+            header_size: 737
+            request_size: 407
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.258078
-            namelookup_time: 0.001927
-            connect_time: 0.068341
-            pretransfer_time: 0.146714
+            total_time: 0.3834
+            namelookup_time: 0.00216
+            connect_time: 0.202146
+            pretransfer_time: 0.276311
             size_upload: 93.0
             size_download: 283.0
-            speed_download: 1096.0
-            speed_upload: 360.0
+            speed_download: 738.0
+            speed_upload: 242.0
             download_content_length: 283.0
             upload_content_length: 93.0
-            starttransfer_time: 0.258001
+            starttransfer_time: 0.383358
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.25
-            local_port: 58117
+            local_ip: 10.130.6.31
+            local_port: 54834
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 146544
-            connect_time_us: 68341
-            namelookup_time_us: 1927
-            pretransfer_time_us: 146714
+            appconnect_time_us: 478422
+            connect_time_us: 202146
+            namelookup_time_us: 2160
+            pretransfer_time_us: 276311
             redirect_time_us: 0
-            starttransfer_time_us: 258001
-            total_time_us: 258078
+            starttransfer_time_us: 383358
+            total_time_us: 383400
+    index: 0

--- a/test/cassettes/reports/createReport.yml
+++ b/test/cassettes/reports/createReport.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: POST
-        url: 'https://api.easypost.com/v2/reports/shipment/'
+        url: 'https://api.easypost.com/v2/reports/shipment'
         headers:
             Host: api.easypost.com
             Expect: ''
@@ -24,55 +24,56 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: e26b98306391145ee78b0a04001e39e8
+            x-ep-request-uuid: d6e2ffc863ee99d9e788f684000c88b4
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '283'
-            etag: 'W/"1af1008d179d3a47a2d201aad901f0d8"'
-            x-runtime: '0.049905'
-            x-node: bigweb2nuq
-            x-version-label: easypost-202212072114-cbd87d5dd7-master
+            etag: 'W/"71f7eeaa5fc63ea93903d04804eb5038"'
+            x-runtime: '0.067810'
+            x-node: bigweb5nuq
+            x-version-label: easypost-202302161858-5b15c0a595-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 29913d444b', 'extlb2nuq 29913d444b']
+            x-proxied: ['intlb1nuq a40ea751fd', 'extlb1nuq a40ea751fd']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_5848cfcfb43d4636bde8821d0c835038","object":"ShipmentReport","created_at":"2022-12-07T22:31:58Z","updated_at":"2022-12-07T22:31:58Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shprep_744fbf60b16044498b8c023c3b50c40b","object":"ShipmentReport","created_at":"2023-02-16T21:02:17Z","updated_at":"2023-02-16T21:02:17Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shipment/'
+            url: 'https://api.easypost.com/v2/reports/shipment'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
             header_size: 736
-            request_size: 384
+            request_size: 383
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.268508
-            namelookup_time: 0.002732
-            connect_time: 0.068745
-            pretransfer_time: 0.1504
+            total_time: 0.429124
+            namelookup_time: 0.004745
+            connect_time: 0.208855
+            pretransfer_time: 0.292628
             size_upload: 69.0
             size_download: 283.0
-            speed_download: 1053.0
-            speed_upload: 256.0
+            speed_download: 659.0
+            speed_upload: 160.0
             download_content_length: 283.0
             upload_content_length: 69.0
-            starttransfer_time: 0.268454
+            starttransfer_time: 0.429049
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.25
-            local_port: 58118
+            local_ip: 10.130.6.31
+            local_port: 54833
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 150350
-            connect_time_us: 68745
-            namelookup_time_us: 2732
-            pretransfer_time_us: 150400
+            appconnect_time_us: 501434
+            connect_time_us: 208855
+            namelookup_time_us: 4745
+            pretransfer_time_us: 292628
             redirect_time_us: 0
-            starttransfer_time_us: 268454
-            total_time_us: 268508
+            starttransfer_time_us: 429049
+            total_time_us: 429124
+    index: 0

--- a/test/cassettes/reports/retrieveReport.yml
+++ b/test/cassettes/reports/retrieveReport.yml
@@ -2,7 +2,7 @@
 -
     request:
         method: POST
-        url: 'https://api.easypost.com/v2/reports/shipment/'
+        url: 'https://api.easypost.com/v2/reports/shipment'
         headers:
             Host: api.easypost.com
             Expect: ''
@@ -24,62 +24,63 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: e26b982b6391145ee78b0a1d001e3a1d
+            x-ep-request-uuid: d6e2ffca63ee99dbe788f688000c8967
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '283'
-            etag: 'W/"98faa42a0bac825b70979889823ff996"'
-            x-runtime: '0.030542'
-            x-node: bigweb3nuq
-            x-version-label: easypost-202212072114-cbd87d5dd7-master
+            etag: 'W/"b4a7479f07b535c7bf5427a965ac8bfd"'
+            x-runtime: '0.045019'
+            x-node: bigweb8nuq
+            x-version-label: easypost-202302161858-5b15c0a595-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq 29913d444b', 'extlb2nuq 29913d444b']
+            x-proxied: ['intlb2nuq a40ea751fd', 'extlb1nuq a40ea751fd']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_9ba818aecc7b43c796eff121ad5f1c92","object":"ShipmentReport","created_at":"2022-12-07T22:31:58Z","updated_at":"2022-12-07T22:31:58Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shprep_2a8d121d183b40d98d41501ee9f96a9d","object":"ShipmentReport","created_at":"2023-02-16T21:02:19Z","updated_at":"2023-02-16T21:02:19Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shipment/'
+            url: 'https://api.easypost.com/v2/reports/shipment'
             content_type: 'application/json; charset=utf-8'
             http_code: 201
             header_size: 736
-            request_size: 384
+            request_size: 383
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.253473
-            namelookup_time: 0.00229
-            connect_time: 0.068058
-            pretransfer_time: 0.155476
+            total_time: 0.398396
+            namelookup_time: 0.002252
+            connect_time: 0.20644
+            pretransfer_time: 0.286502
             size_upload: 69.0
             size_download: 283.0
-            speed_download: 1116.0
-            speed_upload: 272.0
+            speed_download: 710.0
+            speed_upload: 173.0
             download_content_length: 283.0
             upload_content_length: 69.0
-            starttransfer_time: 0.253431
+            starttransfer_time: 0.398323
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.25
-            local_port: 58120
+            local_ip: 10.130.6.31
+            local_port: 54837
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 155426
-            connect_time_us: 68058
-            namelookup_time_us: 2290
-            pretransfer_time_us: 155476
+            appconnect_time_us: 492911
+            connect_time_us: 206440
+            namelookup_time_us: 2252
+            pretransfer_time_us: 286502
             redirect_time_us: 0
-            starttransfer_time_us: 253431
-            total_time_us: 253473
+            starttransfer_time_us: 398323
+            total_time_us: 398396
+    index: 0
 -
     request:
         method: GET
-        url: 'https://api.easypost.com/v2/reports/shprep_9ba818aecc7b43c796eff121ad5f1c92'
+        url: 'https://api.easypost.com/v2/reports/shprep_2a8d121d183b40d98d41501ee9f96a9d'
         headers:
             Host: api.easypost.com
             Accept-Encoding: ''
@@ -99,22 +100,22 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: e26b982e6391145ee78b0a1e001e3a34
+            x-ep-request-uuid: d6e2ffcb63ee99dbe788f689000c8997
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '283'
-            etag: 'W/"98faa42a0bac825b70979889823ff996"'
-            x-runtime: '0.029355'
-            x-node: bigweb1nuq
-            x-version-label: easypost-202212072114-cbd87d5dd7-master
+            etag: 'W/"b4a7479f07b535c7bf5427a965ac8bfd"'
+            x-runtime: '0.131484'
+            x-node: bigweb9nuq
+            x-version-label: easypost-202302161858-5b15c0a595-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq 29913d444b', 'extlb2nuq 29913d444b']
+            x-proxied: ['intlb2nuq a40ea751fd', 'extlb1nuq a40ea751fd']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"id":"shprep_9ba818aecc7b43c796eff121ad5f1c92","object":"ShipmentReport","created_at":"2022-12-07T22:31:58Z","updated_at":"2022-12-07T22:31:58Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+        body: '{"id":"shprep_2a8d121d183b40d98d41501ee9f96a9d","object":"ShipmentReport","created_at":"2023-02-16T21:02:19Z","updated_at":"2023-02-16T21:02:19Z","start_date":"2022-04-09","end_date":"2022-04-09","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
         curl_info:
-            url: 'https://api.easypost.com/v2/reports/shprep_9ba818aecc7b43c796eff121ad5f1c92'
+            url: 'https://api.easypost.com/v2/reports/shprep_2a8d121d183b40d98d41501ee9f96a9d'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 731
@@ -122,32 +123,33 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.247241
-            namelookup_time: 0.001736
-            connect_time: 0.074535
-            pretransfer_time: 0.151318
+            total_time: 0.484676
+            namelookup_time: 0.002193
+            connect_time: 0.206417
+            pretransfer_time: 0.286323
             size_upload: 0.0
             size_download: 283.0
-            speed_download: 1144.0
+            speed_download: 583.0
             speed_upload: 0.0
             download_content_length: 283.0
             upload_content_length: 0.0
-            starttransfer_time: 0.247158
+            starttransfer_time: 0.484646
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.25
-            local_port: 58121
+            local_ip: 10.130.6.31
+            local_port: 54838
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 151130
-            connect_time_us: 74535
-            namelookup_time_us: 1736
-            pretransfer_time_us: 151318
+            appconnect_time_us: 492706
+            connect_time_us: 206417
+            namelookup_time_us: 2193
+            pretransfer_time_us: 286323
             redirect_time_us: 0
-            starttransfer_time_us: 247158
-            total_time_us: 247241
+            starttransfer_time_us: 484646
+            total_time_us: 484676
+    index: 0


### PR DESCRIPTION
# Description

This PR fixes two things that have no production affect:

1. Unsuts the `type` in `params` when retrieving all reports. This just cleans up the URL that's hit a bit, was not broken
2. Finally tracked down why the test suite was ~10 seconds slower than it should have been, whoever added `payload` left some copy/pasta so thr check to see if the cassette existed so it wouldn't sleep was always true to sleep, now with cassettes present it won't unnecessarily sleep
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- Updated tests/re-recorded affected cassettes
<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
