### PR TITLE
feat: adds http request and response hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Adds new `RequestHook` and `ResponseHook` events. (un)subscribe to them with the new `subscribeToRequestHook`, `subscribeToResponseHook`, `unsubscribeFromRequestHook`, or `unsubscribeFromResponseHook` methods of an `EasyPostClient`
+
 ## v6.7.0 (2023-06-06)
 
 - Migrates carrier metadata to GA (now available via `client.carrierMetadata.retrieve`)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,26 @@ $boughtShipment = $client->shipment->buy($shipment->id, $shipment->lowestRate())
 echo $boughtShipment;
 ```
 
+### HTTP Hooks
+
+Users can subscribe to HTTP requests and responses via the `RequestHook` and `ResponseHook` objects. To do so, pass a function to the `subscribeToRequestHook` or `subscribeToResponseHook` methods of an `EasyPostClient` object:
+
+```php
+function customFunction($args)
+{
+    // Pass your code here, data about the request/response is contained within `$args`.
+    echo "Received a request with the status code of: " . $args['http_status'];
+}
+
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
+
+$client->subscribeToResponseHook('customFunction');
+
+// Make your API calls here, your customFunction will trigger once a response is received
+```
+
+You can also unsubscribe your functions in a similar manner by using the `unsubscribeFromRequestHook` and `unsubscribeFromResponseHook` methods of a client object.
+
 ## Documentation
 
 API documentation can be found at: <https://easypost.com/docs/api>.

--- a/lib/EasyPost/EasyPostClient.php
+++ b/lib/EasyPost/EasyPostClient.php
@@ -5,6 +5,8 @@ namespace EasyPost;
 use EasyPost\Constant\Constants;
 use EasyPost\Exception\General\EasyPostException;
 use EasyPost\Exception\General\MissingParameterException;
+use EasyPost\Hook\RequestHook;
+use EasyPost\Hook\ResponseHook;
 use EasyPost\Service\AddressService;
 use EasyPost\Service\BaseService;
 use EasyPost\Service\BatchService;
@@ -65,6 +67,8 @@ class EasyPostClient extends BaseService
     private $timeout;
     private $apiBase;
     private $mockingUtility;
+    public $requestEvent;
+    public $responseEvent;
 
     /**
      * Constructor for an EasyPostClient.
@@ -85,6 +89,8 @@ class EasyPostClient extends BaseService
         $this->timeout = $timeout;
         $this->apiBase = $apiBase;
         $this->mockingUtility = $mockingUtility;
+        $this->requestEvent = new RequestHook();
+        $this->responseEvent = new ResponseHook();
 
         if (!$this->apiKey) {
             throw new MissingParameterException(
@@ -186,5 +192,49 @@ class EasyPostClient extends BaseService
     public function getMockingUtility()
     {
         return $this->mockingUtility;
+    }
+
+    /**
+     * Subscribe functions to run when a request event occurs.
+     *
+     * @param callable $function
+     * @return void
+     */
+    public function subscribeToRequestHook($function)
+    {
+        $this->requestEvent->addHandler($function);
+    }
+
+    /**
+     * Unsubscribe functions from running when a request even occurs.
+     *
+     * @param callable $function
+     * @return void
+     */
+    public function unsubscribeFromRequestHook($function)
+    {
+        $this->requestEvent->removeHandler($function);
+    }
+
+    /**
+     * Subscribe functions to run when a response event occurs.
+     *
+     * @param callable $function
+     * @return void
+     */
+    public function subscribeToResponseHook($function)
+    {
+        $this->responseEvent->addHandler($function);
+    }
+
+    /**
+     * Unsubscribe functions from running when a response even occurs.
+     *
+     * @param callable $function
+     * @return void
+     */
+    public function unsubscribeFromResponseHook($function)
+    {
+        $this->responseEvent->removeHandler($function);
     }
 }

--- a/lib/EasyPost/Hook/EventHook.php
+++ b/lib/EasyPost/Hook/EventHook.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace EasyPost\Hook;
+
+/**
+ * The parent event that occurs when a hook is triggered.
+ */
+class EventHook
+{
+    private $eventHandlers = [];
+
+    public function __invoke(...$args)
+    {
+        foreach ($this->eventHandlers as $eventHandler) {
+            $eventHandler(...$args);
+        }
+    }
+
+    public function addHandler($handler)
+    {
+        $this->eventHandlers[] = $handler;
+        return $this;
+    }
+
+    public function removeHandler($handler)
+    {
+        $index = array_search($handler, $this->eventHandlers, true);
+        if ($index !== false) {
+            array_splice($this->eventHandlers, $index, 1);
+        }
+        return $this;
+    }
+}

--- a/lib/EasyPost/Hook/RequestHook.php
+++ b/lib/EasyPost/Hook/RequestHook.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace EasyPost\Hook;
+
+/**
+ * An event that gets triggered when an HTTP request begins.
+ */
+class RequestHook extends EventHook
+{
+}

--- a/lib/EasyPost/Hook/ResponseHook.php
+++ b/lib/EasyPost/Hook/ResponseHook.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace EasyPost\Hook;
+
+/**
+ * An event that gets triggered when an HTTP response is returned.
+ */
+class ResponseHook extends EventHook
+{
+}

--- a/test/EasyPost/HookTest.php
+++ b/test/EasyPost/HookTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace EasyPost\Test;
+
+use DateTime;
+use EasyPost\EasyPostClient;
+
+class HookTest extends \PHPUnit\Framework\TestCase
+{
+    private static $client;
+
+    /**
+     * Setup the testing environment for this file.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        TestUtil::setupVcrTests();
+        self::$client = new EasyPostClient(getenv('EASYPOST_TEST_API_KEY'));
+    }
+
+    /**
+     * Cleanup the testing environment once finished.
+     */
+    public static function tearDownAfterClass(): void
+    {
+        TestUtil::teardownVcrTests();
+    }
+
+    /**
+     * Make assertions about a request once the RequestHook fires.
+     */
+    public function requestTest($args)
+    {
+        $this->assertEquals('post', $args['method']);
+        $this->assertEquals('https://api.easypost.com/v2/parcels', $args['path']);
+        $this->assertArrayHasKey('parcel', $args['request_body']);
+        $this->assertArrayHasKey('Authorization', $args['headers']);
+        $this->assertIsFloat($args['request_timestamp']);
+        $this->assertEquals(13, strlen($args['request_uuid']));
+    }
+
+    /**
+     * Test that we fire a RequestHook prior to making an HTTP request.
+     */
+    public function testRequestHooks()
+    {
+        TestUtil::setupCassette('hooks/request.yml');
+
+        self::$client->subscribeToRequestHook([$this, 'requestTest']);
+        self::$client->parcel->create(Fixture::basicParcel());
+    }
+
+    /**
+     * Make assertions about a response once the ResponseHook fires.
+     */
+    public function responseTest($args)
+    {
+        $this->assertEquals(201, $args['http_status']);
+        $this->assertEquals('post', $args['method']);
+        $this->assertEquals('https://api.easypost.com/v2/parcels', $args['path']);
+        $this->assertNotNull(json_decode($args['response_body'], true)['object']);
+        $this->assertArrayHasKey('location', $args['headers']);
+        $this->assertTrue($args['response_timestamp'] > $args['request_timestamp']);
+        $this->assertEquals(13, strlen($args['request_uuid']));
+    }
+
+    /**
+     * Test that we fire a ResponseHook after receiving an HTTP response.
+     */
+    public function testResponseHooks()
+    {
+        TestUtil::setupCassette('hooks/response.yml');
+
+        self::$client->subscribeToResponseHook([$this, 'responseTest']);
+        self::$client->parcel->create(Fixture::basicParcel());
+    }
+
+    /**
+     * This function should never run since we unsubscribe from HTTP hooks.
+     */
+    public function failIfSubscribed()
+    {
+        throw new \Exception('Unsubscribing from HTTP hooks did not work as intended');
+    }
+
+    /**
+     * Test that we do not fire a hook once unsubscribed.
+     */
+    public function testUnsubscribeHooks()
+    {
+        TestUtil::setupCassette('hooks/unsubscribe.yml');
+
+        self::$client->subscribeToRequestHook([$this, 'failIfSubscribed']);
+        self::$client->unsubscribeFromRequestHook([$this, 'failIfSubscribed']);
+
+        self::$client->subscribeToResponseHook([$this, 'failIfSubscribed']);
+        self::$client->unsubscribeFromResponseHook([$this, 'failIfSubscribed']);
+
+        self::$client->parcel->create(Fixture::basicParcel());
+    }
+}

--- a/test/cassettes/hooks/request.yml
+++ b/test/cassettes/hooks/request.yml
@@ -1,0 +1,80 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/parcels'
+        headers:
+            Host: api.easypost.com
+            Expect: ''
+            Accept-Encoding: ''
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+        body: '{"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"}}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: ee62ddf764b59c0fe786af580008ba1d
+            cache-control: 'private, no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            location: /api/v2/parcels/prcl_ccad177f02fc45068e69c6ecbc013117
+            content-type: 'application/json; charset=utf-8'
+            content-length: '229'
+            etag: 'W/"bc63a946874d04a690eab4ca9267d255"'
+            x-runtime: '0.033862'
+            x-node: bigweb35nuq
+            x-version-label: easypost-202307171853-dc771c9740-master
+            x-backend: easypost
+            x-proxied: ['intlb1nuq d3d339cca1', 'extlb1nuq 003ad9bca0']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"prcl_ccad177f02fc45068e69c6ecbc013117","object":"Parcel","created_at":"2023-07-17T19:52:47Z","updated_at":"2023-07-17T19:52:47Z","length":10,"width":8,"height":4,"predefined_package":null,"weight":15.4,"mode":"test"}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/parcels'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 802
+            request_size: 372
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.268795
+            namelookup_time: 0.027269
+            connect_time: 0.092959
+            pretransfer_time: 0.16778
+            size_upload: 67.0
+            size_download: 229.0
+            speed_download: 851.0
+            speed_upload: 249.0
+            download_content_length: 229.0
+            upload_content_length: 67.0
+            starttransfer_time: 0.26877
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.21
+            local_port: 50303
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 167590
+            connect_time_us: 92959
+            namelookup_time_us: 27269
+            pretransfer_time_us: 167780
+            redirect_time_us: 0
+            starttransfer_time_us: 268770
+            total_time_us: 268795
+    index: 0

--- a/test/cassettes/hooks/response.yml
+++ b/test/cassettes/hooks/response.yml
@@ -1,0 +1,80 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/parcels'
+        headers:
+            Host: api.easypost.com
+            Expect: ''
+            Accept-Encoding: ''
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+        body: '{"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"}}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: b3cd144d64b5b8ede78744c500090e46
+            cache-control: 'private, no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            location: /api/v2/parcels/prcl_3bdeef98212f4c688f4573ffe7387c86
+            content-type: 'application/json; charset=utf-8'
+            content-length: '229'
+            etag: 'W/"5b85adc4b0a5b56efcc046a6bb6a6a3b"'
+            x-runtime: '0.030570'
+            x-node: bigweb33nuq
+            x-version-label: easypost-202307171853-dc771c9740-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq d3d339cca1', 'extlb1nuq 003ad9bca0']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"prcl_3bdeef98212f4c688f4573ffe7387c86","object":"Parcel","created_at":"2023-07-17T21:55:57Z","updated_at":"2023-07-17T21:55:57Z","length":10,"width":8,"height":4,"predefined_package":null,"weight":15.4,"mode":"test"}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/parcels'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 802
+            request_size: 372
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.267908
+            namelookup_time: 0.024585
+            connect_time: 0.090121
+            pretransfer_time: 0.164313
+            size_upload: 67.0
+            size_download: 229.0
+            speed_download: 854.0
+            speed_upload: 250.0
+            download_content_length: 229.0
+            upload_content_length: 67.0
+            starttransfer_time: 0.267878
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.21
+            local_port: 51549
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 164238
+            connect_time_us: 90121
+            namelookup_time_us: 24585
+            pretransfer_time_us: 164313
+            redirect_time_us: 0
+            starttransfer_time_us: 267878
+            total_time_us: 267908
+    index: 0

--- a/test/cassettes/hooks/unsubscribe.yml
+++ b/test/cassettes/hooks/unsubscribe.yml
@@ -1,0 +1,80 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/parcels'
+        headers:
+            Host: api.easypost.com
+            Expect: ''
+            Accept-Encoding: ''
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+        body: '{"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"}}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: b3cd144664b5bc35e787491f000a4b3c
+            cache-control: 'private, no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            location: /api/v2/parcels/prcl_7bf97ae17e2747b3859e04e66e2a82de
+            content-type: 'application/json; charset=utf-8'
+            content-length: '229'
+            etag: 'W/"8c8bece41db46a819578bbde476b33a3"'
+            x-runtime: '0.028149'
+            x-node: bigweb12nuq
+            x-version-label: easypost-202307171853-dc771c9740-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq d3d339cca1', 'extlb1nuq 003ad9bca0']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"id":"prcl_7bf97ae17e2747b3859e04e66e2a82de","object":"Parcel","created_at":"2023-07-17T22:09:57Z","updated_at":"2023-07-17T22:09:57Z","length":10,"width":8,"height":4,"predefined_package":null,"weight":15.4,"mode":"test"}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/parcels'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 201
+            header_size: 802
+            request_size: 372
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.255241
+            namelookup_time: 0.024673
+            connect_time: 0.090139
+            pretransfer_time: 0.159333
+            size_upload: 67.0
+            size_download: 229.0
+            speed_download: 897.0
+            speed_upload: 262.0
+            download_content_length: 229.0
+            upload_content_length: 67.0
+            starttransfer_time: 0.255213
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 10.130.6.21
+            local_port: 51651
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 159301
+            connect_time_us: 90139
+            namelookup_time_us: 24673
+            pretransfer_time_us: 159333
+            redirect_time_us: 0
+            starttransfer_time_us: 255213
+            total_time_us: 255241
+    index: 0


### PR DESCRIPTION
# Description

- Adds new `RequestHook` and `ResponseHook` events. (un)subscribe to them with the new `subscribeToRequestHook`, `subscribeToResponseHook`, `unsubscribeFromRequestHook`, or `unsubscribeFromResponseHook` methods of an `EasyPostClient`
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Adds a new set of tests that subscribe to the hooks and assert details only exposed via the hooks (not the traditional deserialized objects)

Adds a test to ensure that unsubscribing works as intended (will raise an exception if still subscribed), A/B tested this to ensure it works.
<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
