### PR TITLE
feat: persist the HTTP client inside of EasyPostClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Drops support for PHP 7.4
 - Adds support for PHP 8.3
+- Persists the HTTP client inside of the `EasyPostClient` via the `httpClient` property to reduce memory consumption on consecutive requests
 - Removed `withCarbonOffset` parameter from `create`, `buy`, and `regenerateRates` functions of the Shipment service as EasyPost now offers Carbon Neutral shipments by default for free
 - Fixes a bug where the original filtering criteria of `all` calls wasn't passed along to `getNextPage` calls. Now, these are persisted via a `_params` key on response objects locally
 - Removes the undocumented `createAndBuy` function from the `Batch` service. The proper usage is to create a batch first and buy it separately

--- a/lib/EasyPost/EasyPostClient.php
+++ b/lib/EasyPost/EasyPostClient.php
@@ -33,6 +33,7 @@ use EasyPost\Service\ShipmentService;
 use EasyPost\Service\TrackerService;
 use EasyPost\Service\UserService;
 use EasyPost\Service\WebhookService;
+use GuzzleHttp\Client;
 
 /**
  * Client used to send requests to the EasyPost API.
@@ -71,6 +72,7 @@ class EasyPostClient extends BaseService
     private $mockingUtility;
     public $requestEvent;
     public $responseEvent;
+    public $httpClient;
 
     /**
      * Constructor for an EasyPostClient.
@@ -93,6 +95,7 @@ class EasyPostClient extends BaseService
         $this->mockingUtility = $mockingUtility;
         $this->requestEvent = new RequestHook();
         $this->responseEvent = new ResponseHook();
+        $this->httpClient = new Client();
 
         if (!$this->apiKey) {
             throw new MissingParameterException(

--- a/lib/EasyPost/Http/Requestor.php
+++ b/lib/EasyPost/Http/Requestor.php
@@ -23,7 +23,6 @@ use EasyPost\Exception\Api\ServiceUnavailableException;
 use EasyPost\Exception\Api\TimeoutException;
 use EasyPost\Exception\Api\UnauthorizedException;
 use EasyPost\Exception\Api\UnknownApiException;
-use GuzzleHttp\Client;
 
 class Requestor
 {
@@ -205,10 +204,9 @@ class Requestor
             $httpStatus = $matchingRequest->responseInfo->statusCode;
             $responseHeaders = [];
         } else {
-            $guzzleClient = new Client();
             $requestOptions['headers'] = $headers;
             try {
-                $response = $guzzleClient->request($method, $absoluteUrl, $requestOptions);
+                $response = $client->httpClient->request($method, $absoluteUrl, $requestOptions);
             } catch (\GuzzleHttp\Exception\ConnectException $error) {
                 throw new HttpException(sprintf(Constants::COMMUNICATION_ERROR, 'EasyPost', $error->getMessage()));
             }

--- a/test/cassettes/addresses/all.yml
+++ b/test/cassettes/addresses/all.yml
@@ -21,17 +21,17 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 76e1c9586567a128e787d140007fb80d
+            x-ep-request-uuid: ae35d0b6656641d7e7886e4700175c10
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '3082'
-            x-runtime: '0.041972'
-            x-node: bigweb31nuq
+            x-runtime: '0.040093'
+            x-node: bigweb42nuq
             x-version-label: easypost-202311250013-a0f06fbc2c-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq b3de2c47ef', 'extlb1nuq 003ad9bca0']
+            x-proxied: ['intlb1nuq b3de2c47ef', 'extlb2nuq 003ad9bca0']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
         body: '{"addresses":[{"id":"adr_664b3834897e11ee97edac1f6bc539aa","object":"Address","created_at":"2023-11-22T21:30:47+00:00","updated_at":"2023-11-22T21:30:47+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_66464b3b897e11eea668ac1f6bc53342","object":"Address","created_at":"2023-11-22T21:30:46+00:00","updated_at":"2023-11-22T21:30:46+00:00","name":"ELIZABETH SWAN","company":null,"street1":"179 N HARBOR DR","street2":null,"city":"REDONDO BEACH","state":"CA","zip":"90277-2506","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":33.8436,"longitude":-118.39177,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_656e3fc6897e11eea5eaac1f6bc53342","object":"Address","created_at":"2023-11-22T21:30:45+00:00","updated_at":"2023-11-22T21:30:45+00:00","name":"Elizabeth Swan","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo Beach","state":"CA","zip":"90277","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":[]},{"id":"adr_656a6a19897e11ee976dac1f6bc539aa","object":"Address","created_at":"2023-11-22T21:30:45+00:00","updated_at":"2023-11-22T21:30:45+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_0f6a4181897e11ee8a77ac1f6bc539ae","object":"Address","created_at":"2023-11-22T21:28:21+00:00","updated_at":"2023-11-22T21:28:21+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}}],"has_more":true}'
         curl_info:
@@ -43,35 +43,35 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.27971
-            namelookup_time: 0.0264
-            connect_time: 0.09159
-            pretransfer_time: 0.167325
+            total_time: 0.272734
+            namelookup_time: 0.026269
+            connect_time: 0.097831
+            pretransfer_time: 0.166536
             size_upload: 0.0
             size_download: 3082.0
-            speed_download: 11018.0
+            speed_download: 11300.0
             speed_upload: 0.0
             download_content_length: 3082.0
             upload_content_length: 0.0
-            starttransfer_time: 0.279669
+            starttransfer_time: 0.272649
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.131
+            primary_ip: 169.62.110.130
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.41
-            local_port: 52552
+            local_ip: 10.130.6.21
+            local_port: 53927
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 167007
-            connect_time_us: 91590
-            namelookup_time_us: 26400
-            pretransfer_time_us: 167325
+            appconnect_time_us: 166507
+            connect_time_us: 97831
+            namelookup_time_us: 26269
+            pretransfer_time_us: 166536
             redirect_time_us: 0
-            starttransfer_time_us: 279669
-            total_time_us: 279710
+            starttransfer_time_us: 272649
+            total_time_us: 272734
             effective_method: GET
             capath: ''
             cainfo: ''

--- a/test/cassettes/addresses/all.yml
+++ b/test/cassettes/addresses/all.yml
@@ -21,17 +21,17 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: ae35d0b6656641d7e7886e4700175c10
+            x-ep-request-uuid: 76e1c9586567a128e787d140007fb80d
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '3082'
-            x-runtime: '0.040093'
-            x-node: bigweb42nuq
+            x-runtime: '0.041972'
+            x-node: bigweb31nuq
             x-version-label: easypost-202311250013-a0f06fbc2c-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq b3de2c47ef', 'extlb2nuq 003ad9bca0']
+            x-proxied: ['intlb1nuq b3de2c47ef', 'extlb1nuq 003ad9bca0']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
         body: '{"addresses":[{"id":"adr_664b3834897e11ee97edac1f6bc539aa","object":"Address","created_at":"2023-11-22T21:30:47+00:00","updated_at":"2023-11-22T21:30:47+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_66464b3b897e11eea668ac1f6bc53342","object":"Address","created_at":"2023-11-22T21:30:46+00:00","updated_at":"2023-11-22T21:30:46+00:00","name":"ELIZABETH SWAN","company":null,"street1":"179 N HARBOR DR","street2":null,"city":"REDONDO BEACH","state":"CA","zip":"90277-2506","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":33.8436,"longitude":-118.39177,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_656e3fc6897e11eea5eaac1f6bc53342","object":"Address","created_at":"2023-11-22T21:30:45+00:00","updated_at":"2023-11-22T21:30:45+00:00","name":"Elizabeth Swan","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo Beach","state":"CA","zip":"90277","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":[]},{"id":"adr_656a6a19897e11ee976dac1f6bc539aa","object":"Address","created_at":"2023-11-22T21:30:45+00:00","updated_at":"2023-11-22T21:30:45+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_0f6a4181897e11ee8a77ac1f6bc539ae","object":"Address","created_at":"2023-11-22T21:28:21+00:00","updated_at":"2023-11-22T21:28:21+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}}],"has_more":true}'
         curl_info:
@@ -43,35 +43,35 @@
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.272734
-            namelookup_time: 0.026269
-            connect_time: 0.097831
-            pretransfer_time: 0.166536
+            total_time: 0.27971
+            namelookup_time: 0.0264
+            connect_time: 0.09159
+            pretransfer_time: 0.167325
             size_upload: 0.0
             size_download: 3082.0
-            speed_download: 11300.0
+            speed_download: 11018.0
             speed_upload: 0.0
             download_content_length: 3082.0
             upload_content_length: 0.0
-            starttransfer_time: 0.272649
+            starttransfer_time: 0.279669
             redirect_time: 0.0
             redirect_url: ''
-            primary_ip: 169.62.110.130
+            primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.21
-            local_port: 53927
+            local_ip: 10.130.6.41
+            local_port: 52552
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 166507
-            connect_time_us: 97831
-            namelookup_time_us: 26269
-            pretransfer_time_us: 166536
+            appconnect_time_us: 167007
+            connect_time_us: 91590
+            namelookup_time_us: 26400
+            pretransfer_time_us: 167325
             redirect_time_us: 0
-            starttransfer_time_us: 272649
-            total_time_us: 272734
+            starttransfer_time_us: 279669
+            total_time_us: 279710
             effective_method: GET
             capath: ''
             cainfo: ''

--- a/test/cassettes/addresses/getNextPage.yml
+++ b/test/cassettes/addresses/getNextPage.yml
@@ -12,8 +12,7 @@
             User-Agent: ''
     response:
         status:
-            http_version: '1.1'
-            code: '200'
+            code: 200
             message: OK
         headers:
             x-frame-options: SAMEORIGIN
@@ -22,57 +21,61 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 0610ca3b6564ea7be787e1e50013a9af
+            x-ep-request-uuid: 76e1c9576567a6c3e787d5e300861b45
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '3082'
-            x-runtime: '0.041515'
-            x-node: bigweb34nuq
+            x-runtime: '0.040656'
+            x-node: bigweb32nuq
             x-version-label: easypost-202311250013-a0f06fbc2c-master
             x-backend: easypost
-            x-proxied: ['intlb2nuq b3de2c47ef', 'extlb1nuq 003ad9bca0']
+            x-canary: direct
+            x-proxied: ['intlb1nuq b3de2c47ef', 'extlb1nuq 003ad9bca0']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
         body: '{"addresses":[{"id":"adr_664b3834897e11ee97edac1f6bc539aa","object":"Address","created_at":"2023-11-22T21:30:47+00:00","updated_at":"2023-11-22T21:30:47+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_66464b3b897e11eea668ac1f6bc53342","object":"Address","created_at":"2023-11-22T21:30:46+00:00","updated_at":"2023-11-22T21:30:46+00:00","name":"ELIZABETH SWAN","company":null,"street1":"179 N HARBOR DR","street2":null,"city":"REDONDO BEACH","state":"CA","zip":"90277-2506","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":33.8436,"longitude":-118.39177,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_656e3fc6897e11eea5eaac1f6bc53342","object":"Address","created_at":"2023-11-22T21:30:45+00:00","updated_at":"2023-11-22T21:30:45+00:00","name":"Elizabeth Swan","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo Beach","state":"CA","zip":"90277","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":[]},{"id":"adr_656a6a19897e11ee976dac1f6bc539aa","object":"Address","created_at":"2023-11-22T21:30:45+00:00","updated_at":"2023-11-22T21:30:45+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_0f6a4181897e11ee8a77ac1f6bc539ae","object":"Address","created_at":"2023-11-22T21:28:21+00:00","updated_at":"2023-11-22T21:28:21+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}}],"has_more":true}'
         curl_info:
             url: 'https://api.easypost.com/v2/addresses?page_size=5'
             content_type: 'application/json; charset=utf-8'
             http_code: 200
-            header_size: 689
-            request_size: 298
+            header_size: 707
+            request_size: 297
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.257347
-            namelookup_time: 0.020194
-            connect_time: 0.082427
-            pretransfer_time: 0.151345
+            total_time: 0.273885
+            namelookup_time: 0.033406
+            connect_time: 0.09893
+            pretransfer_time: 0.166692
             size_upload: 0.0
             size_download: 3082.0
-            speed_download: 11976.0
+            speed_download: 11252.0
             speed_upload: 0.0
             download_content_length: 3082.0
             upload_content_length: 0.0
-            starttransfer_time: 0.257297
+            starttransfer_time: 0.273842
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.31
-            local_port: 52926
+            local_ip: 10.130.6.41
+            local_port: 52681
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 151278
-            connect_time_us: 82427
-            namelookup_time_us: 20194
-            pretransfer_time_us: 151345
+            appconnect_time_us: 166648
+            connect_time_us: 98930
+            namelookup_time_us: 33406
+            pretransfer_time_us: 166692
             redirect_time_us: 0
-            starttransfer_time_us: 257297
-            total_time_us: 257347
+            starttransfer_time_us: 273842
+            total_time_us: 273885
+            effective_method: GET
+            capath: ''
+            cainfo: ''
     index: 0
 -
     request:
@@ -87,8 +90,7 @@
             User-Agent: ''
     response:
         status:
-            http_version: '1.1'
-            code: '200'
+            code: 200
             message: OK
         headers:
             x-frame-options: SAMEORIGIN
@@ -97,17 +99,17 @@
             x-download-options: noopen
             x-permitted-cross-domain-policies: none
             referrer-policy: strict-origin-when-cross-origin
-            x-ep-request-uuid: 0610ca3a6564ea7ce787e1e60013ab06
+            x-ep-request-uuid: 76e1c9586567a6c3e787d5e400861bd3
             cache-control: 'private, no-cache, no-store'
             pragma: no-cache
             expires: '0'
             content-type: 'application/json; charset=utf-8'
             content-length: '3077'
-            x-runtime: '0.076631'
-            x-node: bigweb39nuq
+            x-runtime: '0.069020'
+            x-node: bigweb36nuq
             x-version-label: easypost-202311250013-a0f06fbc2c-master
             x-backend: easypost
-            x-proxied: ['intlb1nuq b3de2c47ef', 'extlb1nuq 003ad9bca0']
+            x-proxied: ['intlb2nuq b3de2c47ef', 'extlb1nuq 003ad9bca0']
             strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
         body: '{"addresses":[{"id":"adr_0f62c4fb897e11ee8a72ac1f6bc539ae","object":"Address","created_at":"2023-11-22T21:28:21+00:00","updated_at":"2023-11-22T21:28:21+00:00","name":"ELIZABETH SWAN","company":null,"street1":"179 N HARBOR DR","street2":null,"city":"REDONDO BEACH","state":"CA","zip":"90277-2506","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":33.8436,"longitude":-118.39177,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_0e7e9acc897e11eeb99e3cecef1b359e","object":"Address","created_at":"2023-11-22T21:28:19+00:00","updated_at":"2023-11-22T21:28:19+00:00","name":"Elizabeth Swan","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo Beach","state":"CA","zip":"90277","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":[]},{"id":"adr_0e7c4479897e11eeb99d3cecef1b359e","object":"Address","created_at":"2023-11-22T21:28:19+00:00","updated_at":"2023-11-22T21:28:20+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_01363b9b897e11eeaf05ac1f6bc53342","object":"Address","created_at":"2023-11-22T21:27:57+00:00","updated_at":"2023-11-22T21:27:57+00:00","name":"JACK SPARROW","company":null,"street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America\/Los_Angeles"}}}},{"id":"adr_013098c9897e11ee82caac1f6bc539ae","object":"Address","created_at":"2023-11-22T21:27:57+00:00","updated_at":"2023-11-22T21:27:57+00:00","name":"ELIZABETH SWAN","company":null,"street1":"179 N HARBOR DR","street2":null,"city":"REDONDO BEACH","state":"CA","zip":"90277-2506","country":"US","phone":"<REDACTED>","email":"<REDACTED>","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":33.8436,"longitude":-118.39177,"time_zone":"America\/Los_Angeles"}}}}],"has_more":true}'
         curl_info:
@@ -115,37 +117,40 @@
             content_type: 'application/json; charset=utf-8'
             http_code: 200
             header_size: 689
-            request_size: 345
+            request_size: 344
             filetime: -1
             ssl_verify_result: 0
             redirect_count: 0
-            total_time: 0.280032
-            namelookup_time: 0.002763
-            connect_time: 0.070187
-            pretransfer_time: 0.135708
+            total_time: 0.268152
+            namelookup_time: 0.00226
+            connect_time: 0.067008
+            pretransfer_time: 0.13217
             size_upload: 0.0
             size_download: 3077.0
-            speed_download: 10988.0
+            speed_download: 11474.0
             speed_upload: 0.0
             download_content_length: 3077.0
             upload_content_length: 0.0
-            starttransfer_time: 0.279991
+            starttransfer_time: 0.26794
             redirect_time: 0.0
             redirect_url: ''
             primary_ip: 169.62.110.131
             certinfo: {  }
             primary_port: 443
-            local_ip: 10.130.6.31
-            local_port: 52927
+            local_ip: 10.130.6.41
+            local_port: 52682
             http_version: 2
             protocol: 2
             ssl_verifyresult: 0
             scheme: HTTPS
-            appconnect_time_us: 135682
-            connect_time_us: 70187
-            namelookup_time_us: 2763
-            pretransfer_time_us: 135708
+            appconnect_time_us: 132125
+            connect_time_us: 67008
+            namelookup_time_us: 2260
+            pretransfer_time_us: 132170
             redirect_time_us: 0
-            starttransfer_time_us: 279991
-            total_time_us: 280032
+            starttransfer_time_us: 267940
+            total_time_us: 268152
+            effective_method: GET
+            capath: ''
+            cainfo: ''
     index: 0


### PR DESCRIPTION
# Description

We previously recreated the Guzzle Client on every request. This PR moves the creation of the HTTP client into the `EasyPostClient` object to ensure that back-to-back requests using the same EasyPostClient will reuse the same HTTP client to reduce memory consumption. There should be no user impact with this change.

Please note that although the HTTP client is now a publicly accessible property of the EasyPostClient, it is not intended to be replaced as no additional work has been made yet to allow this (see #318 for that initiative)

Closes #315

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Re-recorded a cassette with two requests to ensure it works as expected
<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
