### PR TITLE
[fix] FedEx Smartpost hits register endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Fix endpoint for creating a FedEx Smartpost carrier account
+
 ## v6.8.0 (2023-07-28)
 
 - Adds new `RequestHook` and `ResponseHook` events. (un)subscribe to them with the new `subscribeToRequestHook`, `subscribeToResponseHook`, `unsubscribeFromRequestHook`, or `unsubscribeFromResponseHook` methods of an `EasyPostClient`

--- a/lib/EasyPost/Constant/Constants.php
+++ b/lib/EasyPost/Constant/Constants.php
@@ -17,7 +17,8 @@ abstract class Constants
     // Validation
     const CARRIER_ACCOUNT_TYPES_WITH_CUSTOM_WORKFLOWS = [
         'FedexAccount',
-        'UpsAccount'
+        'UpsAccount',
+        'FedexSmartpostAccount'
     ];
 
     // Exception messages (many of these are intended to be used with `sprintf()`)


### PR DESCRIPTION
# Description

- FedEx SmartPost carrier account registration should hit `/register` endpoint for creation

# Testing

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
