### PR TITLE
fix: UTC timezone bug for request/response timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v6.9.1 (2023-11-20)
+
+- Fixes a bug that globally reset the timezone to UTC instead of setting the timezone per-request (closes #310)
+
 ## v6.9.0 (2023-10-11)
 
 - Deprecates API key-related functions in the `user` service and introduces the replacement functions in the `api_keys` service

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "easypost/easypost-php",
   "description": "EasyPost Shipping API Client Library for PHP",
-  "version": "6.9.0",
+  "version": "6.9.1",
   "keywords": [
     "shipping",
     "api",

--- a/lib/EasyPost/Constant/Constants.php
+++ b/lib/EasyPost/Constant/Constants.php
@@ -11,7 +11,7 @@ abstract class Constants
     const BETA_API_VERSION = 'beta';
 
     // Library constants
-    const LIBRARY_VERSION = '6.9.0';
+    const LIBRARY_VERSION = '6.9.1';
     const SUPPORT_EMAIL = 'support@easypost.com';
 
     // Validation

--- a/lib/EasyPost/Http/Requestor.php
+++ b/lib/EasyPost/Http/Requestor.php
@@ -183,9 +183,7 @@ class Requestor
         ];
 
         $requestUuid = uniqid();
-        $originalTimezone = date_default_timezone_get();
-        date_default_timezone_set('UTC');
-        $requestTimestamp = microtime(true);
+        $requestTimestamp = (float) (new DateTime('now', new DateTimeZone('UTC')))->format('U.u');
         ($client->requestEvent)([
             'method' => $method,
             'path' => $absoluteUrl,
@@ -226,7 +224,7 @@ class Requestor
             $responseHeaders = $response->getHeaders();
         }
 
-        $responseTimestamp = microtime(true);
+        $responseTimestamp = (float) (new DateTime('now', new DateTimeZone('UTC')))->format('U.u');
         ($client->responseEvent)([
             'http_status' => $httpStatus,
             'method' => $method,
@@ -237,9 +235,6 @@ class Requestor
             'response_timestamp' => $responseTimestamp,
             'request_uuid' => $requestUuid,
         ]);
-
-        // Reset the timezone after we've done our UTC calculations so we don't affect user code
-        date_default_timezone_set($originalTimezone);
 
         return [$responseBody, $httpStatus];
     }


### PR DESCRIPTION
# Description

Fixes a bug that globally reset the timezone to UTC instead of setting the timezone per-request (closes #310)
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Tests worked great in catching a bug for conversion. Corrected and all green.

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
