### PR TITLE
fix: PHP 8.2 coverage on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        # TODO: We are getting segfaults on PHP 8.2 when running the test suite. This needs to be investigated before enabling
-        phpversion: ['7.4', '8.0', '8.1']
+        phpversion: ['7.4', '8.0', '8.1', '8.2']
     steps:
       - uses: actions/checkout@v3
       - name: set up PHP
@@ -44,7 +43,7 @@ jobs:
       - name: install dependencies
         run: make install
       - name: test with phpunit on ${{ matrix.phpversion }}
-        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 make coverage
+        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 make coverage-ci
       - name: Coveralls
         if: github.ref == 'refs/heads/master'
         env:

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ codesniffer-fix:
 coverage:
 	composer coverage
 
+## coverage-ci - Runs the test suite and generates a coverage report (without the HTML report which leads to seg faults on PHP 8.2+)
+coverage-ci:
+	composer coverage-ci
+
 ## docs - Generate documentation for the library
 docs:
 	curl -LJs https://github.com/phpDocumentor/phpDocumentor/releases/latest/download/phpDocumentor.phar -o phpDocumentor.phar
@@ -55,4 +59,4 @@ update-examples-submodule:
 	git submodule init
 	git submodule update --remote
 
-.PHONY: help clean codesniffer codesniffer-fix docs install lint lint-fix release scan test update update-examples-submodule
+.PHONY: help clean codesniffer codesniffer-fix coverage coverage-ci docs install lint lint-fix release scan test update update-examples-submodule

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require-dev": {
     "allejo/php-vcr-sanitizer": "^1.0.9",
     "php-coveralls/php-coveralls": "^2.5",
-    "php-vcr/php-vcr": "1.5.5",
+    "php-vcr/php-vcr": "^1.5.5",
     "phpunit/phpunit": "^9",
     "squizlabs/php_codesniffer": "^3.7",
     "roave/security-advisories": "dev-latest",
@@ -33,6 +33,7 @@
   },
   "scripts": {
     "coverage": "XDEBUG_MODE=coverage ./bin/phpunit --coverage-html clover.html --coverage-clover build/logs/clover.xml && ./bin/coverage-check build/logs/clover.xml 86 --only-percentage",
+    "coverage-ci": "XDEBUG_MODE=coverage ./bin/phpunit --coverage-clover build/logs/clover.xml && ./bin/coverage-check build/logs/clover.xml 86 --only-percentage",
     "fix": "./bin/phpcbf --standard=examples/style_guides/php/phpcs.xml lib test",
     "lint": "./bin/phpcs --standard=examples/style_guides/php/phpcs.xml lib test",
     "scan": "composer update --dry-run roave/security-advisories",

--- a/lib/EasyPost/Exception/Api/ApiException.php
+++ b/lib/EasyPost/Exception/Api/ApiException.php
@@ -25,14 +25,14 @@ class ApiException extends EasyPostException
      * @param int $httpStatus
      * @param string $httpBody
      */
-    public function __construct($message = '', $httpStatus = null, $httpBody = '')
+    public function __construct($message = '', $httpStatus = null, $httpBody = null)
     {
         parent::__construct($message);
         $this->httpStatus = $httpStatus;
         $this->httpBody = $httpBody;
 
         try {
-            $this->jsonBody = json_decode($httpBody, true);
+            $this->jsonBody = isset($httpBody) ? json_decode($httpBody, true) : null;
 
             // Setup `errors` property
             if (isset($this->jsonBody) && !empty($this->jsonBody['error']['errors'])) {

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -4,13 +4,13 @@ use allejo\VCR\VCRCleaner;
 use EasyPost\Util\InternalUtil;
 use VCR\VCR;
 
-const CASSETTE_DIR = 'test/cassettes';
+$cassetteDir = dirname(__FILE__) . '/cassettes';
 
-if (!file_exists(CASSETTE_DIR)) {
-    mkdir(CASSETTE_DIR, 0755, true);
+if (!file_exists($cassetteDir)) {
+    mkdir($cassetteDir, 0755, true);
 }
 
-VCR::configure()->setCassettePath(CASSETTE_DIR)
+VCR::configure()->setCassettePath($cassetteDir)
     ->setStorage('yaml')
     ->setMode('once')
     ->setWhiteList(['vendor/guzzle']);


### PR DESCRIPTION
# Description

- Fixes the segfault issue related to VCR on PHP 8.2 by using an absolute path instead of a relative one
- Loosens the PHP VCR pin to allow the right version to get pulled for PHP 7 and PHP 8
- Fixes a deprecation issue discovered during test runs of null checks for JSON (de)serialization
- Adds a new make target to generate coverage without the HTML report which is part 2 of the segfault issue, will use this on CI only

NOTE: Please do not merge this PR until I return

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Works locally with these changes
<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
