### PR TITLE
fix: reset timezone to original (closes #310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 - Migrate API Key-related functions from `user` service to `api_keys` service
+- Fixes a bug that changed the timezone to UTC on each request without resetting it to the original timezone in use (closes #310)
 
 ## v6.8.1 (2023-09-05)
 

--- a/lib/EasyPost/Http/Requestor.php
+++ b/lib/EasyPost/Http/Requestor.php
@@ -183,6 +183,7 @@ class Requestor
         ];
 
         $requestUuid = uniqid();
+        $originalTimezone = date_default_timezone_get();
         date_default_timezone_set('UTC');
         $requestTimestamp = microtime(true);
         ($client->requestEvent)([
@@ -236,6 +237,9 @@ class Requestor
             'response_timestamp' => $responseTimestamp,
             'request_uuid' => $requestUuid,
         ]);
+
+        // Reset the timezone after we've done our UTC calculations so we don't affect user code
+        date_default_timezone_set($originalTimezone);
 
         return [$responseBody, $httpStatus];
     }


### PR DESCRIPTION
# Description

- Fixes a bug that changed the timezone to UTC on each request without resetting it to the original timezone in use (closes #310)
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Ran these added commands in the repl to make sure these work as expected.

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
