### PR TITLE
type hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Drops support for PHP 7.4
 - Adds support for PHP 8.3
 - Persists the HTTP client inside of the `EasyPostClient` via the `httpClient` property to reduce memory consumption on consecutive requests
+- Adds type hints for parameters and return values throughout the library, corrects docstring hints where necessary
 - Removed `withCarbonOffset` parameter from `create`, `buy`, and `regenerateRates` functions of the Shipment service as EasyPost now offers Carbon Neutral shipments by default for free
 - Fixes a bug where the original filtering criteria of `all` calls wasn't passed along to `getNextPage` calls. Now, these are persisted via a `_params` key on response objects locally
 - Removes the undocumented `createAndBuy` function from the `Batch` service. The proper usage is to create a batch first and buy it separately

--- a/lib/EasyPost/EasyPostClient.php
+++ b/lib/EasyPost/EasyPostClient.php
@@ -4,7 +4,6 @@ namespace EasyPost;
 
 use EasyPost\Constant\Constants;
 use EasyPost\Exception\General\EasyPostException;
-use EasyPost\Exception\General\MissingParameterException;
 use EasyPost\Hook\RequestHook;
 use EasyPost\Hook\ResponseHook;
 use EasyPost\Service\AddressService;
@@ -83,10 +82,10 @@ class EasyPostClient extends BaseService
      * @param object $mockingUtility
      */
     public function __construct(
-        $apiKey,
-        $timeout = Constants::TIMEOUT,
-        $apiBase = Constants::API_BASE,
-        $mockingUtility = null
+        string $apiKey,
+        float $timeout = Constants::TIMEOUT,
+        string $apiBase = Constants::API_BASE,
+        ?object $mockingUtility = null
     ) {
         // Client properties
         $this->apiKey = $apiKey;
@@ -96,22 +95,16 @@ class EasyPostClient extends BaseService
         $this->requestEvent = new RequestHook();
         $this->responseEvent = new ResponseHook();
         $this->httpClient = new Client();
-
-        if (!$this->apiKey) {
-            throw new MissingParameterException(
-                'No API key provided. See https://www.easypost.com/docs for details, or contact ' . Constants::SUPPORT_EMAIL . ' for assistance.' // phpcs:ignore
-            );
-        }
     }
 
     /**
      * Get a Service when calling a property of an EasyPostClient.
      *
      * @param string $serviceName
-     * @return BaseService
+     * @return mixed
      * @throws EasyPostException
      */
-    public function __get($serviceName)
+    public function __get(string $serviceName)
     {
         $serviceClassMap = [
             'address' => AddressService::class,
@@ -159,7 +152,7 @@ class EasyPostClient extends BaseService
      *
      * @return string
      */
-    public function getApiKey()
+    public function getApiKey(): string
     {
         return $this->apiKey;
     }
@@ -169,7 +162,7 @@ class EasyPostClient extends BaseService
      *
      * @return float
      */
-    public function getTimeout()
+    public function getTimeout(): float
     {
         return $this->timeout;
     }
@@ -179,7 +172,7 @@ class EasyPostClient extends BaseService
      *
      * @return string
      */
-    public function getApiBase()
+    public function getApiBase(): string
     {
         return $this->apiBase;
     }
@@ -189,7 +182,7 @@ class EasyPostClient extends BaseService
      *
      * @return bool
      */
-    public function mock()
+    public function mock(): bool
     {
         return $this->mockingUtility !== null;
     }
@@ -199,7 +192,7 @@ class EasyPostClient extends BaseService
      *
      * @return object
      */
-    public function getMockingUtility()
+    public function getMockingUtility(): object
     {
         return $this->mockingUtility;
     }
@@ -210,7 +203,7 @@ class EasyPostClient extends BaseService
      * @param callable $function
      * @return void
      */
-    public function subscribeToRequestHook($function)
+    public function subscribeToRequestHook(callable $function): void
     {
         $this->requestEvent->addHandler($function);
     }
@@ -221,7 +214,7 @@ class EasyPostClient extends BaseService
      * @param callable $function
      * @return void
      */
-    public function unsubscribeFromRequestHook($function)
+    public function unsubscribeFromRequestHook(callable $function): void
     {
         $this->requestEvent->removeHandler($function);
     }
@@ -232,7 +225,7 @@ class EasyPostClient extends BaseService
      * @param callable $function
      * @return void
      */
-    public function subscribeToResponseHook($function)
+    public function subscribeToResponseHook(callable $function): void
     {
         $this->responseEvent->addHandler($function);
     }
@@ -243,7 +236,7 @@ class EasyPostClient extends BaseService
      * @param callable $function
      * @return void
      */
-    public function unsubscribeFromResponseHook($function)
+    public function unsubscribeFromResponseHook(callable $function): void
     {
         $this->responseEvent->removeHandler($function);
     }

--- a/lib/EasyPost/EasyPostObject.php
+++ b/lib/EasyPost/EasyPostObject.php
@@ -8,33 +8,18 @@ use EasyPost\Util\Util;
 
 class EasyPostObject implements \ArrayAccess, \Iterator
 {
-    /**
-     * @var array
-     */
-    protected $_values;
-
-    /**
-     * @var array
-     */
-    protected $_immutableValues;
-
-    /**
-     * @var string
-     */
-    private $_parent;
-
-    /**
-     * @var string
-     */
-    private $_name;
+    protected array $_values;
+    protected array $_immutableValues;
+    private mixed $_parent;
+    private mixed $_name;
 
     /**
      * Constructor for EasyPost objects.
      *
-     * @param string $parent
-     * @param string $name
+     * @param mixed $parent
+     * @param mixed $name
      */
-    public function __construct($parent = null, $name = null)
+    public function __construct(mixed $parent = null, mixed $name = null)
     {
         $this->_values = [];
         $this->_immutableValues = ['id'];
@@ -48,7 +33,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      * @param string $k
      * @param mixed $v
      */
-    public function __set($k, $v)
+    public function __set(string $k, mixed $v): void
     {
         $this->_values[$k] = $v;
 
@@ -71,7 +56,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      * @param string $k
      * @return bool
      */
-    public function __isset($k)
+    public function __isset(string $k): bool
     {
         return isset($this->_values[$k]);
     }
@@ -81,7 +66,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @param string $k
      */
-    public function __unset($k)
+    public function __unset(string $k): void
     {
         if (!in_array($k, $this->_immutableValues)) {
             unset($this->_values[$k]);
@@ -106,7 +91,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      * @param string $k
      * @return mixed
      */
-    public function __get($k)
+    public function __get(string $k): mixed
     {
         if (array_key_exists($k, $this->_values)) {
             return $this->_values[$k];
@@ -121,12 +106,12 @@ class EasyPostObject implements \ArrayAccess, \Iterator
     /**
      * Construct EasyPost objects from a response.
      *
-     * @param EasyPostClient $client
+     * @param EasyPostClient|null $client
      * @param array $values
      * @param string $class
      * @return mixed
      */
-    public static function constructFrom($client, $values, $class)
+    public static function constructFrom(?EasyPostClient $client, array $values, string $class): mixed
     {
         $object = new $class($client);
         $object->convertEach($client, $values);
@@ -137,10 +122,10 @@ class EasyPostObject implements \ArrayAccess, \Iterator
     /**
      * Convert each piece of an EasyPost object.
      *
-     * @param EasyPostClient $client
+     * @param EasyPostClient|null $client
      * @param array $values
      */
-    public function convertEach($client, $values)
+    public function convertEach(?EasyPostClient $client, array $values): void
     {
         foreach ($values as $k => $v) {
             // We don't want `_params` to become the default `EasyPostObject` since it needs to remain a normal array
@@ -155,11 +140,10 @@ class EasyPostObject implements \ArrayAccess, \Iterator
     /**
      * ArrayAccess methods.
      *
-     * @param string $k
+     * @param mixed $k
      * @param mixed $v
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($k, $v)
+    public function offsetSet(mixed $k, mixed $v): void
     {
         $this->$k = $v;
     }
@@ -167,11 +151,10 @@ class EasyPostObject implements \ArrayAccess, \Iterator
     /**
      * ArrayAccess methods.
      *
-     * @param string $k
+     * @param mixed $k
      * @return bool
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($k)
+    public function offsetExists(mixed $k): bool
     {
         return array_key_exists($k, $this->_values);
     }
@@ -179,10 +162,9 @@ class EasyPostObject implements \ArrayAccess, \Iterator
     /**
      * ArrayAccess methods.
      *
-     * @param string $k
+     * @param mixed $k
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($k)
+    public function offsetUnset(mixed $k): void
     {
         unset($this->$k);
     }
@@ -190,11 +172,10 @@ class EasyPostObject implements \ArrayAccess, \Iterator
     /**
      * ArrayAccess methods.
      *
-     * @param string $k
+     * @param mixed $k
      * @return mixed
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($k)
+    public function offsetGet(mixed $k): mixed
     {
         return array_key_exists($k, $this->_values) ? $this->_values[$k] : null;
     }
@@ -204,8 +185,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->_values);
     }
@@ -215,8 +195,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return mixed
      */
-    #[\ReturnTypeWillChange]
-    public function current()
+    public function current(): mixed
     {
         return current($this->_values);
     }
@@ -226,8 +205,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return mixed
      */
-    #[\ReturnTypeWillChange]
-    public function key()
+    public function key(): mixed
     {
         return key($this->_values);
     }
@@ -235,12 +213,11 @@ class EasyPostObject implements \ArrayAccess, \Iterator
     /**
      * Iterator methods.
      *
-     * @return mixed
+     * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function next()
+    public function next(): void
     {
-        return next($this->_values);
+        next($this->_values);
     }
 
     /**
@@ -248,8 +225,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         $key = key($this->_values);
         return ($key !== null && $key !== false);
@@ -258,9 +234,9 @@ class EasyPostObject implements \ArrayAccess, \Iterator
     /**
      * Convert object to JSON.
      *
-     * @return string
+     * @return string|bool
      */
-    public function __toJSON()
+    public function __toJSON(): string|bool
     {
         if (defined('JSON_PRETTY_PRINT')) {
             return json_encode($this->__toArray(true), JSON_PRETTY_PRINT);
@@ -274,7 +250,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->__toJSON();
     }
@@ -282,10 +258,10 @@ class EasyPostObject implements \ArrayAccess, \Iterator
     /**
      * Convert object to an array.
      *
-     * @param bool $recursive
+     * @param bool|null $recursive
      * @return array
      */
-    public function __toArray($recursive = false)
+    public function __toArray(?bool $recursive = false): array
     {
         if ($recursive) {
             return Util::convertEasyPostObjectToArray($this->_values);

--- a/lib/EasyPost/Exception/Api/ApiException.php
+++ b/lib/EasyPost/Exception/Api/ApiException.php
@@ -22,10 +22,10 @@ class ApiException extends EasyPostException
      * ApiException constructor.
      *
      * @param string $message
-     * @param int $httpStatus
-     * @param string $httpBody
+     * @param int|null $httpStatus
+     * @param string|null $httpBody
      */
-    public function __construct($message = '', $httpStatus = null, $httpBody = null)
+    public function __construct(string $message = '', ?int $httpStatus = null, ?string $httpBody = null)
     {
         parent::__construct($message);
         $this->httpStatus = $httpStatus;
@@ -57,7 +57,7 @@ class ApiException extends EasyPostException
      *
      * @return int
      */
-    public function getHttpStatus()
+    public function getHttpStatus(): int
     {
         return $this->httpStatus;
     }
@@ -67,7 +67,7 @@ class ApiException extends EasyPostException
      *
      * @return string
      */
-    public function getHttpBody()
+    public function getHttpBody(): string
     {
         return $this->httpBody;
     }
@@ -77,7 +77,7 @@ class ApiException extends EasyPostException
      *
      * @return void
      */
-    public function prettyPrint()
+    public function prettyPrint(): void
     {
         print($this->code . ' (' . $this->getHttpStatus() . '): ' .
             $this->getMessage() . "\n");

--- a/lib/EasyPost/Exception/General/EasyPostException.php
+++ b/lib/EasyPost/Exception/General/EasyPostException.php
@@ -9,7 +9,7 @@ class EasyPostException extends \Exception
      *
      * @param string $message
      */
-    public function __construct($message = '')
+    public function __construct(string $message = '')
     {
         parent::__construct($message);
     }

--- a/lib/EasyPost/Hook/EventHook.php
+++ b/lib/EasyPost/Hook/EventHook.php
@@ -16,13 +16,25 @@ class EventHook
         }
     }
 
-    public function addHandler($handler)
+    /**
+     * Add an HTTP handler to the list of handlers.
+     *
+     * @param callable $handler
+     * @return EventHook
+     */
+    public function addHandler(callable $handler)
     {
         $this->eventHandlers[] = $handler;
         return $this;
     }
 
-    public function removeHandler($handler)
+    /**
+     * Remove an HTTP handler from the list of handlers.
+     *
+     * @param callable $handler
+     * @return EventHook
+     */
+    public function removeHandler(callable $handler)
     {
         $index = array_search($handler, $this->eventHandlers, true);
         if ($index !== false) {

--- a/lib/EasyPost/Http/Requestor.php
+++ b/lib/EasyPost/Http/Requestor.php
@@ -34,7 +34,7 @@ class Requestor
      * @param bool $beta
      * @return string
      */
-    private static function absoluteUrl($client, $url = '', $beta = false)
+    private static function absoluteUrl(EasyPostClient $client, string $url = '', bool $beta = false): string
     {
         if ($beta) {
             $apiBase = Constants::API_BASE . '/' . Constants::BETA_API_VERSION;
@@ -51,7 +51,7 @@ class Requestor
      * @param mixed $value
      * @return string
      */
-    public static function utf8($value)
+    public static function utf8(mixed $value): string
     {
         if (is_string($value) && mb_detect_encoding($value, 'UTF-8', true) != 'UTF-8') {
             return mb_convert_encoding($value, 'UTF-8', 'ISO-8859-1');
@@ -66,7 +66,7 @@ class Requestor
      * @param mixed $data
      * @return array|string
      */
-    private static function encodeObjects($data)
+    private static function encodeObjects(mixed $data): array|string
     {
         if (is_null($data)) {
             return [];
@@ -94,10 +94,10 @@ class Requestor
      * URL Encodes data for GET requests.
      *
      * @param mixed $arr
-     * @param null $prefix
+     * @param string|null $prefix
      * @return string
      */
-    public static function urlEncode($arr, $prefix = null)
+    public static function urlEncode(mixed $arr, ?string $prefix = null): string
     {
         if (!is_array($arr)) {
             return $arr;
@@ -133,10 +133,15 @@ class Requestor
      * @param string $url
      * @param mixed $params
      * @param bool $beta
-     * @return array
+     * @return mixed
      */
-    public static function request($client, $method, $url, $params = null, $beta = false)
-    {
+    public static function request(
+        EasyPostClient $client,
+        string $method,
+        string $url,
+        mixed $params = null,
+        bool $beta = false
+    ): mixed {
         list($responseBody, $httpStatus) = self::requestRaw($client, $method, $url, $params, $beta);
         $httpBody = self::interpretResponse($responseBody, $httpStatus);
 
@@ -155,8 +160,13 @@ class Requestor
      * @throws HttpException
      * @throws TimeoutException
      */
-    private static function requestRaw($client, $method, $url, $params, $beta = false)
-    {
+    private static function requestRaw(
+        EasyPostClient $client,
+        string $method,
+        string $url,
+        mixed $params,
+        bool $beta = false
+    ): array {
         $absoluteUrl = self::absoluteUrl($client, $url, $beta);
         $requestOptions = [
             'http_errors' => false, // we set this false here so we can do our own error handling
@@ -245,7 +255,7 @@ class Requestor
      * @return mixed
      * @throws JsonException
      */
-    public static function interpretResponse($httpBody, $httpStatus)
+    public static function interpretResponse(string $httpBody, int $httpStatus): mixed
     {
         try {
             $response = json_decode($httpBody, true);
@@ -267,7 +277,7 @@ class Requestor
     /**
      * Handles API errors returned from EasyPost.
      *
-     * @param string $httpBody
+     * @param string|null $httpBody
      * @param int $httpStatus
      * @param array $response
      * @throws BadRequestException
@@ -285,7 +295,7 @@ class Requestor
      * @throws UnauthorizedException
      * @throws UnknownApiException
      */
-    public static function handleApiError($httpBody, $httpStatus, $response)
+    public static function handleApiError(?string $httpBody, int $httpStatus, array $response)
     {
         if (!is_array($response) || !isset($response['error'])) {
             throw new JsonException(
@@ -352,11 +362,11 @@ class Requestor
     /**
      * Recursively traverses a JSON element to extract error messages and returns them as a comma-separated string.
      *
-     * @param array $errorMessage
+     * @param mixed $errorMessage
      * @param array $messagesList
      * @return string
      */
-    private static function traverseJsonElement($errorMessage, &$messagesList)
+    private static function traverseJsonElement(mixed $errorMessage, array &$messagesList): string
     {
         switch (gettype($errorMessage)) {
             case 'array':

--- a/lib/EasyPost/Order.php
+++ b/lib/EasyPost/Order.php
@@ -28,11 +28,11 @@ class Order extends EasyPostObject
      *
      * To exclude a carrier or service, prepend the string with `!`.
      *
-     * @param array $carriers
-     * @param array $services
+     * @param array|null $carriers
+     * @param array|null $services
      * @return Rate
      */
-    public function lowestRate($carriers = [], $services = [])
+    public function lowestRate(?array $carriers = [], ?array $services = []): Rate
     {
         $lowestRate = InternalUtil::getLowestObjectRate($this, $carriers, $services);
 

--- a/lib/EasyPost/Pickup.php
+++ b/lib/EasyPost/Pickup.php
@@ -2,6 +2,7 @@
 
 namespace EasyPost;
 
+use EasyPost\PickupRate;
 use EasyPost\Util\InternalUtil;
 
 /**
@@ -31,11 +32,11 @@ class Pickup extends EasyPostObject
      *
      * To exclude a carrier or service, prepend the string with `!`.
      *
-     * @param array $carriers
-     * @param array $services
-     * @return Rate
+     * @param array|null $carriers
+     * @param array|null $services
+     * @return PickupRate
      */
-    public function lowestRate($carriers = [], $services = [])
+    public function lowestRate(?array $carriers = [], ?array $services = []): PickupRate
     {
         $lowestRate = InternalUtil::getLowestObjectRate($this, $carriers, $services, 'pickup_rates');
 

--- a/lib/EasyPost/Service/AddressService.php
+++ b/lib/EasyPost/Service/AddressService.php
@@ -16,7 +16,7 @@ class AddressService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -27,7 +27,7 @@ class AddressService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function all($params = null)
+    public function all(mixed $params = null): mixed
     {
         return self::allResources(self::serviceModelClassName(self::class), $params);
     }
@@ -36,10 +36,10 @@ class AddressService extends BaseService
      * Retrieve the next page of Address collection
      *
      * @param mixed $addresses
-     * @param string $pageSize
+     * @param int|null $pageSize
      * @return mixed
      */
-    public function getNextPage($addresses, $pageSize = null)
+    public function getNextPage(mixed $addresses, ?int $pageSize = null)
     {
         return $this->getNextPageResources(self::serviceModelClassName(self::class), $addresses, $pageSize);
     }
@@ -50,7 +50,7 @@ class AddressService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         $wrappedParams = [];
 
@@ -77,7 +77,7 @@ class AddressService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function createAndVerify($params = null)
+    public function createAndVerify(mixed $params = null): mixed
     {
         if (!isset($params['address']) || !is_array($params['address'])) {
             $clone = $params;
@@ -97,7 +97,7 @@ class AddressService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function verify($id)
+    public function verify(string $id): mixed
     {
         $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/verify';
         $response = Requestor::request($this->client, 'get', $url, null);

--- a/lib/EasyPost/Service/ApiKeyService.php
+++ b/lib/EasyPost/Service/ApiKeyService.php
@@ -17,7 +17,7 @@ class ApiKeyService extends BaseService
      *
      * @return mixed
      */
-    public function all()
+    public function all(): mixed
     {
         $response = Requestor::request($this->client, 'get', '/api_keys');
 
@@ -31,7 +31,7 @@ class ApiKeyService extends BaseService
      * @return mixed
      * @throws FilteringException If no user is found with the given ID
      */
-    public function retrieveApiKeysForUser($id)
+    public function retrieveApiKeysForUser(string $id): mixed
     {
         $apiKeys = self::all();
 

--- a/lib/EasyPost/Service/BaseService.php
+++ b/lib/EasyPost/Service/BaseService.php
@@ -3,6 +3,7 @@
 namespace EasyPost\Service;
 
 use EasyPost\Constant\Constants;
+use EasyPost\EasyPostClient;
 use EasyPost\Exception\General\EndOfPaginationException;
 use EasyPost\Exception\General\InvalidObjectException;
 use EasyPost\Exception\General\InvalidParameterException;
@@ -11,7 +12,7 @@ use EasyPost\Util\InternalUtil;
 
 class BaseService
 {
-    protected $client;
+    protected EasyPostClient $client;
 
     /**
      * Service constructor shared by all child services.

--- a/lib/EasyPost/Service/BaseService.php
+++ b/lib/EasyPost/Service/BaseService.php
@@ -29,7 +29,7 @@ class BaseService
      * @param string $class
      * @return string
      */
-    protected static function className($class)
+    protected static function className(string $class): string
     {
         // Strip namespace if present
         if ($postfix = strrchr($class, '\\')) {
@@ -52,7 +52,7 @@ class BaseService
      * @param string $serviceClassName
      * @return string
      */
-    protected static function serviceModelClassName($serviceClassName)
+    protected static function serviceModelClassName(string $serviceClassName): string
     {
         return str_replace('Service', '', $serviceClassName);
     }
@@ -63,7 +63,7 @@ class BaseService
      * @param string $class
      * @return string
      */
-    protected static function classUrl($class)
+    protected static function classUrl(string $class): string
     {
         $className = self::className($class);
         if (substr($className, -1) !== 's' && substr($className, -1) !== 'h') {
@@ -81,7 +81,7 @@ class BaseService
      * @return string
      * @throws InvalidObjectException
      */
-    protected function instanceUrl($class, $id)
+    protected function instanceUrl(string $class, string $id): string
     {
         if (!$id) {
             throw new InvalidObjectException(sprintf(Constants::NO_ID_URL_ERROR), $class, $id);
@@ -95,10 +95,10 @@ class BaseService
     /**
      * Validate library usage.
      *
-     * @param array $params
+     * @param mixed $params
      * @throws InvalidParameterException
      */
-    protected static function validate($params = null)
+    protected static function validate(mixed $params = null): void
     {
         if ($params && !is_array($params)) {
             throw new InvalidParameterException(Constants::ARRAY_REQUIRED_ERROR);
@@ -113,7 +113,7 @@ class BaseService
      * @param bool $beta
      * @return mixed
      */
-    protected function retrieveResource($class, $id, $beta = false)
+    protected function retrieveResource(string $class, string $id, bool $beta = false): mixed
     {
         $url = $this->instanceUrl($class, $id);
 
@@ -130,7 +130,7 @@ class BaseService
      * @param bool $beta
      * @return mixed
      */
-    protected function allResources($class, $params = null, $beta = false)
+    protected function allResources(string $class, mixed $params = null, bool $beta = false): mixed
     {
         self::validate($params);
         $url = self::classUrl($class);
@@ -148,10 +148,10 @@ class BaseService
      *
      * @param string $class
      * @param mixed $collection
-     * @param int $pageSize
+     * @param int|null $pageSize
      * @return mixed
      */
-    protected function getNextPageResources($class, $collection, $pageSize = null)
+    protected function getNextPageResources(string $class, mixed $collection, ?int $pageSize = null): mixed
     {
         $objectName = substr(self::classUrl($class), 1);
         $collectionArray = $collection[$objectName];
@@ -191,7 +191,7 @@ class BaseService
      * @param bool $beta
      * @return mixed
      */
-    protected function createResource($class, $params = null, $beta = false)
+    protected function createResource(string $class, mixed $params = null, bool $beta = false): mixed
     {
         self::validate($params);
         $url = self::classUrl($class);
@@ -209,7 +209,7 @@ class BaseService
      * @param bool $beta
      * @return void
      */
-    protected function deleteResource($class, $id, $params = null, $beta = false)
+    protected function deleteResource(string $class, string $id, mixed $params = null, bool $beta = false): void
     {
         self::validate();
         $url = $this->instanceUrl($class, $id);
@@ -223,12 +223,17 @@ class BaseService
      * @param string $class
      * @param string $id
      * @param mixed $params
-     * @param string $method
+     * @param string|null $method
      * @param bool $beta
      * @return mixed
      */
-    protected function updateResource($class, $id, $params = null, $method = 'patch', $beta = false)
-    {
+    protected function updateResource(
+        string $class,
+        string $id,
+        mixed $params = null,
+        ?string $method = 'patch',
+        bool $beta = false
+    ): mixed {
         self::validate();
         $url = $this->instanceUrl($class, $id);
         $response = Requestor::request($this->client, $method, $url, $params, $beta);

--- a/lib/EasyPost/Service/BatchService.php
+++ b/lib/EasyPost/Service/BatchService.php
@@ -16,7 +16,7 @@ class BatchService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -27,7 +27,7 @@ class BatchService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function all($params = null)
+    public function all(mixed $params = null): mixed
     {
         return self::allResources(self::serviceModelClassName(self::class), $params);
     }
@@ -38,7 +38,7 @@ class BatchService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         if (!isset($params['batch']) || !is_array($params['batch'])) {
             $clone = $params;
@@ -56,7 +56,7 @@ class BatchService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function buy($id, $params = null)
+    public function buy(string $id, mixed $params = null): mixed
     {
         $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/buy';
         $response = Requestor::request($this->client, 'post', $url, $params);
@@ -71,7 +71,7 @@ class BatchService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function label($id, $params = null)
+    public function label(string $id, mixed $params = null): mixed
     {
         $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/label';
         $response = Requestor::request($this->client, 'post', $url, $params);
@@ -86,7 +86,7 @@ class BatchService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function removeShipments($id, $params = null)
+    public function removeShipments(string $id, mixed $params = null): mixed
     {
         $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/remove_shipments';
         $response = Requestor::request($this->client, 'post', $url, $params);
@@ -101,7 +101,7 @@ class BatchService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function addShipments($id, $params = null)
+    public function addShipments(string $id, mixed $params = null): mixed
     {
         $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/add_shipments';
         $response = Requestor::request($this->client, 'post', $url, $params);
@@ -116,7 +116,7 @@ class BatchService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function createScanForm($id, $params = null)
+    public function createScanForm(string $id, mixed $params = null): mixed
     {
         $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/scan_form';
         $response = Requestor::request($this->client, 'post', $url, $params);

--- a/lib/EasyPost/Service/BetaRateService.php
+++ b/lib/EasyPost/Service/BetaRateService.php
@@ -16,7 +16,7 @@ class BetaRateService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function retrieveStatelessRates($params)
+    public function retrieveStatelessRates(mixed $params): mixed
     {
         $wrappedParams = [
             'shipment' => $params,

--- a/lib/EasyPost/Service/BetaReferralCustomerService.php
+++ b/lib/EasyPost/Service/BetaReferralCustomerService.php
@@ -23,8 +23,11 @@ class BetaReferralCustomerService extends BaseService
      * @param string $priority
      * @return mixed
      */
-    public function addPaymentMethod(string $stripeCustomerId, string $paymentMethodReference, string $priority = 'primary'): mixed
-    {
+    public function addPaymentMethod(
+        string $stripeCustomerId,
+        string $paymentMethodReference,
+        string $priority = 'primary'
+    ): mixed {
         $params = [
             'payment_method' => [
                 'stripe_customer_id' => $stripeCustomerId,

--- a/lib/EasyPost/Service/BetaReferralCustomerService.php
+++ b/lib/EasyPost/Service/BetaReferralCustomerService.php
@@ -23,7 +23,7 @@ class BetaReferralCustomerService extends BaseService
      * @param string $priority
      * @return mixed
      */
-    public function addPaymentMethod($stripeCustomerId, $paymentMethodReference, $priority = 'primary')
+    public function addPaymentMethod(string $stripeCustomerId, string $paymentMethodReference, string $priority = 'primary'): mixed
     {
         $params = [
             'payment_method' => [
@@ -44,7 +44,7 @@ class BetaReferralCustomerService extends BaseService
      * @param int $refundAmount
      * @return mixed
      */
-    public function refundByAmount($refundAmount)
+    public function refundByAmount(int $refundAmount): mixed
     {
         $params = ['refund_amount' => $refundAmount];
 
@@ -59,7 +59,7 @@ class BetaReferralCustomerService extends BaseService
      * @param string $paymentLogId
      * @return mixed
      */
-    public function refundByPaymentLog($paymentLogId)
+    public function refundByPaymentLog(string $paymentLogId): mixed
     {
         $params = ['payment_log_id' => $paymentLogId];
 

--- a/lib/EasyPost/Service/BillingService.php
+++ b/lib/EasyPost/Service/BillingService.php
@@ -22,7 +22,7 @@ class BillingService extends BaseService
      * @return mixed
      * @throws PaymentException
      */
-    public function retrievePaymentMethods($params = null)
+    public function retrievePaymentMethods(mixed $params = null): mixed
     {
         $paymentMethods = self::allResources(self::$modelClass, $params);
 
@@ -40,7 +40,7 @@ class BillingService extends BaseService
      * @param string $priority
      * @return void
      */
-    public function fundWallet($amount, $priority = 'primary')
+    public function fundWallet(string $amount, string $priority = 'primary'): void
     {
         [$paymentMethodEndpoint, $paymentMethodId] = self::getPaymentInfo(strtolower($priority));
 
@@ -56,7 +56,7 @@ class BillingService extends BaseService
      * @param string $priority
      * @return void
      */
-    public function deletePaymentMethod($priority)
+    public function deletePaymentMethod(string $priority): void
     {
         [$paymentMethodEndpoint, $paymentMethodId] = self::getPaymentInfo(strtolower($priority));
         $url = $paymentMethodEndpoint . "/$paymentMethodId";
@@ -71,7 +71,7 @@ class BillingService extends BaseService
      * @return array
      * @throws PaymentException
      */
-    private function getPaymentInfo($priority = 'primary')
+    private function getPaymentInfo(string $priority = 'primary'): array
     {
         $paymentMethods = self::retrievePaymentMethods();
         $paymentMethodMap = [

--- a/lib/EasyPost/Service/CarrierAccountService.php
+++ b/lib/EasyPost/Service/CarrierAccountService.php
@@ -18,7 +18,7 @@ class CarrierAccountService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -29,7 +29,7 @@ class CarrierAccountService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function all($params = null)
+    public function all(mixed $params = null): mixed
     {
         return self::allResources(self::serviceModelClassName(self::class), $params);
     }
@@ -41,7 +41,7 @@ class CarrierAccountService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function update($id, $params)
+    public function update(string $id, mixed $params): mixed
     {
         return self::updateResource(self::serviceModelClassName(self::class), $id, $params);
     }
@@ -53,7 +53,7 @@ class CarrierAccountService extends BaseService
      * @param mixed $params
      * @return void
      */
-    public function delete($id, $params = null)
+    public function delete(string $id, mixed $params = null): void
     {
         self::deleteResource(self::serviceModelClassName(self::class), $id, $params);
     }
@@ -65,7 +65,7 @@ class CarrierAccountService extends BaseService
      * @return mixed
      * @throws MissingParameterException
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         if (!isset($params['carrier_account']) || !is_array($params['carrier_account'])) {
             $clone = $params;
@@ -89,7 +89,7 @@ class CarrierAccountService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function types($params = null)
+    public function types(mixed $params = null): mixed
     {
         $response = Requestor::request($this->client, 'get', '/carrier_types', $params);
 
@@ -102,7 +102,7 @@ class CarrierAccountService extends BaseService
      * @param string $carrierAccountType The type of carrier account to create.
      * @return string The endpoint for creating a carrier account.
      */
-    private function selectCarrierAccountCreationEndpoint($carrierAccountType): string
+    private function selectCarrierAccountCreationEndpoint(string $carrierAccountType): string
     {
         if (in_array($carrierAccountType, Constants::CARRIER_ACCOUNT_TYPES_WITH_CUSTOM_WORKFLOWS, true)) {
             return '/carrier_accounts/register';

--- a/lib/EasyPost/Service/CarrierMetadataService.php
+++ b/lib/EasyPost/Service/CarrierMetadataService.php
@@ -17,7 +17,7 @@ class CarrierMetadataService extends BaseService
      * @param array|null $types
      * @return mixed
      */
-    public function retrieve($carriers = null, $types = null)
+    public function retrieve(?array $carriers = null, ?array $types = null): mixed
     {
         $url = '/metadata/carriers';
         if (isset($carriers) || isset($types)) {

--- a/lib/EasyPost/Service/CustomsInfoService.php
+++ b/lib/EasyPost/Service/CustomsInfoService.php
@@ -13,7 +13,7 @@ class CustomsInfoService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -24,7 +24,7 @@ class CustomsInfoService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         if (!isset($params['customs_info']) || !is_array($params['customs_info'])) {
             $clone = $params;

--- a/lib/EasyPost/Service/CustomsItemService.php
+++ b/lib/EasyPost/Service/CustomsItemService.php
@@ -13,7 +13,7 @@ class CustomsItemService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -24,7 +24,7 @@ class CustomsItemService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         if (!isset($params['customs_item']) || !is_array($params['customs_item'])) {
             $clone = $params;

--- a/lib/EasyPost/Service/EndShipperService.php
+++ b/lib/EasyPost/Service/EndShipperService.php
@@ -13,7 +13,7 @@ class EndShipperService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         if (!isset($params['address']) || !is_array($params['address'])) {
             $clone = $params;
@@ -30,7 +30,7 @@ class EndShipperService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -41,7 +41,7 @@ class EndShipperService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function all($params = null)
+    public function all(mixed $params = null): mixed
     {
         return self::allResources(self::serviceModelClassName(self::class), $params);
     }
@@ -53,7 +53,7 @@ class EndShipperService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function update($id, $params)
+    public function update(string $id, mixed $params): mixed
     {
         if (!isset($params['address']) || !is_array($params['address'])) {
             $clone = $params;

--- a/lib/EasyPost/Service/EventService.php
+++ b/lib/EasyPost/Service/EventService.php
@@ -16,7 +16,7 @@ class EventService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -27,7 +27,7 @@ class EventService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function all($params = null)
+    public function all(mixed $params = null): mixed
     {
         return self::allResources(self::serviceModelClassName(self::class), $params);
     }
@@ -36,10 +36,10 @@ class EventService extends BaseService
      * Retrieve the next page of Event collection
      *
      * @param mixed $events
-     * @param string $pageSize
+     * @param int|null $pageSize
      * @return mixed
      */
-    public function getNextPage($events, $pageSize = null)
+    public function getNextPage(mixed $events, ?int $pageSize = null): mixed
     {
         return $this->getNextPageResources(self::serviceModelClassName(self::class), $events, $pageSize);
     }
@@ -50,7 +50,7 @@ class EventService extends BaseService
      * @param string $id The event id
      * @return mixed
      */
-    public function retrieveAllPayloads($id)
+    public function retrieveAllPayloads(string $id): mixed
     {
         $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/payloads';
 
@@ -66,7 +66,7 @@ class EventService extends BaseService
      * @param string $payloadId The payload id
      * @return mixed
      */
-    public function retrievePayload($id, $payloadId)
+    public function retrievePayload(string $id, string $payloadId): mixed
     {
         $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/payloads/' . $payloadId;
 

--- a/lib/EasyPost/Service/InsuranceService.php
+++ b/lib/EasyPost/Service/InsuranceService.php
@@ -13,7 +13,7 @@ class InsuranceService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -24,7 +24,7 @@ class InsuranceService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function all($params = null)
+    public function all(mixed $params = null): mixed
     {
         return self::allResources(self::serviceModelClassName(self::class), $params);
     }
@@ -33,10 +33,10 @@ class InsuranceService extends BaseService
      * Retrieve the next page of Insurance collection
      *
      * @param mixed $insurances
-     * @param string $pageSize
+     * @param int|null $pageSize
      * @return mixed
      */
-    public function getNextPage($insurances, $pageSize = null)
+    public function getNextPage(mixed $insurances, ?int $pageSize = null): mixed
     {
         return $this->getNextPageResources(self::serviceModelClassName(self::class), $insurances, $pageSize);
     }
@@ -47,7 +47,7 @@ class InsuranceService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         if (!isset($params['insurance']) || !is_array($params['insurance'])) {
             $clone = $params;

--- a/lib/EasyPost/Service/OrderService.php
+++ b/lib/EasyPost/Service/OrderService.php
@@ -17,7 +17,7 @@ class OrderService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -28,7 +28,7 @@ class OrderService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         if (!isset($params['order']) || !is_array($params['order'])) {
             $clone = $params;
@@ -46,7 +46,7 @@ class OrderService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function getRates($id, $params = null)
+    public function getRates(string $id, mixed $params = null): mixed
     {
         $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/rates';
         $response = Requestor::request($this->client, 'get', $url, $params);
@@ -61,7 +61,7 @@ class OrderService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function buy($id, $params = null)
+    public function buy(string $id, mixed $params = null): mixed
     {
         if ($params instanceof Rate) {
             $clone = $params;

--- a/lib/EasyPost/Service/ParcelService.php
+++ b/lib/EasyPost/Service/ParcelService.php
@@ -13,7 +13,7 @@ class ParcelService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -24,7 +24,7 @@ class ParcelService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         if (!isset($params['parcel']) || !is_array($params['parcel'])) {
             $clone = $params;

--- a/lib/EasyPost/Service/PickupService.php
+++ b/lib/EasyPost/Service/PickupService.php
@@ -16,7 +16,7 @@ class PickupService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -27,7 +27,7 @@ class PickupService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function all($params = null)
+    public function all(mixed $params = null): mixed
     {
         return self::allResources(self::serviceModelClassName(self::class), $params);
     }
@@ -36,10 +36,10 @@ class PickupService extends BaseService
      * Retrieve the next page of Pickup collection
      *
      * @param mixed $pickups
-     * @param string $pageSize
+     * @param int|null $pageSize
      * @return mixed
      */
-    public function getNextPage($pickups, $pageSize = null)
+    public function getNextPage(mixed $pickups, ?int $pageSize = null): mixed
     {
         return $this->getNextPageResources(self::serviceModelClassName(self::class), $pickups, $pageSize);
     }
@@ -50,7 +50,7 @@ class PickupService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         if (!isset($params['pickup']) || !is_array($params['pickup'])) {
             $clone = $params;
@@ -68,7 +68,7 @@ class PickupService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function buy($id, $params = null)
+    public function buy(string $id, mixed $params = null): mixed
     {
         $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/buy';
         $response = Requestor::request($this->client, 'post', $url, $params);
@@ -83,7 +83,7 @@ class PickupService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function cancel($id, $params = null)
+    public function cancel(string $id, mixed $params = null): mixed
     {
         $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/cancel';
         $response = Requestor::request($this->client, 'post', $url, $params);

--- a/lib/EasyPost/Service/RateService.php
+++ b/lib/EasyPost/Service/RateService.php
@@ -13,7 +13,7 @@ class RateService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }

--- a/lib/EasyPost/Service/ReferralCustomerService.php
+++ b/lib/EasyPost/Service/ReferralCustomerService.php
@@ -22,7 +22,7 @@ class ReferralCustomerService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function all($params = null)
+    public function all(mixed $params = null): mixed
     {
         return self::allResources(self::serviceModelClassName(self::class), $params);
     }
@@ -31,10 +31,10 @@ class ReferralCustomerService extends BaseService
      * Retrieve the next page of Referral collection
      *
      * @param mixed $referrals
-     * @param string $pageSize
+     * @param int|null $pageSize
      * @return mixed
      */
-    public function getNextPage($referrals, $pageSize = null)
+    public function getNextPage(mixed $referrals, ?int $pageSize = null): mixed
     {
         return $this->getNextPageResources(self::serviceModelClassName(self::class), $referrals, $pageSize);
     }
@@ -45,7 +45,7 @@ class ReferralCustomerService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         if (!isset($params['user']) || !is_array($params['user'])) {
             $clone = $params;
@@ -63,7 +63,7 @@ class ReferralCustomerService extends BaseService
      * @param string $userId
      * @return void
      */
-    public function updateEmail($email, $userId)
+    public function updateEmail(string $email, string $userId): void
     {
         // TODO: Swap the order of these params so ID comes first to match all other functions
         // this will be a breaking change and must be done when the next major release happens
@@ -91,13 +91,13 @@ class ReferralCustomerService extends BaseService
      * @throws ExternalApiException
      */
     public function addCreditCard(
-        $referralApiKey,
-        $number,
-        $expirationMonth,
-        $expirationYear,
-        $cvc,
-        $priority = 'primary'
-    ) {
+        string $referralApiKey,
+        string $number,
+        int $expirationMonth,
+        int $expirationYear,
+        string $cvc,
+        string $priority = 'primary'
+    ): mixed {
         $easypostStripeApiKey = self::retrieveEasypostStripeApiKey();
 
         try {
@@ -124,7 +124,7 @@ class ReferralCustomerService extends BaseService
      *
      * @return string
      */
-    private function retrieveEasypostStripeApiKey()
+    private function retrieveEasypostStripeApiKey(): string
     {
         $response = Requestor::request($this->client, 'get', '/partners/stripe_public_key');
 
@@ -143,8 +143,13 @@ class ReferralCustomerService extends BaseService
      * @throws HttpException
      * @throws TimeoutException
      */
-    private function createStripeToken($number, $expirationMonth, $expirationYear, $cvc, $easypostStripeKey)
-    {
+    private function createStripeToken(
+        string $number,
+        int $expirationMonth,
+        int $expirationYear,
+        string $cvc,
+        string $easypostStripeKey
+    ): mixed {
         $headers = [
             'Content-Type' => 'application/x-www-form-urlencoded',
             'Authorization' => "Bearer $easypostStripeKey",
@@ -194,8 +199,11 @@ class ReferralCustomerService extends BaseService
      * @param string @priority
      * @return mixed
      */
-    private function createEasypostCreditCard($referralApiKey, $stripeObjectId, $priority = 'primary')
-    {
+    private function createEasypostCreditCard(
+        string $referralApiKey,
+        string $stripeObjectId,
+        string $priority = 'primary'
+    ): mixed {
         $params = [
             'credit_card' => [
                 'stripe_object_id' => $stripeObjectId,

--- a/lib/EasyPost/Service/RefundService.php
+++ b/lib/EasyPost/Service/RefundService.php
@@ -13,7 +13,7 @@ class RefundService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -24,7 +24,7 @@ class RefundService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function all($params = null)
+    public function all(mixed $params = null): mixed
     {
         return self::allResources(self::serviceModelClassName(self::class), $params);
     }
@@ -33,10 +33,10 @@ class RefundService extends BaseService
      * Retrieve the next page of Refund collection
      *
      * @param mixed $refunds
-     * @param string $pageSize
+     * @param ?int $pageSize
      * @return mixed
      */
-    public function getNextPage($refunds, $pageSize = null)
+    public function getNextPage(mixed $refunds, ?int $pageSize = null): mixed
     {
         return $this->getNextPageResources(self::serviceModelClassName(self::class), $refunds, $pageSize);
     }
@@ -47,7 +47,7 @@ class RefundService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         if (!isset($params['refund']) || !is_array($params['refund'])) {
             $clone = $params;

--- a/lib/EasyPost/Service/ReportService.php
+++ b/lib/EasyPost/Service/ReportService.php
@@ -19,7 +19,7 @@ class ReportService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -31,7 +31,7 @@ class ReportService extends BaseService
      * @return mixed
      * @throws MissingParameterException
      */
-    public function all($params = null)
+    public function all(mixed $params = null): mixed
     {
         if (!isset($params) || !isset($params['type'])) {
             throw new MissingParameterException(Constants::MISSING_PARAMETER_ERROR);
@@ -51,10 +51,10 @@ class ReportService extends BaseService
      * Retrieve the next page of Report collection
      *
      * @param mixed $reports
-     * @param string $pageSize
+     * @param int|null $pageSize
      * @return mixed
      */
-    public function getNextPage($reports, $pageSize = null)
+    public function getNextPage(mixed $reports, ?int $pageSize = null): mixed
     {
         $reportArray = $reports['reports'];
         $userParams = $reports['_params'] ?? null;
@@ -93,7 +93,7 @@ class ReportService extends BaseService
      * @return mixed
      * @throws MissingParameterException
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         if (!isset($params['type'])) {
             throw new MissingParameterException(Constants::MISSING_PARAMETER_ERROR);
@@ -112,7 +112,7 @@ class ReportService extends BaseService
      * @param string $type
      * @return mixed
      */
-    private function reportUrl($type)
+    private function reportUrl(string $type): mixed
     {
         // Strip namespace if present
         if ($postfix = strrchr($type, '\\')) {

--- a/lib/EasyPost/Service/ScanFormService.php
+++ b/lib/EasyPost/Service/ScanFormService.php
@@ -13,7 +13,7 @@ class ScanFormService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -24,7 +24,7 @@ class ScanFormService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function all($params = null)
+    public function all(mixed $params = null): mixed
     {
         return self::allResources(self::serviceModelClassName(self::class), $params);
     }
@@ -33,10 +33,10 @@ class ScanFormService extends BaseService
      * Retrieve the next page of ScanForm collection
      *
      * @param mixed $scanforms
-     * @param string $pageSize
+     * @param int|null $pageSize
      * @return mixed
      */
-    public function getNextPage($scanforms, $pageSize = null)
+    public function getNextPage(mixed $scanforms, ?int $pageSize = null): mixed
     {
         return $this->getNextPageResources(self::serviceModelClassName(self::class), $scanforms, $pageSize);
     }
@@ -47,7 +47,7 @@ class ScanFormService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         return self::createResource(self::serviceModelClassName(self::class), $params);
     }

--- a/lib/EasyPost/Service/ShipmentService.php
+++ b/lib/EasyPost/Service/ShipmentService.php
@@ -3,6 +3,7 @@
 namespace EasyPost\Service;
 
 use EasyPost\Http\Requestor;
+use EasyPost\Rate;
 use EasyPost\Util\InternalUtil;
 use EasyPost\Util\Util;
 
@@ -17,7 +18,7 @@ class ShipmentService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -28,7 +29,7 @@ class ShipmentService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function all($params = null)
+    public function all(mixed $params = null): mixed
     {
         return self::allResources(self::serviceModelClassName(self::class), $params);
     }
@@ -37,10 +38,10 @@ class ShipmentService extends BaseService
      * Retrieve the next page of Shipment collection
      *
      * @param mixed $shipments
-     * @param string $pageSize
+     * @param int|null $pageSize
      * @return mixed
      */
-    public function getNextPage($shipments, $pageSize = null)
+    public function getNextPage(mixed $shipments, ?int $pageSize = null): mixed
     {
         return $this->getNextPageResources(self::serviceModelClassName(self::class), $shipments, $pageSize);
     }
@@ -51,7 +52,7 @@ class ShipmentService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         if (!isset($params['shipment']) || !is_array($params['shipment'])) {
             $clone = $params;
@@ -69,7 +70,7 @@ class ShipmentService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function regenerateRates($id, $params = null)
+    public function regenerateRates(string $id, mixed $params = null): mixed
     {
         $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/rerate';
         $response = Requestor::request($this->client, 'post', $url, $params);
@@ -83,7 +84,7 @@ class ShipmentService extends BaseService
      * @param string $id
      * @return array
      */
-    public function getSmartRates($id)
+    public function getSmartRates(string $id): array
     {
         $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/smartrate';
         $response = Requestor::request($this->client, 'get', $url);
@@ -98,10 +99,10 @@ class ShipmentService extends BaseService
      *
      * @param string $id
      * @param mixed $params
-     * @param string $endShipperId
+     * @param string|bool $endShipperId
      * @return mixed
      */
-    public function buy($id, $params = null, $endShipperId = false)
+    public function buy(string $id, mixed $params = null, string|bool $endShipperId = false)
     {
         if (isset($params['id']) && (!isset($params['rate']) || !is_array($params['rate']))) {
             $clone = $params;
@@ -127,7 +128,7 @@ class ShipmentService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function refund($id, $params = null)
+    public function refund(string $id, mixed $params = null): mixed
     {
         $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/refund';
         $response = Requestor::request($this->client, 'post', $url, $params);
@@ -142,7 +143,7 @@ class ShipmentService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function label($id, $params = null)
+    public function label(string $id, mixed $params = null): mixed
     {
         if (!isset($params['file_format'])) {
             $clone = $params;
@@ -163,7 +164,7 @@ class ShipmentService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function insure($id, $params = null)
+    public function insure(string $id, mixed $params = null): mixed
     {
         if (!isset($params['amount'])) {
             $clone = $params;
@@ -185,7 +186,7 @@ class ShipmentService extends BaseService
      * @param mixed $formOptions
      * @return mixed
      */
-    public function generateForm($id, $formType, $formOptions = null)
+    public function generateForm(string $id, string $formType, mixed $formOptions = null): mixed
     {
         $url = $this->instanceUrl(self::serviceModelClassName(self::class), $id) . '/forms';
         $formOptions['type'] = $formType;
@@ -207,7 +208,7 @@ class ShipmentService extends BaseService
      * @param string $deliveryAccuracy
      * @return Rate
      */
-    public function lowestSmartRate($id, $deliveryDays, $deliveryAccuracy)
+    public function lowestSmartRate(string $id, int $deliveryDays, string $deliveryAccuracy): Rate
     {
         $smartRates = self::getSmartRates($id);
         $lowestRate = Util::getLowestSmartRate($smartRates, $deliveryDays, strtolower($deliveryAccuracy));
@@ -222,7 +223,7 @@ class ShipmentService extends BaseService
      * @param string $plannedShipDate
      * @return mixed
      */
-    public function retrieveEstimatedDeliveryDate($id, $plannedShipDate)
+    public function retrieveEstimatedDeliveryDate(string $id, string $plannedShipDate): mixed
     {
         $params = [
             'planned_ship_date' => $plannedShipDate,

--- a/lib/EasyPost/Service/TrackerService.php
+++ b/lib/EasyPost/Service/TrackerService.php
@@ -16,7 +16,7 @@ class TrackerService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -27,7 +27,7 @@ class TrackerService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function all($params = null)
+    public function all(mixed $params = null): mixed
     {
         return self::allResources(self::serviceModelClassName(self::class), $params);
     }
@@ -36,10 +36,10 @@ class TrackerService extends BaseService
      * Retrieve the next page of Tracker collection
      *
      * @param mixed $trackers
-     * @param string $pageSize
+     * @param int|null $pageSize
      * @return mixed
      */
-    public function getNextPage($trackers, $pageSize = null)
+    public function getNextPage(mixed $trackers, ?int $pageSize = null): mixed
     {
         return $this->getNextPageResources(self::serviceModelClassName(self::class), $trackers, $pageSize);
     }
@@ -50,7 +50,7 @@ class TrackerService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         if (!is_array($params)) {
             $clone = $params;
@@ -71,7 +71,7 @@ class TrackerService extends BaseService
      * @param mixed $params
      * @return void
      */
-    public function createList($params = null)
+    public function createList(mixed $params = null): void
     {
         if (!isset($params['trackers']) || !is_array($params['trackers'])) {
             $clone = $params;

--- a/lib/EasyPost/Service/UserService.php
+++ b/lib/EasyPost/Service/UserService.php
@@ -16,7 +16,7 @@ class UserService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -24,9 +24,11 @@ class UserService extends BaseService
     /**
      * Update a user.
      *
+     * @param string $id
+     * @param mixed $params
      * @return mixed
      */
-    public function update($id, $params)
+    public function update(string $id, mixed $params): mixed
     {
         if (!isset($params['user']) || !is_array($params['user'])) {
             $clone = $params;
@@ -43,7 +45,7 @@ class UserService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         if (!isset($params['user']) || !is_array($params['user'])) {
             $clone = $params;
@@ -59,7 +61,7 @@ class UserService extends BaseService
      *
      * @return mixed
      */
-    public function retrieveMe()
+    public function retrieveMe(): mixed
     {
         return self::allResources(self::serviceModelClassName(self::class));
     }
@@ -71,7 +73,7 @@ class UserService extends BaseService
      * @param mixed @params
      * @return mixed
      */
-    public function delete($id, $params = null)
+    public function delete(string $id, mixed $params = null): mixed
     {
         return $this->deleteResource(self::serviceModelClassName(self::class), $id, $params);
     }
@@ -83,7 +85,7 @@ class UserService extends BaseService
      *
      * @return mixed
      */
-    public function allApiKeys()
+    public function allApiKeys(): mixed
     {
         $response = Requestor::request($this->client, 'get', '/api_keys');
 
@@ -98,7 +100,7 @@ class UserService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function apiKeys($id)
+    public function apiKeys(string $id): mixed
     {
         $apiKeys = self::allApiKeys();
 
@@ -126,7 +128,7 @@ class UserService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function updateBrand($id, $params = null)
+    public function updateBrand(string $id, mixed $params = null): mixed
     {
         $response = Requestor::request(
             $this->client,

--- a/lib/EasyPost/Service/WebhookService.php
+++ b/lib/EasyPost/Service/WebhookService.php
@@ -13,7 +13,7 @@ class WebhookService extends BaseService
      * @param string $id
      * @return mixed
      */
-    public function retrieve($id)
+    public function retrieve(string $id): mixed
     {
         return self::retrieveResource(self::serviceModelClassName(self::class), $id);
     }
@@ -24,7 +24,7 @@ class WebhookService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function all($params = null)
+    public function all(mixed $params = null): mixed
     {
         return self::allResources(self::serviceModelClassName(self::class), $params);
     }
@@ -36,7 +36,7 @@ class WebhookService extends BaseService
      * @param mixed $params
      * @return void
      */
-    public function delete($id, $params = null)
+    public function delete(string $id, mixed $params = null): void
     {
         self::deleteResource(self::serviceModelClassName(self::class), $id, $params);
     }
@@ -48,7 +48,7 @@ class WebhookService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function update($id, $params = null)
+    public function update(string $id, mixed $params = null): mixed
     {
         if (!isset($params['webhook']) || !is_array($params['webhook'])) {
             $clone = $params;
@@ -65,7 +65,7 @@ class WebhookService extends BaseService
      * @param mixed $params
      * @return mixed
      */
-    public function create($params = null)
+    public function create(mixed $params = null): mixed
     {
         if (!isset($params['webhook']) || !is_array($params['webhook'])) {
             $clone = $params;

--- a/lib/EasyPost/Shipment.php
+++ b/lib/EasyPost/Shipment.php
@@ -44,11 +44,11 @@ class Shipment extends EasyPostObject
      *
      * To exclude a carrier or service, prepend the string with `!`.
      *
-     * @param array $carriers
-     * @param array $services
+     * @param array|null $carriers
+     * @param array|null $services
      * @return Rate
      */
-    public function lowestRate($carriers = [], $services = [])
+    public function lowestRate(?array $carriers = [], ?array $services = []): Rate
     {
         $lowestRate = InternalUtil::getLowestObjectRate($this, $carriers, $services);
 

--- a/lib/EasyPost/Util/InternalUtil.php
+++ b/lib/EasyPost/Util/InternalUtil.php
@@ -11,6 +11,7 @@ use EasyPost\CarrierDetail;
 use EasyPost\Constant\Constants;
 use EasyPost\CustomsInfo;
 use EasyPost\CustomsItem;
+use EasyPost\EasyPostClient;
 use EasyPost\EasyPostObject;
 use EasyPost\EndShipper;
 use EasyPost\Event;
@@ -107,10 +108,10 @@ abstract class InternalUtil
      * PHP treats JSON objects (associative arrays) and lists (sequential arrays) as the
      * same thing (array), so one can use this function to determine what kind of array something is.
      *
-     * @param $array
+     * @param mixed $array
      * @return bool
      */
-    public static function isList($array)
+    public static function isList(mixed $array): bool
     {
         if (!is_array($array)) {
             return false;
@@ -128,11 +129,11 @@ abstract class InternalUtil
     /**
      * Convert input to an EasyPost object.
      *
-     * @param EasyPostClient $client
+     * @param EasyPostClient|null $client
      * @param mixed $response
      * @return mixed
      */
-    public static function convertToEasyPostObject($client, $response)
+    public static function convertToEasyPostObject(EasyPostClient|null $client, mixed $response): mixed
     {
         if (InternalUtil::isList($response)) {
             $mapped = [];
@@ -172,15 +173,19 @@ abstract class InternalUtil
      *
      * This internal utility is intended to be used by other EasyPost `lowest_rate` functions.
      *
-     * @param object EasyPostObject
+     * @param object EasyPostObject|null
      * @param array $carriers
      * @param array $services
-     * @param string $ratesKey
+     * @param string|null $ratesKey
      * @return Rate|PickupRate
      * @throws \EasyPost\Exception\EasyPostException
      */
-    public static function getLowestObjectRate($easypostObject, $carriers = [], $services = [], $ratesKey = 'rates')
-    {
+    public static function getLowestObjectRate(
+        EasyPostObject|null $easypostObject,
+        array $carriers = [],
+        array $services = [],
+        ?string $ratesKey = 'rates'
+    ): Rate|PickupRate {
         $lowestRate = false;
         $carriersInclude = [];
         $carriersExclude = [];

--- a/lib/EasyPost/Util/InternalUtil.php
+++ b/lib/EasyPost/Util/InternalUtil.php
@@ -176,7 +176,7 @@ abstract class InternalUtil
      * @param array $carriers
      * @param array $services
      * @param string $ratesKey
-     * @return Rate
+     * @return Rate|PickupRate
      * @throws \EasyPost\Exception\EasyPostException
      */
     public static function getLowestObjectRate($easypostObject, $carriers = [], $services = [], $ratesKey = 'rates')

--- a/lib/EasyPost/Util/Util.php
+++ b/lib/EasyPost/Util/Util.php
@@ -9,6 +9,7 @@ use EasyPost\Exception\General\FilteringException;
 use EasyPost\Exception\General\InvalidParameterException;
 use EasyPost\Exception\General\MissingParameterException;
 use EasyPost\Exception\General\SignatureVerificationException;
+use EasyPost\Rate;
 use Normalizer;
 
 abstract class Util
@@ -19,7 +20,7 @@ abstract class Util
      * @param mixed $values
      * @return array
      */
-    public static function convertEasyPostObjectToArray($values)
+    public static function convertEasyPostObjectToArray(mixed $values): array
     {
         $results = [];
         foreach ($values as $k => $value) {
@@ -46,7 +47,7 @@ abstract class Util
      * @return Rate
      * @throws EasyPostException
      */
-    public static function getLowestSmartRate($smartRates, $deliveryDays, $deliveryAccuracy)
+    public static function getLowestSmartRate(array $smartRates, int $deliveryDays, string $deliveryAccuracy): Rate
     {
         $validDeliveryAccuracyValues = [
             'percentile_50',
@@ -92,7 +93,7 @@ abstract class Util
      * @return mixed
      * @throws EasyPostException
      */
-    public static function validateWebhook($eventBody, $headers, $webhookSecret)
+    public static function validateWebhook(mixed $eventBody, mixed $headers, string $webhookSecret): mixed
     {
         $easypostHmacSignature = $headers['X-Hmac-Signature'] ?? null;
 
@@ -118,11 +119,11 @@ abstract class Util
     /**
      * Receive an event (convert JSON string to object).
      *
-     * @param string $rawInput
+     * @param string|null $rawInput
      * @return mixed
      * @throws EasyPostException
      */
-    public static function receiveEvent($rawInput = null)
+    public static function receiveEvent(?string $rawInput = null): mixed
     {
         if ($rawInput == null) {
             throw new MissingParameterException(sprintf(Constants::MISSING_PARAMETER_ERROR, 'rawInput'));
@@ -145,7 +146,7 @@ abstract class Util
      * @return Rate
      * @throws \EasyPost\Exception\EasyPostException
      */
-    public static function getLowestStatelessRate($statelessRates, $carriers = [], $services = [])
+    public static function getLowestStatelessRate(array $statelessRates, array $carriers = [], array $services = [])
     {
         $lowestStatelessRate = false;
         $carriersInclude = [];

--- a/test/EasyPost/EasyPostClientTest.php
+++ b/test/EasyPost/EasyPostClientTest.php
@@ -52,21 +52,6 @@ class EasyPostClientTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test setting and getting the API key for different EasyPostClients.
-     */
-    public function testNoApiKey()
-    {
-        try {
-            new EasyPostClient(null);
-        } catch (MissingParameterException $error) {
-            $this->assertEquals(
-                'No API key provided. See https://www.easypost.com/docs for details, or contact support@easypost.com for assistance.', // phpcs:ignore
-                $error->getMessage()
-            );
-        }
-    }
-
-    /**
      * Test invalid property (service) called on an EasyPostClient.
      */
     public function testInvalidServiceProperty()

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -59,7 +59,7 @@ VCRCleaner::enable([
  * @param mixed $data
  * @return mixed
  */
-function scrubCassette($data)
+function scrubCassette(mixed $data): mixed
 {
     if (isset($data)) {
         foreach (RESPONSE_BODY_SCRUBBERS as $scrubber) {


### PR DESCRIPTION
# Description

- Adds type hints now that we have dropped PHP 7.4
- Corrects docstring type hints to match
- Removes the API key check, now that there are type hints, the lib will throw an error at runtime if required params (like the API key) are not passed
- Corrected all magic method params to conform to what PHP expects

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Tests caught various items needed fixing. In PHP, if you don't pass params that match the definitions you'll get runtime errors. This will help us develop but also will help users know what to pass in. Re-ran all tests every few files I edited.

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
