### PR TITLE
fix: coverage generation with PHP 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        phpversion: ['7.4', '8.0', '8.1', '8.2']
+        # 8.2.9+ is needed due to segfaults on 8.2-8.2.8 when generating coverage: https://github.com/php-vcr/php-vcr/issues/373
+        phpversion: ['7.4', '8.0', '8.1', '8.2.9']
     steps:
       - uses: actions/checkout@v3
       - name: set up PHP
@@ -43,7 +44,7 @@ jobs:
       - name: install dependencies
         run: make install
       - name: test with phpunit on ${{ matrix.phpversion }}
-        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 make coverage-ci
+        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 make coverage
       - name: Coveralls
         if: github.ref == 'refs/heads/master'
         env:

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,6 @@ codesniffer-fix:
 coverage:
 	composer coverage
 
-## coverage-ci - Runs the test suite and generates a coverage report (without the HTML report which leads to seg faults on PHP 8.2+)
-coverage-ci:
-	composer coverage-ci
-
 ## docs - Generate documentation for the library
 docs:
 	curl -LJs https://github.com/phpDocumentor/phpDocumentor/releases/latest/download/phpDocumentor.phar -o phpDocumentor.phar
@@ -59,4 +55,4 @@ update-examples-submodule:
 	git submodule init
 	git submodule update --remote
 
-.PHONY: help clean codesniffer codesniffer-fix coverage coverage-ci docs install lint lint-fix release scan test update update-examples-submodule
+.PHONY: help clean codesniffer codesniffer-fix coverage docs install lint lint-fix release scan test update update-examples-submodule

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ make lint-fix
 EASYPOST_TEST_API_KEY=123... EASYPOST_PROD_API_KEY=123... make test
 
 # Generate coverage reports (requires Xdebug for HTML report)
+# NOTE: When using PHP 8.2, you must use 8.2.9+ to avoid segfaults when generating coverage
 EASYPOST_TEST_API_KEY=123... EASYPOST_PROD_API_KEY=123... make coverage
 
 # Run security analysis

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
   },
   "scripts": {
     "coverage": "XDEBUG_MODE=coverage ./bin/phpunit --coverage-html clover.html --coverage-clover build/logs/clover.xml && ./bin/coverage-check build/logs/clover.xml 86 --only-percentage",
-    "coverage-ci": "XDEBUG_MODE=coverage ./bin/phpunit --coverage-clover build/logs/clover.xml && ./bin/coverage-check build/logs/clover.xml 86 --only-percentage",
     "fix": "./bin/phpcbf --standard=examples/style_guides/php/phpcs.xml lib test",
     "lint": "./bin/phpcs --standard=examples/style_guides/php/phpcs.xml lib test",
     "scan": "composer update --dry-run roave/security-advisories",


### PR DESCRIPTION
# Description

Fixes coverage by ensuring we use PHP 8.2.9 for the 8.2 branch which corrects the previous segfaults.

See https://github.com/php-vcr/php-vcr/issues/373 for more details.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
