### PR TITLE
fix: enforce line length of 120

### DIFF
--- a/lib/EasyPost/Constant/Constants.php
+++ b/lib/EasyPost/Constant/Constants.php
@@ -22,12 +22,12 @@ abstract class Constants
 
     // Exception messages (many of these are intended to be used with `sprintf()`)
     const ARRAY_REQUIRED_ERROR = 'You must pass an array as the first argument to EasyPost API method calls.';
-    const COMMUNICATION_ERROR = 'Unexpected error communicating with %s. If this problem persists please let us know at ' . self::SUPPORT_EMAIL . '. %s';
+    const COMMUNICATION_ERROR = 'Unexpected error communicating with %s. If this problem persists please let us know at ' . self::SUPPORT_EMAIL . '. %s'; // phpcs:ignore
     const DECODE_WEBHOOK_ERROR = 'There was a problem decoding the webhook.';
     const INVALID_PARAMETER_ERROR_WITH_SUGGESTION = 'Invalid %s value, must be one of: %s';
     const INVALID_PAYMENT_METHOD_ERROR = 'The chosen payment method is not valid. Please try again.';
     const INVALID_SIGNATURE_ERROR = 'Webhook received does not contain an HMAC signature.';
-    const INVALID_WEBHOOK_VALIDATION_ERROR = 'Webhook received did not originate from EasyPost or had a webhook secret mismatch.';
+    const INVALID_WEBHOOK_VALIDATION_ERROR = 'Webhook received did not originate from EasyPost or had a webhook secret mismatch.'; // phpcs:ignore
     const MISSING_PARAMETER_ERROR = '%s is required.';
     const NO_BILLING_ERROR = 'Billing has not been setup for this user. Please add a payment method.';
     const NO_ID_URL_ERROR = 'Could not determine which URL to request: %s instance has invalid ID: %s';

--- a/lib/EasyPost/EasyPostClient.php
+++ b/lib/EasyPost/EasyPostClient.php
@@ -73,8 +73,12 @@ class EasyPostClient extends BaseService
      * @param string $apiBase
      * @param object $mockingUtility
      */
-    public function __construct($apiKey, $timeout = Constants::TIMEOUT, $apiBase = Constants::API_BASE, $mockingUtility = null)
-    {
+    public function __construct(
+        $apiKey,
+        $timeout = Constants::TIMEOUT,
+        $apiBase = Constants::API_BASE,
+        $mockingUtility = null
+    ) {
         // Client properties
         $this->apiKey = $apiKey;
         $this->timeout = $timeout;
@@ -82,7 +86,9 @@ class EasyPostClient extends BaseService
         $this->mockingUtility = $mockingUtility;
 
         if (!$this->apiKey) {
-            throw new MissingParameterException('No API key provided. See https://www.easypost.com/docs for details, or contact ' . Constants::SUPPORT_EMAIL . ' for assistance.');
+            throw new MissingParameterException(
+                'No API key provided. See https://www.easypost.com/docs for details, or contact ' . Constants::SUPPORT_EMAIL . ' for assistance.' // phpcs:ignore
+            );
         }
     }
 
@@ -124,7 +130,9 @@ class EasyPostClient extends BaseService
         if (array_key_exists($serviceName, $serviceClassMap)) {
             return new $serviceClassMap[$serviceName]($this);
         } else {
-            throw new EasyPostException(sprintf(Constants::UNDEFINED_PROPERTY_ERROR, 'EasyPostClient', $serviceName));
+            throw new EasyPostException(
+                sprintf(Constants::UNDEFINED_PROPERTY_ERROR, 'EasyPostClient', $serviceName)
+            );
         }
     }
 

--- a/lib/EasyPost/Http/Requestor.php
+++ b/lib/EasyPost/Http/Requestor.php
@@ -176,7 +176,7 @@ class Requestor
             'Accept' => 'application/json',
             'Authorization' => "Bearer {$client->getApiKey()}",
             'Content-Type' => 'application/json',
-            'User-Agent' => 'EasyPost/v2 PhpClient/' . Constants::LIBRARY_VERSION . " PHP/$phpVersion OS/$osType OSVersion/$osVersion OSArch/$osArch",
+            'User-Agent' => 'EasyPost/v2 PhpClient/' . Constants::LIBRARY_VERSION . " PHP/$phpVersion OS/$osType OSVersion/$osVersion OSArch/$osArch", // phpcs:ignore
         ];
 
         if ($client->mock()) {
@@ -201,7 +201,8 @@ class Requestor
             throw new HttpException(sprintf(Constants::COMMUNICATION_ERROR, 'EasyPost', $error->getMessage()));
         }
 
-        // Guzzle does not have a native way of catching timeout exceptions... If we don't have a response at this point, it's likely due to a timeout
+        // Guzzle does not have a native way of catching timeout exceptions...
+        // If we don't have a response at this point, it's likely due to a timeout.
         if (!isset($response)) {
             throw new TimeoutException(sprintf(Constants::NO_RESPONSE_ERROR, 'EasyPost'));
         }
@@ -225,7 +226,11 @@ class Requestor
         try {
             $response = json_decode($httpBody, true);
         } catch (\Exception $e) {
-            throw new JsonException("Invalid response body from API: HTTP Status: ({$httpStatus}) {$httpBody}", $httpStatus, $httpBody);
+            throw new JsonException(
+                "Invalid response body from API: HTTP Status: ({$httpStatus}) {$httpBody}",
+                $httpStatus,
+                $httpBody
+            );
         }
 
         if ($httpStatus < 200 || $httpStatus >= 300) {
@@ -258,10 +263,15 @@ class Requestor
     public static function handleApiError($httpBody, $httpStatus, $response)
     {
         if (!is_array($response) || !isset($response['error'])) {
-            throw new JsonException("Invalid response object from API: HTTP Status: ({$httpStatus}) {$httpBody})", $httpStatus, $httpBody);
+            throw new JsonException(
+                "Invalid response object from API: HTTP Status: ({$httpStatus}) {$httpBody})",
+                $httpStatus,
+                $httpBody
+            );
         }
 
-        // Errors may be an array improperly assigned to the `message` field instead of the `errors` field, concatenate those here
+        // Errors may be an array improperly assigned to the `message` field instead
+        // of the `errors` field, concatenate those here.
         if (is_array($response['error'])) {
             $message = is_array($response['error']['message'])
                 ? json_encode($response['error']['message'])

--- a/lib/EasyPost/Service/ReferralCustomerService.php
+++ b/lib/EasyPost/Service/ReferralCustomerService.php
@@ -90,12 +90,24 @@ class ReferralCustomerService extends BaseService
      * @return mixed
      * @throws ExternalApiException
      */
-    public function addCreditCard($referralApiKey, $number, $expirationMonth, $expirationYear, $cvc, $primaryOrSecondary = 'primary')
-    {
+    public function addCreditCard(
+        $referralApiKey,
+        $number,
+        $expirationMonth,
+        $expirationYear,
+        $cvc,
+        $primaryOrSecondary = 'primary'
+    ) {
         $easypostStripeApiKey = self::retrieveEasypostStripeApiKey();
 
         try {
-            $stripeToken = self::createStripeToken($number, $expirationMonth, $expirationYear, $cvc, $easypostStripeApiKey);
+            $stripeToken = self::createStripeToken(
+                $number,
+                $expirationMonth,
+                $expirationYear,
+                $cvc,
+                $easypostStripeApiKey
+            );
         } catch (\Exception $error) {
             throw new ExternalApiException(Constants::SEND_STRIPE_DETAILS_ERROR);
         }
@@ -161,7 +173,8 @@ class ReferralCustomerService extends BaseService
             throw new HttpException(sprintf(Constants::COMMUNICATION_ERROR, 'Stripe', $error->getMessage()));
         }
 
-        // Guzzle does not have a native way of catching timeout exceptions... If we don't have a response at this point, it's likely due to a timeout
+        // Guzzle does not have a native way of catching timeout exceptions...
+        // If we don't have a response at this point, it's likely due to a timeout.
         if (!isset($response)) {
             throw new TimeoutException(sprintf(Constants::NO_RESPONSE_ERROR, 'Stripe'));
         }

--- a/lib/EasyPost/Service/UserService.php
+++ b/lib/EasyPost/Service/UserService.php
@@ -102,7 +102,7 @@ class UserService extends BaseService
             // This function was called on the authenticated user
             $myApiKeys = $apiKeys->keys;
         } else {
-            // This function was called on a child user (authenticated as parent, only return this child user's details).
+            // This function was called on a child user, authenticated as parent, only return this child user's details
             $myApiKeys = [];
             foreach ($apiKeys->children as $childrenKeys) {
                 if ($childrenKeys->id == $id) {
@@ -124,7 +124,12 @@ class UserService extends BaseService
      */
     public function updateBrand($id, $params = null)
     {
-        $response = Requestor::request($this->client, 'patch', $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/brand', $params);
+        $response = Requestor::request(
+            $this->client,
+            'patch',
+            $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/brand',
+            $params
+        );
 
         return InternalUtil::convertToEasyPostObject($this->client, $response);
     }

--- a/lib/EasyPost/Util/InternalUtil.php
+++ b/lib/EasyPost/Util/InternalUtil.php
@@ -145,9 +145,16 @@ abstract class InternalUtil
 
             return $mapped;
         } elseif (is_array($response)) {
-            if (isset($response['object']) && is_string($response['object']) && isset(OBJECT_MAPPING[$response['object']])) {
+            if (
+                isset($response['object'])
+                && is_string($response['object'])
+                && isset(OBJECT_MAPPING[$response['object']])
+            ) {
                 $class = OBJECT_MAPPING[$response['object']];
-            } elseif (isset($response['id']) && isset(OBJECT_ID_PREFIXES[substr($response['id'], 0, strpos($response['id'], '_'))])) {
+            } elseif (
+                isset($response['id'])
+                && isset(OBJECT_ID_PREFIXES[substr($response['id'], 0, strpos($response['id'], '_'))])
+            ) {
                 $class = OBJECT_ID_PREFIXES[substr($response['id'], 0, strpos($response['id'], '_'))];
             } else {
                 $class = '\EasyPost\EasyPostObject';

--- a/lib/EasyPost/Util/Util.php
+++ b/lib/EasyPost/Util/Util.php
@@ -61,7 +61,9 @@ abstract class Util
 
         if (!in_array(strtolower($deliveryAccuracy), $validDeliveryAccuracyValues)) {
             $jsonValidList = json_encode($validDeliveryAccuracyValues);
-            throw new InvalidParameterException(sprintf(Constants::INVALID_PARAMETER_ERROR_WITH_SUGGESTION, 'delivery_accuracy', $jsonValidList));
+            throw new InvalidParameterException(
+                sprintf(Constants::INVALID_PARAMETER_ERROR_WITH_SUGGESTION, 'delivery_accuracy', $jsonValidList)
+            );
         }
 
         foreach ($smartRates as $rate) {
@@ -82,7 +84,7 @@ abstract class Util
     /**
      * Validate a webhook originated from EasyPost by comparing the HMAC header to a shared secret.
      * If the signatures do not match, an error will be raised signifying the webhook either did not originate
-     * from EasyPost or the secrets do not match. If the signatures do match, the `event_body` will be returned as JSON.
+     * from EasyPost or the secrets do not match. If the signatures do match, the `event_body` will be returned as JSON
      *
      * @param mixed $eventBody
      * @param mixed $headers

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -21,6 +21,12 @@
     <rule ref="PSR12" />
 
     <!-- Enforce custom rules -->
+    <rule ref= "Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="120"/>
+            <property name="absoluteLineLimit" value="120"/>
+        </properties>
+    </rule>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
     <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps" />
     <rule ref="Squiz.Strings.DoubleQuoteUsage.NotRequired" />

--- a/test/EasyPost/AddressTest.php
+++ b/test/EasyPost/AddressTest.php
@@ -60,7 +60,10 @@ class AddressTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(Address::class, $address);
         $this->assertStringMatchesFormat('adr_%s', $address->id);
         $this->assertEquals('417 MONTGOMERY ST FL 5', $address->street1);
-        $this->assertEquals('Invalid secondary information(Apt/Suite#)', $address->verifications->zip4->errors[0]->message);
+        $this->assertEquals(
+            'Invalid secondary information(Apt/Suite#)',
+            $address->verifications->zip4->errors[0]->message
+        );
     }
 
     /**
@@ -97,7 +100,10 @@ class AddressTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(Address::class, $address);
         $this->assertStringMatchesFormat('adr_%s', $address->id);
         $this->assertEquals('417 MONTGOMERY ST FL 5', $address->street1);
-        $this->assertEquals('Invalid secondary information(Apt/Suite#)', $address->verifications->zip4->errors[0]->message);
+        $this->assertEquals(
+            'Invalid secondary information(Apt/Suite#)',
+            $address->verifications->zip4->errors[0]->message
+        );
     }
 
     /**

--- a/test/EasyPost/BatchTest.php
+++ b/test/EasyPost/BatchTest.php
@@ -134,7 +134,8 @@ class BatchTest extends \PHPUnit\Framework\TestCase
 
         $scanformBatch = self::$client->batch->createScanForm($boughtBatch->id);
 
-        // We can't assert anything meaningful here because the scanform gets queued for generation and may not be immediately available
+        // We can't assert anything meaningful here because the scanform gets queued for generation
+        // and may not be immediately available.
         $this->assertInstanceOf(Batch::class, $scanformBatch);
     }
 
@@ -186,7 +187,8 @@ class BatchTest extends \PHPUnit\Framework\TestCase
             ['file_format' => 'ZPL']
         );
 
-        // We can't assert anything meaningful here because the label gets queued for generation and may not be immediately available
+        // We can't assert anything meaningful here because the label gets queued for generation
+        // and may not be immediately available.
         $this->assertInstanceOf(Batch::class, $labelBatch);
     }
 }

--- a/test/EasyPost/BetaReferralCustomerTest.php
+++ b/test/EasyPost/BetaReferralCustomerTest.php
@@ -15,7 +15,8 @@ class BetaReferralCustomerTest extends \PHPUnit\Framework\TestCase
     public static function setUpBeforeClass(): void
     {
         TestUtil::setupVcrTests();
-        $referralCustomerProdApiKey = getenv('REFERRAL_CUSTOMER_PROD_API_KEY') !== false ? getenv('REFERRAL_CUSTOMER_PROD_API_KEY') : '123';
+        $referralCustomerProdApiKey = getenv('REFERRAL_CUSTOMER_PROD_API_KEY') !== false
+            ? getenv('REFERRAL_CUSTOMER_PROD_API_KEY') : '123';
         self::$client = new EasyPostClient($referralCustomerProdApiKey);
     }
 
@@ -59,7 +60,10 @@ class BetaReferralCustomerTest extends \PHPUnit\Framework\TestCase
         try {
             self::$client->betaReferralCustomer->refundByAmount(2000);
         } catch (ApiException $error) {
-            $this->assertEquals('Refund amount is invalid. Please use a valid amount or escalate to finance.', $error->getMessage());
+            $this->assertEquals(
+                'Refund amount is invalid. Please use a valid amount or escalate to finance.',
+                $error->getMessage()
+            );
         }
     }
 

--- a/test/EasyPost/BillingTest.php
+++ b/test/EasyPost/BillingTest.php
@@ -65,7 +65,7 @@ class BillingTest extends \PHPUnit\Framework\TestCase
                 ),
                 new MockRequestResponseInfo(
                     200,
-                    '{"id": "summary_123", "primary_payment_method": {"id": "card_123", "last4": "1234"}, "secondary_payment_method": {"id": "bank_123", "bank_name": "Mock Bank"}}'
+                    '{"id": "summary_123", "primary_payment_method": {"id": "card_123", "last4": "1234"}, "secondary_payment_method": {"id": "bank_123", "bank_name": "Mock Bank"}}' // phpcs:ignore
                 )
             ),
         );
@@ -82,7 +82,12 @@ class BillingTest extends \PHPUnit\Framework\TestCase
      */
     public static function getClient($mockUtility = null)
     {
-        return new EasyPostClient(getenv('EASYPOST_TEST_API_KEY'), Constants::TIMEOUT, Constants::API_BASE, $mockUtility);
+        return new EasyPostClient(
+            getenv('EASYPOST_TEST_API_KEY'),
+            Constants::TIMEOUT,
+            Constants::API_BASE,
+            $mockUtility
+        );
     }
 
     /**
@@ -171,7 +176,8 @@ class BillingTest extends \PHPUnit\Framework\TestCase
      * Test getting a payment method by priority level
      *
      * Deleting a payment method gets the payment method internally, which should test the switch case.
-     * The payment method is not exposed by this method, so we can't assert against it. If the function doesn't throw an exception, it worked.
+     * The payment method is not exposed by this method, so we can't assert against it.
+     * If the function doesn't throw an exception, it worked.
      */
     public function testGetPaymentMethodPrioritySwitchCase()
     {
@@ -216,14 +222,16 @@ class BillingTest extends \PHPUnit\Framework\TestCase
                 ),
                 new MockRequestResponseInfo(
                     200,
-                    '{"id": "summary_123", "primary_payment_method": null, "secondary_payment_method": null}' // null, will throw an error when we try to grab this payment method from the summary
+                    // null, will throw an error when we try to grab this payment method from the summary
+                    '{"id": "summary_123", "primary_payment_method": null, "secondary_payment_method": null}'
                 )
             )
         );
 
         $client = self::getClient($mockingUtility);
 
-        // Deleting a payment method gets the payment method internally, which should execute the code that will trigger an exception.
+        // Deleting a payment method gets the payment method internally, which should execute the
+        // code that will trigger an exception.
         try {
             $client->billing->deletePaymentMethod('primary');
 
@@ -246,14 +254,16 @@ class BillingTest extends \PHPUnit\Framework\TestCase
                 ),
                 new MockRequestResponseInfo(
                     200,
-                    '{"id": "summary_123", "primary_payment_method": {"id": ""}, "secondary_payment_method": {"id": ""}}' // No ID, will throw an error when we try to grab this payment method from the summary
+                    // No ID, will throw an error when we try to grab this payment method from the summary
+                    '{"id": "summary_123", "primary_payment_method": {"id": ""}, "secondary_payment_method": {"id": ""}}' // phpcs:ignore
                 )
             )
         );
 
         $client = self::getClient($mockingUtility);
 
-        // Deleting a payment method gets the payment method internally, which should execute the code that will trigger an exception.
+        // Deleting a payment method gets the payment method internally, which should execute the
+        // code that will trigger an exception.
         try {
             $client->billing->deletePaymentMethod('primary');
 

--- a/test/EasyPost/CarrierAccountTest.php
+++ b/test/EasyPost/CarrierAccountTest.php
@@ -43,7 +43,8 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(CarrierAccount::class, $carrierAccount);
         $this->assertStringMatchesFormat('ca_%s', $carrierAccount->id);
 
-        self::$client->carrierAccount->delete($carrierAccount->id); // Delete the carrier account once it's done being tested.
+        // Delete the carrier account once it's done being tested.
+        self::$client->carrierAccount->delete($carrierAccount->id);
     }
 
     /**
@@ -118,7 +119,8 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(CarrierAccount::class, $retrievedCarrierAccount);
         $this->assertEquals($carrierAccount, $retrievedCarrierAccount);
 
-        self::$client->carrierAccount->delete($retrievedCarrierAccount->id); // Delete the carrier account once it's done being tested.
+        // Delete the carrier account once it's done being tested.
+        self::$client->carrierAccount->delete($retrievedCarrierAccount->id);
     }
 
     /**
@@ -155,7 +157,8 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
         $this->assertStringMatchesFormat('ca_%s', $updatedCarrierAccount->id);
         $this->assertEquals($testDescription, $updatedCarrierAccount->description);
 
-        self::$client->carrierAccount->delete($updatedCarrierAccount->id); // Delete the carrier account once it's done being tested.
+        // Delete the carrier account once it's done being tested.
+        self::$client->carrierAccount->delete($updatedCarrierAccount->id);
     }
 
     /**

--- a/test/EasyPost/EasyPostClientTest.php
+++ b/test/EasyPost/EasyPostClientTest.php
@@ -59,7 +59,10 @@ class EasyPostClientTest extends \PHPUnit\Framework\TestCase
         try {
             new EasyPostClient(null);
         } catch (MissingParameterException $error) {
-            $this->assertEquals('No API key provided. See https://www.easypost.com/docs for details, or contact support@easypost.com for assistance.', $error->getMessage());
+            $this->assertEquals(
+                'No API key provided. See https://www.easypost.com/docs for details, or contact support@easypost.com for assistance.', // phpcs:ignore
+                $error->getMessage()
+            );
         }
     }
 
@@ -72,7 +75,10 @@ class EasyPostClientTest extends \PHPUnit\Framework\TestCase
             $client = new EasyPostClient('123');
             $client->invalidProperty;
         } catch (EasyPostException $error) {
-            $this->assertEquals('EasyPost Notice: Undefined property of EasyPostClient instance: invalidProperty', $error->getMessage());
+            $this->assertEquals(
+                'EasyPost Notice: Undefined property of EasyPostClient instance: invalidProperty',
+                $error->getMessage()
+            );
         }
     }
 }

--- a/test/EasyPost/ErrorTest.php
+++ b/test/EasyPost/ErrorTest.php
@@ -41,9 +41,10 @@ class ErrorTest extends \PHPUnit\Framework\TestCase
             $this->assertEquals('PARAMETER.REQUIRED', $error->code);
             $this->assertEquals('Missing required parameter.', $error->getMessage());
             $this->assertEquals(['field' => 'shipment', 'message' => 'cannot be blank'], $error->errors[0]);
-            $this->assertEquals('{"error":{"code":"PARAMETER.REQUIRED","message":"Missing required parameter.","errors":[{"field":"shipment","message":"cannot be blank"}]}}', $error->getHttpBody());
+            $this->assertEquals('{"error":{"code":"PARAMETER.REQUIRED","message":"Missing required parameter.","errors":[{"field":"shipment","message":"cannot be blank"}]}}', $error->getHttpBody()); // phpcs:ignore
 
-            // We check that the pretty printed output is the same here, leave the odd formatting as it is here and do not auto-format the next few lines
+            // We check that the pretty printed output is the same here, leave the odd formatting as
+            // it is here and do not auto-format the next few lines.
             $error->prettyPrint();
             $this->expectOutputString('PARAMETER.REQUIRED (422): Missing required parameter.
 Field errors:

--- a/test/EasyPost/Fixture.php
+++ b/test/EasyPost/Fixture.php
@@ -19,11 +19,13 @@ class Fixture
         return self::readFixtureData()['page_sizes']['five_results'];
     }
 
-    // This is the USPS carrier account ID that comes with your EasyPost account by default and should be used for all tests
+    // This is the USPS carrier account ID that comes with your EasyPost account by
+    // default and should be used for all tests.
     public static function uspsCarrierAccountId()
     {
         // Fallback to the EasyPost PHP Client Library Test User USPS carrier account ID due to strict matching
-        $uspsCarrierAccountId = getenv('USPS_CARRIER_ACCOUNT_ID') !== false ? getenv('USPS_CARRIER_ACCOUNT_ID') : 'ca_8dc116debcdb49b5a66a2ddee4612600';
+        $uspsCarrierAccountId = getenv('USPS_CARRIER_ACCOUNT_ID') !== false
+            ? getenv('USPS_CARRIER_ACCOUNT_ID') : 'ca_8dc116debcdb49b5a66a2ddee4612600';
 
         return $uspsCarrierAccountId;
     }

--- a/test/EasyPost/Mocking/MockingUtility.php
+++ b/test/EasyPost/Mocking/MockingUtility.php
@@ -19,8 +19,10 @@ class MockingUtility
     public function findMatchingMockRequest($method, $url)
     {
         foreach ($this->mockRequests as $mockRequest) {
-            $methodMatches = $mockRequest->matchRule->method === '' || $mockRequest->matchRule->method === $method;
-            $urlMatches = $mockRequest->matchRule->urlRegexPattern == '' || preg_match($mockRequest->matchRule->urlRegexPattern, $url) >= 1;  // limit to exactly one match?
+            $methodMatches = $mockRequest->matchRule->method === ''
+                || $mockRequest->matchRule->method === $method;
+            $urlMatches = $mockRequest->matchRule->urlRegexPattern == ''
+                || preg_match($mockRequest->matchRule->urlRegexPattern, $url) >= 1;  // limit to exactly one match?
             if ($methodMatches && $urlMatches) {
                 return $mockRequest;
             }

--- a/test/EasyPost/ReferralCustomerTest.php
+++ b/test/EasyPost/ReferralCustomerTest.php
@@ -3,8 +3,8 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
-use EasyPost\User;
 use EasyPost\Exception\General\EndOfPaginationException;
+use EasyPost\User;
 use Exception;
 
 class ReferralCustomerTest extends \PHPUnit\Framework\TestCase
@@ -18,9 +18,11 @@ class ReferralCustomerTest extends \PHPUnit\Framework\TestCase
     public static function setUpBeforeClass(): void
     {
         TestUtil::setupVcrTests();
-        $partnerUserProdApiKey = getenv('PARTNER_USER_PROD_API_KEY') !== false ? getenv('PARTNER_USER_PROD_API_KEY') : '123';
+        $partnerUserProdApiKey = getenv('PARTNER_USER_PROD_API_KEY') !== false
+            ? getenv('PARTNER_USER_PROD_API_KEY') : '123';
         self::$client = new EasyPostClient($partnerUserProdApiKey);
-        self::$referralUserProdApiKey = getenv('REFERRAL_USER_PROD_API_KEY') !== false ? getenv('REFERRAL_USER_PROD_API_KEY') : '123';
+        self::$referralUserProdApiKey = getenv('REFERRAL_USER_PROD_API_KEY') !== false
+            ? getenv('REFERRAL_USER_PROD_API_KEY') : '123';
     }
 
     /**
@@ -67,7 +69,7 @@ class ReferralCustomerTest extends \PHPUnit\Framework\TestCase
         $this->assertContainsOnlyInstancesOf(User::class, $referralUsersArray);
     }
 
-        /**
+    /**
      * Test retrieving next page.
      */
     public function testGetNextPage()
@@ -102,7 +104,10 @@ class ReferralCustomerTest extends \PHPUnit\Framework\TestCase
         $referralUsers = self::$client->referralCustomer->all();
 
         try {
-            self::$client->referralCustomer->updateEmail('email@example.com', $referralUsers['referral_customers'][0]['id']);
+            self::$client->referralCustomer->updateEmail(
+                'email@example.com',
+                $referralUsers['referral_customers'][0]['id']
+            );
             $this->assertTrue(true);
         } catch (\Exception $exception) {
             $this->fail('Exception thrown when we expected no error');

--- a/test/EasyPost/RefundTest.php
+++ b/test/EasyPost/RefundTest.php
@@ -3,8 +3,8 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
-use EasyPost\Refund;
 use EasyPost\Exception\General\EndOfPaginationException;
+use EasyPost\Refund;
 use Exception;
 
 class RefundTest extends \PHPUnit\Framework\TestCase
@@ -36,7 +36,8 @@ class RefundTest extends \PHPUnit\Framework\TestCase
         TestUtil::setupCassette('refunds/create.yml');
 
         $shipment = self::$client->shipment->create(Fixture::oneCallBuyShipment());
-        $retrievedShipment = self::$client->shipment->retrieve($shipment->id); // We need to retrieve the shipment so that the tracking_code has time to populate
+        // We need to retrieve the shipment so that the tracking_code has time to populate
+        $retrievedShipment = self::$client->shipment->retrieve($shipment->id);
 
         $refund = self::$client->refund->create([
             'carrier' => Fixture::usps(),

--- a/test/EasyPost/ShipmentTest.php
+++ b/test/EasyPost/ShipmentTest.php
@@ -3,13 +3,13 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
+use EasyPost\Exception\General\EndOfPaginationException;
 use EasyPost\Exception\General\FilteringException;
 use EasyPost\Exception\General\InvalidParameterException;
-use EasyPost\Exception\General\EndOfPaginationException;
-use Exception;
 use EasyPost\Rate;
 use EasyPost\Shipment;
 use EasyPost\Util\Util;
+use Exception;
 
 class ShipmentTest extends \PHPUnit\Framework\TestCase
 {
@@ -375,7 +375,8 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
         $shipment = self::$client->shipment->create(Fixture::fullShipment());
 
-        // Test lowest rate by excluding a carrier (this is a weak test but we cannot assume existence of a non-USPS carrier)
+        // Test lowest rate by excluding a carrier (this is a weak test but we cannot assume existence
+        // of a non-USPS carrier).
         $lowestRate = $shipment->lowestRate(['!RandomCarrier']);
         $this->assertEquals('First', $lowestRate['service']);
         $this->assertEquals('5.82', $lowestRate['rate']);
@@ -418,7 +419,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
             self::$client->shipment->lowestSmartRate($shipment->id, 3, 'BAD_ACCURACY');
         } catch (InvalidParameterException $error) {
             $this->assertEquals(
-                'Invalid delivery_accuracy value, must be one of: ["percentile_50","percentile_75","percentile_85","percentile_90","percentile_95","percentile_97","percentile_99"]',
+                'Invalid delivery_accuracy value, must be one of: ["percentile_50","percentile_75","percentile_85","percentile_90","percentile_95","percentile_97","percentile_99"]', // phpcs:ignore
                 $error->getMessage()
             );
         }
@@ -443,7 +444,10 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
         try {
             Util::getLowestSmartRate($smartRates, 3, 'BAD_ACCURACY');
         } catch (InvalidParameterException $error) {
-            $this->assertEquals('Invalid delivery_accuracy value, must be one of: ["percentile_50","percentile_75","percentile_85","percentile_90","percentile_95","percentile_97","percentile_99"]', $error->getMessage());
+            $this->assertEquals(
+                'Invalid delivery_accuracy value, must be one of: ["percentile_50","percentile_75","percentile_85","percentile_90","percentile_95","percentile_97","percentile_99"]', // phpcs:ignore
+                $error->getMessage()
+            );
         }
     }
 

--- a/test/EasyPost/TestUtil.php
+++ b/test/EasyPost/TestUtil.php
@@ -58,7 +58,7 @@ class TestUtil
             $currentTimestamp = time();
 
             if ($currentTimestamp > $expirationTimestamp) {
-                error_log("$fullCassettePath is older than $expirationDays days and has expired. Please re-record the cassette.");
+                error_log("$fullCassettePath is older than $expirationDays days and has expired. Please re-record the cassette."); // phpcs:ignore
             }
         }
     }

--- a/test/EasyPost/TrackerTest.php
+++ b/test/EasyPost/TrackerTest.php
@@ -3,8 +3,8 @@
 namespace EasyPost\Test;
 
 use EasyPost\EasyPostClient;
-use EasyPost\Tracker;
 use EasyPost\Exception\General\EndOfPaginationException;
+use EasyPost\Tracker;
 use Exception;
 
 class TrackerTest extends \PHPUnit\Framework\TestCase
@@ -69,7 +69,8 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
             'tracking_code' => 'EZ1000000001',
         ]);
 
-        // Test trackers cycle through their "dummy" statuses automatically, the created and retrieved objects may differ
+        // Test trackers cycle through their "dummy" statuses automatically,
+        // the created and retrieved objects may differ.
         $retrievedTracker = self::$client->tracker->retrieve($tracker->id);
 
         $this->assertInstanceOf(Tracker::class, $retrievedTracker);

--- a/test/EasyPost/UserTest.php
+++ b/test/EasyPost/UserTest.php
@@ -42,7 +42,8 @@ class UserTest extends \PHPUnit\Framework\TestCase
         $this->assertStringMatchesFormat('user_%s', $user->id);
         $this->assertEquals('Test User', $user->name);
 
-        self::$client->user->delete($user->id); // Delete the user once done so we don't pollute with hundreds of child users
+        // Delete the user once done so we don't pollute with hundreds of child users
+        self::$client->user->delete($user->id);
     }
 
     /**
@@ -157,7 +158,8 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
         $this->assertContainsOnlyInstancesOf(ApiKey::class, $apiKeys);
 
-        self::$client->user->delete($childUser->id); // Delete the user once done so we don't pollute with hundreds of child users
+        // Delete the user once done so we don't pollute with hundreds of child users
+        self::$client->user->delete($childUser->id);
     }
 
     /**

--- a/test/EasyPost/WebhookTest.php
+++ b/test/EasyPost/WebhookTest.php
@@ -43,7 +43,8 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         $this->assertStringMatchesFormat('hook_%s', $webhook->id);
         $this->assertEquals(Fixture::webhookUrl(), $webhook->url);
 
-        self::$client->webhook->delete($webhook->id); // We are deleting the webhook here so we don't keep sending events to a dead webhook.
+        // We are deleting the webhook here so we don't keep sending events to a dead webhook.
+        self::$client->webhook->delete($webhook->id);
     }
 
     /**
@@ -62,7 +63,8 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(Webhook::class, $retrievedWebhook);
         $this->assertEquals($webhook, $retrievedWebhook);
 
-        self::$client->webhook->delete($retrievedWebhook->id); // We are deleting the webhook here so we don't keep sending events to a dead webhook.
+        // We are deleting the webhook here so we don't keep sending events to a dead webhook.
+        self::$client->webhook->delete($retrievedWebhook->id);
     }
 
     /**
@@ -98,7 +100,8 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         // The response here won't differ since we don't update any data, just check we get the object back
         $this->assertInstanceOf(Webhook::class, $updatedWebhook);
 
-        self::$client->webhook->delete($webhook->id); // We are deleting the webhook here so we don't keep sending events to a dead webhook.
+        // We are deleting the webhook here so we don't keep sending events to a dead webhook.
+        self::$client->webhook->delete($webhook->id);
     }
 
     /**
@@ -150,7 +153,10 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         try {
             Util::validateWebhook(Fixture::eventBytes(), $headers, $webhookSecret);
         } catch (SignatureVerificationException $error) {
-            $this->assertEquals('Webhook received did not originate from EasyPost or had a webhook secret mismatch.', $error->getMessage());
+            $this->assertEquals(
+                'Webhook received did not originate from EasyPost or had a webhook secret mismatch.',
+                $error->getMessage()
+            );
         }
     }
 


### PR DESCRIPTION
# Description

Enforces a line length of 120 chars.

I meant to do this a year ago when we setup our styles but it slipped my mind and I finally had a second to come back to this.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
