### PR TITLE
Fix deprecation warnings for null Exception message

### DIFF
--- a/lib/EasyPost/Exception/Api/ApiException.php
+++ b/lib/EasyPost/Exception/Api/ApiException.php
@@ -25,7 +25,7 @@ class ApiException extends EasyPostException
      * @param int $httpStatus
      * @param string $httpBody
      */
-    public function __construct($message = null, $httpStatus = null, $httpBody = '')
+    public function __construct($message = '', $httpStatus = null, $httpBody = '')
     {
         parent::__construct($message);
         $this->httpStatus = $httpStatus;

--- a/lib/EasyPost/Exception/General/EasyPostException.php
+++ b/lib/EasyPost/Exception/General/EasyPostException.php
@@ -9,7 +9,7 @@ class EasyPostException extends \Exception
      *
      * @param string $message
      */
-    public function __construct($message = null)
+    public function __construct($message = '')
     {
         parent::__construct($message);
     }


### PR DESCRIPTION
Fixes EasyPost/easypost-php#286

# Description
Fixes deprecation warnings when using PHP 8.1. Please see linked issue for details.

> Passing null to non-nullable internal function parameters is deprecated.

Source: https://www.php.net/releases/8.1/en.php

# Testing
No additional testing is required. This does not add any new features or functionality. The existing test suite should catch any problems.

# Pull Request Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
