### PR TITLE
[bug] Cannot determine payment method when funding/deleting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 
+- Fix payment method funding and deletion failures due to undetermined payment method type
 - Adds `refund` function in Insurance service for requesting a refund for a standalone insurance
 
 ## v7.1.0 (2024-01-08)

--- a/lib/EasyPost/Service/BillingService.php
+++ b/lib/EasyPost/Service/BillingService.php
@@ -82,9 +82,10 @@ class BillingService extends BaseService
 
         if ($paymentMethodToUse != null && $paymentMethods->$paymentMethodToUse->id != null) {
             $paymentMethodId = $paymentMethods->$paymentMethodToUse->id;
-            if (strpos($paymentMethodId, 'card_') === 0) {
+            $paymentMethodObjectType = $paymentMethods->$paymentMethodToUse->object;
+            if (str_starts_with($paymentMethodId, 'card_') || $paymentMethodObjectType == 'CreditCard') {
                 $endpoint = '/credit_cards';
-            } else if (strpos($paymentMethodId, 'bank_') === 0) {
+            } else if (str_starts_with($paymentMethodId, 'bank_') || $paymentMethodObjectType == 'BankAccount') {
                 $endpoint = '/bank_accounts';
             } else {
                 throw new PaymentException(Constants::INVALID_PAYMENT_METHOD_ERROR);

--- a/lib/EasyPost/Service/BillingService.php
+++ b/lib/EasyPost/Service/BillingService.php
@@ -83,9 +83,9 @@ class BillingService extends BaseService
         if ($paymentMethodToUse != null && $paymentMethods->$paymentMethodToUse->id != null) {
             $paymentMethodId = $paymentMethods->$paymentMethodToUse->id;
             $paymentMethodObjectType = $paymentMethods->$paymentMethodToUse->object;
-            if (str_starts_with($paymentMethodId, 'card_') || $paymentMethodObjectType == 'CreditCard') {
+            if ($paymentMethodObjectType == 'CreditCard') {
                 $endpoint = '/credit_cards';
-            } else if (str_starts_with($paymentMethodId, 'bank_') || $paymentMethodObjectType == 'BankAccount') {
+            } else if ($paymentMethodObjectType == 'BankAccount') {
                 $endpoint = '/bank_accounts';
             } else {
                 throw new PaymentException(Constants::INVALID_PAYMENT_METHOD_ERROR);

--- a/test/EasyPost/BillingTest.php
+++ b/test/EasyPost/BillingTest.php
@@ -313,45 +313,4 @@ class BillingTest extends \PHPUnit\Framework\TestCase
             $this->fail('Exception thrown when we expected no error');
         }
     }
-
-    /**
-     * Test determining the payment method type by legacy ID prefix
-     */
-    public function testGetPaymentMethodInfoByLegacyIdPrefix(): void
-    {
-        $mockingUtility = new MockingUtility(
-            new MockRequest(
-                new MockRequestMatchRule(
-                    'get',
-                    '/v2\\/payment_methods$/'
-                ),
-                new MockRequestResponseInfo(
-                    200,
-                    '{"id": "summary_123", "primary_payment_method": {"id": "card_123", "object": null, "last4": "1234"}, "secondary_payment_method": {"id": "bank_123", "object": null, "bank_name": "Mock Bank"}}' // phpcs:ignore
-                )
-            ),
-            new MockRequest(
-                new MockRequestMatchRule(
-                    'delete',
-                    '/v2\\/bank_accounts\\/bank_123$/'
-                ),
-                new MockRequestResponseInfo(
-                    200,
-                    '{}'
-                )
-            ),
-        );
-        $client = self::getClient($mockingUtility);
-
-        // getPaymentInfo is private, but we can test it by attempting to delete a payment method
-        // only a delete request to /v2/bank_accounts/bank_123 is mocked
-        // if the delete function works, it's because it found the correct payment method type
-        try {
-            $client->billing->deletePaymentMethod('secondary');
-
-            $this->assertTrue(true);
-        } catch (\Exception $exception) {
-            $this->fail('Exception thrown when we expected no error');
-        }
-    }
 }


### PR DESCRIPTION
# Description

- Use payment method object type as fallback when determining type for fund, delete functions

# Testing

- Update, add unit test to confirm legacy (by ID prefix) and new (by object type) both work to determine payment method type

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
