### PR TITLE
chore: overhaul version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: set up PHP
@@ -20,10 +20,10 @@ jobs:
       - name: lint
         run: make lint
   run-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        phpversion: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        phpversion: ['8.0', '8.1', '8.2', '8.3']
     steps:
       - uses: actions/checkout@v3
       - name: set up PHP
@@ -51,7 +51,7 @@ jobs:
         run: ./bin/php-coveralls --coverage_clover=build/logs/clover.xml -v
   docs:
     if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
       - name: install dependencies
         run: make install
       - name: lint
@@ -23,8 +23,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        # 8.2.9+ is needed due to segfaults on 8.2-8.2.8 when generating coverage: https://github.com/php-vcr/php-vcr/issues/373
-        phpversion: ['7.4', '8.0', '8.1', '8.2.9']
+        phpversion: ['7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
       - uses: actions/checkout@v3
       - name: set up PHP
@@ -59,7 +58,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
       - name: Install Dependencies
         run: make install
       - name: Generate Docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: set up PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -25,7 +25,7 @@ jobs:
       matrix:
         phpversion: ['8.0', '8.1', '8.2', '8.3']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: set up PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Major Release
 
+- Drops support for PHP 7.4
+- Adds support for PHP 8.3
 - Removed `withCarbonOffset` parameter from `create`, `buy`, and `regenerateRates` functions of the Shipment service as EasyPost now offers Carbon Neutral shipments by default for free
 - Fixes a bug where the original filtering criteria of `all` calls wasn't passed along to `getNextPage` calls. Now, these are persisted via a `_params` key on response objects locally
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ For additional support, see our [org-wide support policy](https://github.com/Eas
 
 ## Development
 
-**NOTE:** Recording VCR cassettes only works with PHP 7.4. Once recorded, tests can be run on PHP 7.4 or 8.0+.
-
 ```bash
 # Install dependencies
 make install

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require-dev": {
     "allejo/php-vcr-sanitizer": "^1.0.9",
     "php-coveralls/php-coveralls": "^2.5",
-    "php-vcr/php-vcr": "1.6.7",
+    "php-vcr/php-vcr": "^1.6",
     "phpunit/phpunit": "^9",
     "squizlabs/php_codesniffer": "^3.7",
     "roave/security-advisories": "dev-latest",

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
   ],
   "require": {
     "ext-json": "*",
-    "php": ">=7.4",
+    "php": ">=8.0",
     "guzzlehttp/guzzle": "^7.5"
   },
   "require-dev": {
     "allejo/php-vcr-sanitizer": "^1.0.9",
     "php-coveralls/php-coveralls": "^2.5",
-    "php-vcr/php-vcr": "^1.5.5",
+    "php-vcr/php-vcr": "1.6.7",
     "phpunit/phpunit": "^9",
     "squizlabs/php_codesniffer": "^3.7",
     "roave/security-advisories": "dev-latest",

--- a/test/cassettes/addresses/all.yml
+++ b/test/cassettes/addresses/all.yml
@@ -21,14 +21,14 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 95a969b26565065fe788f2a800379bc1
+            x-ep-request-uuid: ae35d0b6656641d7e7886e4700175c10
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '3082'
-            x-runtime: '0.052928'
-            x-node: bigweb33nuq
+            x-runtime: '0.040093'
+            x-node: bigweb42nuq
             x-version-label: easypost-202311250013-a0f06fbc2c-master
             x-backend: easypost
             x-proxied: ['intlb1nuq b3de2c47ef', 'extlb2nuq 003ad9bca0']
@@ -43,35 +43,35 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.282621
-            namelookup_time: 0.031916
-            connect_time: 0.094843
-            pretransfer_time: 0.164349
+            total_time: 0.272734
+            namelookup_time: 0.026269
+            connect_time: 0.097831
+            pretransfer_time: 0.166536
             size_upload: 0.0
             size_download: 3082.0
-            speed_download: 10905.0
+            speed_download: 11300.0
             speed_upload: 0.0
             download_content_length: 3082.0
             upload_content_length: 0.0
-            starttransfer_time: 0.282573
+            starttransfer_time: 0.272649
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.31
-            local_port: 54765
+            local_ip: 10.130.6.21
+            local_port: 53927
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 164284
-            connect_time_us: 94843
-            namelookup_time_us: 31916
-            pretransfer_time_us: 164349
+            appconnect_time_us: 166507
+            connect_time_us: 97831
+            namelookup_time_us: 26269
+            pretransfer_time_us: 166536
             redirect_time_us: 0
-            starttransfer_time_us: 282573
-            total_time_us: 282621
+            starttransfer_time_us: 272649
+            total_time_us: 272734
             effective_method: GET
             capath: ''
             cainfo: ''

--- a/test/cassettes/addresses/all.yml
+++ b/test/cassettes/addresses/all.yml
@@ -12,8 +12,7 @@
             User-Agent: ''
     response:
         status:
-            http_version: '1.1'
-            code: '200'
+            code: 200
             message: OK
         headers:
             x-frame-options: SAMEORIGIN
@@ -22,11 +21,16 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
+<<<<<<< HEAD
             x-ep-request-uuid: 71ef911b655e64afe7885564001f877f
+=======
+            x-ep-request-uuid: 0610ca3a6564fff8e788dd610030900c
+>>>>>>> a503ce9 (!chore: drop support for PHP 7.4)
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
+<<<<<<< HEAD
             content-length: '3080'
             x-runtime: '0.035116'
             x-node: bigweb38nuq
@@ -35,11 +39,22 @@
             x-proxied: ['intlb2nuq b3de2c47ef', 'extlb2nuq 003ad9bca0']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
         body: '{"addresses":[{"id":"adr_d9f77023897511eeba1eac1f6bc53342","object":"Address","created_at":"2023-11-22T20:29:35+00:00","updated_at":"2023-11-22T20:29:35+00:00","name":null,"company":"EASYPOST","street1":"417 MONTGOMERY ST FL 5","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94104-1129","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_d9ceb38b897511eeba09ac1f6bc53342","object":"Address","created_at":"2023-11-22T20:29:35+00:00","updated_at":"2023-11-22T20:29:35+00:00","name":"Jack Sparrow","company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":[]},{"id":"adr_d9aa6ac2897511eeb9f5ac1f6bc53342","object":"Address","created_at":"2023-11-22T20:29:35+00:00","updated_at":"2023-11-22T20:29:35+00:00","name":null,"company":"EASYPOST","street1":"417 MONTGOMERY ST FL 5","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94104-1129","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_d98074de897511eea9cbac1f6bc539aa","object":"Address","created_at":"2023-11-22T20:29:34+00:00","updated_at":"2023-11-22T20:29:34+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_d9538a21897511eea9b0ac1f6bc539aa","object":"Address","created_at":"2023-11-22T20:29:34+00:00","updated_at":"2023-11-22T20:29:34+00:00","name":null,"company":"EASYPOST","street1":"417 MONTGOMERY ST FL 5","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94104-1129","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America\/Los_Angeles"}}}}],"has_more":true}'
+=======
+            content-length: '3082'
+            x-runtime: '0.043249'
+            x-node: bigweb34nuq
+            x-version-label: easypost-202311250013-a0f06fbc2c-master
+            x-backend: easypost
+            x-proxied: ['intlb2nuq b3de2c47ef', 'extlb1nuq 003ad9bca0']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"addresses":[{"id":"adr_664b3834897e11ee97edac1f6bc539aa","object":"Address","created_at":"2023-11-22T21:30:47+00:00","updated_at":"2023-11-22T21:30:47+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_66464b3b897e11eea668ac1f6bc53342","object":"Address","created_at":"2023-11-22T21:30:46+00:00","updated_at":"2023-11-22T21:30:46+00:00","name":"ELIZABETH SWAN","company":null,"street1":"179 N HARBOR DR","street2":null,"city":"REDONDO BEACH","state":"CA","zip":"90277-2506","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":33.8436,"longitude":-118.39177,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_656e3fc6897e11eea5eaac1f6bc53342","object":"Address","created_at":"2023-11-22T21:30:45+00:00","updated_at":"2023-11-22T21:30:45+00:00","name":"Elizabeth Swan","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo Beach","state":"CA","zip":"90277","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":[]},{"id":"adr_656a6a19897e11ee976dac1f6bc539aa","object":"Address","created_at":"2023-11-22T21:30:45+00:00","updated_at":"2023-11-22T21:30:45+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_0f6a4181897e11ee8a77ac1f6bc539ae","object":"Address","created_at":"2023-11-22T21:28:21+00:00","updated_at":"2023-11-22T21:28:21+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}}],"has_more":true}'
+>>>>>>> a503ce9 (!chore: drop support for PHP 7.4)
         curl_info:
             url: 'https://api.easypost.com/v2/addresses?page_size=5'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 689
+<<<<<<< HEAD
             request_size: 298
             filetime: -1
             ssl_verify_result: 0
@@ -55,17 +70,40 @@
             download_content_length: 3080.0
             upload_content_length: 0.0
             starttransfer_time: 0.226078
+=======
+            request_size: 297
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.274239
+            namelookup_time: 0.031873
+            connect_time: 0.095498
+            pretransfer_time: 0.161835
+            size_upload: 0.0
+            size_download: 3082.0
+            speed_download: 11238.0
+            speed_upload: 0.0
+            download_content_length: 3082.0
+            upload_content_length: 0.0
+            starttransfer_time: 0.274197
+>>>>>>> a503ce9 (!chore: drop support for PHP 7.4)
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
+<<<<<<< HEAD
             local_ip: 10.130.6.39
             local_port: 53375
+=======
+            local_ip: 10.130.6.31
+            local_port: 54263
+>>>>>>> a503ce9 (!chore: drop support for PHP 7.4)
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
+<<<<<<< HEAD
             appconnect_time_us: 127345
             connect_time_us: 63404
             namelookup_time_us: 1123
@@ -73,4 +111,16 @@
             redirect_time_us: 0
             starttransfer_time_us: 226078
             total_time_us: 226097
+=======
+            appconnect_time_us: 161785
+            connect_time_us: 95498
+            namelookup_time_us: 31873
+            pretransfer_time_us: 161835
+            redirect_time_us: 0
+            starttransfer_time_us: 274197
+            total_time_us: 274239
+            effective_method: GET
+            capath: ''
+            cainfo: ''
+>>>>>>> a503ce9 (!chore: drop support for PHP 7.4)
     index: 0

--- a/test/cassettes/addresses/all.yml
+++ b/test/cassettes/addresses/all.yml
@@ -21,106 +21,58 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-<<<<<<< HEAD
-            x-ep-request-uuid: 71ef911b655e64afe7885564001f877f
-=======
-            x-ep-request-uuid: 0610ca3a6564fff8e788dd610030900c
->>>>>>> a503ce9 (!chore: drop support for PHP 7.4)
+            x-ep-request-uuid: 95a969b26565065fe788f2a800379bc1
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
-<<<<<<< HEAD
-            content-length: '3080'
-            x-runtime: '0.035116'
-            x-node: bigweb38nuq
-            x-version-label: easypost-202311212221-a0f06fbc2c-master
-            x-backend: easypost
-            x-proxied: ['intlb2nuq b3de2c47ef', 'extlb2nuq 003ad9bca0']
-            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
-        body: '{"addresses":[{"id":"adr_d9f77023897511eeba1eac1f6bc53342","object":"Address","created_at":"2023-11-22T20:29:35+00:00","updated_at":"2023-11-22T20:29:35+00:00","name":null,"company":"EASYPOST","street1":"417 MONTGOMERY ST FL 5","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94104-1129","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_d9ceb38b897511eeba09ac1f6bc53342","object":"Address","created_at":"2023-11-22T20:29:35+00:00","updated_at":"2023-11-22T20:29:35+00:00","name":"Jack Sparrow","company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":[]},{"id":"adr_d9aa6ac2897511eeb9f5ac1f6bc53342","object":"Address","created_at":"2023-11-22T20:29:35+00:00","updated_at":"2023-11-22T20:29:35+00:00","name":null,"company":"EASYPOST","street1":"417 MONTGOMERY ST FL 5","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94104-1129","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_d98074de897511eea9cbac1f6bc539aa","object":"Address","created_at":"2023-11-22T20:29:34+00:00","updated_at":"2023-11-22T20:29:34+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_d9538a21897511eea9b0ac1f6bc539aa","object":"Address","created_at":"2023-11-22T20:29:34+00:00","updated_at":"2023-11-22T20:29:34+00:00","name":null,"company":"EASYPOST","street1":"417 MONTGOMERY ST FL 5","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94104-1129","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America\/Los_Angeles"}}}}],"has_more":true}'
-=======
             content-length: '3082'
-            x-runtime: '0.043249'
-            x-node: bigweb34nuq
+            x-runtime: '0.052928'
+            x-node: bigweb33nuq
             x-version-label: easypost-202311250013-a0f06fbc2c-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq b3de2c47ef', 'extlb1nuq 003ad9bca0']
+            x-proxied: ['intlb1nuq b3de2c47ef', 'extlb2nuq 003ad9bca0']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
         body: '{"addresses":[{"id":"adr_664b3834897e11ee97edac1f6bc539aa","object":"Address","created_at":"2023-11-22T21:30:47+00:00","updated_at":"2023-11-22T21:30:47+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_66464b3b897e11eea668ac1f6bc53342","object":"Address","created_at":"2023-11-22T21:30:46+00:00","updated_at":"2023-11-22T21:30:46+00:00","name":"ELIZABETH SWAN","company":null,"street1":"179 N HARBOR DR","street2":null,"city":"REDONDO BEACH","state":"CA","zip":"90277-2506","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":33.8436,"longitude":-118.39177,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_656e3fc6897e11eea5eaac1f6bc53342","object":"Address","created_at":"2023-11-22T21:30:45+00:00","updated_at":"2023-11-22T21:30:45+00:00","name":"Elizabeth Swan","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo Beach","state":"CA","zip":"90277","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":[]},{"id":"adr_656a6a19897e11ee976dac1f6bc539aa","object":"Address","created_at":"2023-11-22T21:30:45+00:00","updated_at":"2023-11-22T21:30:45+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_0f6a4181897e11ee8a77ac1f6bc539ae","object":"Address","created_at":"2023-11-22T21:28:21+00:00","updated_at":"2023-11-22T21:28:21+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}}],"has_more":true}'
->>>>>>> a503ce9 (!chore: drop support for PHP 7.4)
         curl_info:
             url: 'https://api.easypost.com/v2/addresses?page_size=5'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 689
-<<<<<<< HEAD
-            request_size: 298
-            filetime: -1
-            ssl_verify_result: 0
-            redirect_count: 0
-            total_time: 0.226097
-            namelookup_time: 0.001123
-            connect_time: 0.063404
-            pretransfer_time: 0.127376
-            size_upload: 0.0
-            size_download: 3080.0
-            speed_download: 13622.0
-            speed_upload: 0.0
-            download_content_length: 3080.0
-            upload_content_length: 0.0
-            starttransfer_time: 0.226078
-=======
             request_size: 297
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.274239
-            namelookup_time: 0.031873
-            connect_time: 0.095498
-            pretransfer_time: 0.161835
+            total_time: 0.282621
+            namelookup_time: 0.031916
+            connect_time: 0.094843
+            pretransfer_time: 0.164349
             size_upload: 0.0
             size_download: 3082.0
-            speed_download: 11238.0
+            speed_download: 10905.0
             speed_upload: 0.0
             download_content_length: 3082.0
             upload_content_length: 0.0
-            starttransfer_time: 0.274197
->>>>>>> a503ce9 (!chore: drop support for PHP 7.4)
+            starttransfer_time: 0.282573
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-<<<<<<< HEAD
-            local_ip: 10.130.6.39
-            local_port: 53375
-=======
             local_ip: 10.130.6.31
-            local_port: 54263
->>>>>>> a503ce9 (!chore: drop support for PHP 7.4)
+            local_port: 54765
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-<<<<<<< HEAD
-            appconnect_time_us: 127345
-            connect_time_us: 63404
-            namelookup_time_us: 1123
-            pretransfer_time_us: 127376
+            appconnect_time_us: 164284
+            connect_time_us: 94843
+            namelookup_time_us: 31916
+            pretransfer_time_us: 164349
             redirect_time_us: 0
-            starttransfer_time_us: 226078
-            total_time_us: 226097
-=======
-            appconnect_time_us: 161785
-            connect_time_us: 95498
-            namelookup_time_us: 31873
-            pretransfer_time_us: 161835
-            redirect_time_us: 0
-            starttransfer_time_us: 274197
-            total_time_us: 274239
+            starttransfer_time_us: 282573
+            total_time_us: 282621
             effective_method: GET
             capath: ''
             cainfo: ''
->>>>>>> a503ce9 (!chore: drop support for PHP 7.4)
     index: 0


### PR DESCRIPTION
# Description

PHP 7.4 has been dead for 2 years and 8.0 is also EOL. Keeping with our policy to include only the most recently deprecated version, this drops support for PHP 7.4 and adds support for the just released 8.3. This also allows us to finally upgrade PHP VCR which now allows cassettes to be recorded with any supported PHP version (previously you could only record on 7.4 but replay on any version).

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- Re-recorded a cassette to ensure VCR works
- Tested on every supported PHP version

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
