### PR TITLE
fix: remove the incorrect inclusion of shipment prop on pickup model

### DIFF
--- a/lib/EasyPost/Pickup.php
+++ b/lib/EasyPost/Pickup.php
@@ -18,7 +18,6 @@ use EasyPost\Util\InternalUtil;
  * @property string $instructions
  * @property Message[] $messages
  * @property string $confirmation
- * @property Shipment $shipment
  * @property Address $address
  * @property CarrierAccount[] $carrier_accounts
  * @property PickupRate[] $pickup_rates


### PR DESCRIPTION
# Description

There is no `shipment` property of a `Pickup` object, remove it from the docstring
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
