### PR TITLE
fix: prettyPrint errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Adds `custom_headers` property to webhook model
 - Corrects wrapping payload for update webhook endpoint
+- Fixes a bug where you could not `prettyPrint` an error if it used the alternative format
 - Removes the deprecated `create_list` tracker endpoint function as it is no longer available via API
 
 ## v7.4.2 (2024-08-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 - Adds `custom_headers` property to webhook model
 - Corrects wrapping payload for update webhook endpoint
-- Fixes a bug where you could not `prettyPrint` an error if it used the alternative format
+- Fixes error handling
+  - Corrects the type of `errors` property on an `ApiException` to allow for the alternative format
+  - Fixes a bug where you could not `prettyPrint` an error if it used the alternative format
+  - Corrects the `param` references to `property` references on all error models
+  - Adds new `AddressVerificationFieldError` for the `errors` property on a `Verification` model
+  - Adds missing `suggestion` property to `FieldError`
 - Removes the deprecated `create_list` tracker endpoint function as it is no longer available via API
 
 ## v7.4.2 (2024-08-16)

--- a/lib/EasyPost/AddressVerificationFieldError.php
+++ b/lib/EasyPost/AddressVerificationFieldError.php
@@ -4,10 +4,11 @@ namespace EasyPost;
 
 /**
  * @package EasyPost
- * @property string $field
  * @property string $message
+ * @property string $code
+ * @property string $field
  * @property string $suggestion
  */
-class FieldError extends EasyPostObject
+class AddressVerificationFieldError extends EasyPostObject
 {
 }

--- a/lib/EasyPost/Exception/Api/ApiException.php
+++ b/lib/EasyPost/Exception/Api/ApiException.php
@@ -85,7 +85,7 @@ class ApiException extends EasyPostException
     {
         print($this->code . ' (' . $this->getHttpStatus() . '): ' .
             $this->getMessage() . "\n");
-        if (!empty($this->errors)) {
+        if (!empty($this->errors) && is_array($this->errors[0])) {
             print("Field errors:\n");
             foreach ($this->errors as $fieldError) {
                 foreach ($fieldError as $k => $v) {

--- a/lib/EasyPost/Exception/Api/ApiException.php
+++ b/lib/EasyPost/Exception/Api/ApiException.php
@@ -9,7 +9,7 @@ use Exception;
 /**
  * @package EasyPost
  * @property string|null $code
- * @property FieldError[]|null $errors
+ * @property array<int, FieldError|array>|null $errors
  * @property string $message
  * @property string|null $httpBody
  * @property int|null $httpStatus

--- a/lib/EasyPost/Verification.php
+++ b/lib/EasyPost/Verification.php
@@ -4,9 +4,9 @@ namespace EasyPost;
 
 /**
  * @package EasyPost
- * @param bool $success
- * @param FieldError[] $errors
- * @param VerificationDetails $details
+ * @property bool $success
+ * @property AddressVerificationFieldError[] $errors
+ * @property VerificationDetails $details
  */
 class Verification extends EasyPostObject
 {

--- a/lib/EasyPost/VerificationDetails.php
+++ b/lib/EasyPost/VerificationDetails.php
@@ -4,9 +4,9 @@ namespace EasyPost;
 
 /**
  * @package EasyPost
- * @param int $latitude
- * @param int $longitude
- * @param string $time_zone
+ * @property int $latitude
+ * @property int $longitude
+ * @property string $time_zone
  */
 class VerificationDetails extends EasyPostObject
 {

--- a/lib/EasyPost/Verifications.php
+++ b/lib/EasyPost/Verifications.php
@@ -4,8 +4,8 @@ namespace EasyPost;
 
 /**
  * @package EasyPost
- * @param Verification $zip4
- * @param Verification $delivery
+ * @property Verification $delivery
+ * @property Verification $zip4
  */
 class Verifications extends EasyPostObject
 {

--- a/test/EasyPost/AddressTest.php
+++ b/test/EasyPost/AddressTest.php
@@ -65,8 +65,22 @@ class AddressTest extends \PHPUnit\Framework\TestCase
         $address = self::$client->address->create($addressData);
 
         $this->assertInstanceOf(Address::class, $address);
-        $this->assertNotNull($address->verifications->delivery); /* @phpstan-ignore-line */
-        $this->assertNotNull($address->verifications->zip4); /* @phpstan-ignore-line */
+
+        // Delivery verification assertions
+        $this->assertFalse($address->verifications->delivery->success);
+        $this->assertEmpty($address->verifications->delivery->details);
+        $this->assertEquals("E.ADDRESS.NOT_FOUND", $address->verifications->delivery->errors[0]->code);
+        $this->assertEquals("address", $address->verifications->delivery->errors[0]->field);
+        $this->assertNull($address->verifications->delivery->suggestion);
+        $this->assertEquals("Address not found", $address->verifications->delivery->errors[0]->message);
+
+        // Delivery verification assertions
+        $this->assertFalse($address->verifications->zip4->success);
+        $this->assertNull($address->verifications->zip4->details);
+        $this->assertEquals("E.ADDRESS.NOT_FOUND", $address->verifications->zip4->errors[0]->code);
+        $this->assertEquals("address", $address->verifications->zip4->errors[0]->field);
+        $this->assertNull($address->verifications->zip4->suggestion);
+        $this->assertEquals("Address not found", $address->verifications->zip4->errors[0]->message);
     }
 
     /**

--- a/test/EasyPost/AddressTest.php
+++ b/test/EasyPost/AddressTest.php
@@ -69,18 +69,18 @@ class AddressTest extends \PHPUnit\Framework\TestCase
         // Delivery verification assertions
         $this->assertFalse($address->verifications->delivery->success);
         $this->assertEmpty($address->verifications->delivery->details);
-        $this->assertEquals("E.ADDRESS.NOT_FOUND", $address->verifications->delivery->errors[0]->code);
-        $this->assertEquals("address", $address->verifications->delivery->errors[0]->field);
-        $this->assertNull($address->verifications->delivery->suggestion);
-        $this->assertEquals("Address not found", $address->verifications->delivery->errors[0]->message);
+        $this->assertEquals('E.ADDRESS.NOT_FOUND', $address->verifications->delivery->errors[0]->code);
+        $this->assertEquals('address', $address->verifications->delivery->errors[0]->field);
+        $this->assertNull($address->verifications->delivery->errors[0]->suggestion);
+        $this->assertEquals('Address not found', $address->verifications->delivery->errors[0]->message);
 
         // Delivery verification assertions
         $this->assertFalse($address->verifications->zip4->success);
         $this->assertNull($address->verifications->zip4->details);
-        $this->assertEquals("E.ADDRESS.NOT_FOUND", $address->verifications->zip4->errors[0]->code);
-        $this->assertEquals("address", $address->verifications->zip4->errors[0]->field);
-        $this->assertNull($address->verifications->zip4->suggestion);
-        $this->assertEquals("Address not found", $address->verifications->zip4->errors[0]->message);
+        $this->assertEquals('E.ADDRESS.NOT_FOUND', $address->verifications->zip4->errors[0]->code);
+        $this->assertEquals('address', $address->verifications->zip4->errors[0]->field);
+        $this->assertNull($address->verifications->zip4->errors[0]->suggestion);
+        $this->assertEquals('Address not found', $address->verifications->zip4->errors[0]->message);
     }
 
     /**
@@ -122,8 +122,8 @@ class AddressTest extends \PHPUnit\Framework\TestCase
         $address = self::$client->address->create($addressData);
 
         $this->assertInstanceOf(Address::class, $address);
-        $this->assertNotNull($address->verifications->delivery); /* @phpstan-ignore-line */
-        $this->assertNotNull($address->verifications->zip4); /* @phpstan-ignore-line */
+        $this->assertNotNull($address->verifications->delivery);
+        $this->assertNotNull($address->verifications->zip4);
     }
 
     /**

--- a/test/EasyPost/ErrorTest.php
+++ b/test/EasyPost/ErrorTest.php
@@ -58,6 +58,34 @@ Field errors:
     }
 
     /**
+     * Tests that we assign properties of an error correctly when returned via the alternative format.
+     * NOTE: Claims (among other things) uses the alternative errors format.
+     */
+    public function testErrorAlternativeFormat(): void
+    {
+        TestUtil::setupCassette('errors/errorsAlternativeFormat.yml');
+
+        try {
+            $claimData = Fixture::basicClaimData();
+            $claimData['tracking_code'] = '123';  // Intentionally pass a bad tracking code
+
+            self::$client->claim->create($claimData);
+        } catch (ApiException $error) {
+            $this->assertEquals(404, $error->getHttpStatus());
+            $this->assertEquals('NOT_FOUND', $error->code);
+            $this->assertEquals('The requested resource could not be found.', $error->getMessage());
+            $this->assertEquals('No eligible insurance found with provided tracking code.', $error->errors[0]);
+            $this->assertEquals('{"error":{"code":"NOT_FOUND","errors":["No eligible insurance found with provided tracking code."],"message":"The requested resource could not be found."}}', $error->getHttpBody()); // phpcs:ignore
+
+            // We check that the pretty printed output is the same here, leave the odd formatting as
+            // it is here and do not auto-format the next few lines.
+            $error->prettyPrint();
+            $this->expectOutputString('NOT_FOUND (404): The requested resource could not be found.
+');
+        }
+    }
+
+    /**
      * Test error deserialization with an array of error.message
      */
     public function testErrorMessageArray(): void

--- a/test/cassettes/errors/errorsAlternativeFormat.yml
+++ b/test/cassettes/errors/errorsAlternativeFormat.yml
@@ -1,0 +1,78 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.easypost.com/v2/claims'
+        headers:
+            Host: api.easypost.com
+            Expect: ''
+            Accept-Encoding: ''
+            Accept: application/json
+            Authorization: ''
+            Content-Type: application/json
+            User-Agent: ''
+        body: '{"type":"damage","email_evidence_attachments":["data:image\/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8\/\/8\/AwAI\/AL+4Q7AIAAAAABJRU5ErkJggg=="],"invoice_attachments":["data:image\/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8\/\/8\/AwAI\/AL+4Q7AIAAAAABJRU5ErkJggg=="],"supporting_documentation_attachments":["data:image\/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8\/\/8\/AwAI\/AL+4Q7AIAAAAABJRU5ErkJggg=="],"description":"Test description","contact_email":"test@example.com","tracking_code":"123"}'
+    response:
+        status:
+            code: 404
+            message: 'Not Found'
+        headers:
+            x-frame-options: SAMEORIGIN
+            x-xss-protection: '1; mode=block'
+            x-content-type-options: nosniff
+            x-download-options: noopen
+            x-permitted-cross-domain-policies: none
+            referrer-policy: strict-origin-when-cross-origin
+            x-ep-request-uuid: 764a527867b8f50be2b9fad700359f02
+            cache-control: 'private, no-cache, no-store'
+            pragma: no-cache
+            expires: '0'
+            content-type: 'application/json; charset=utf-8'
+            content-length: '156'
+            x-runtime: '0.028895'
+            x-node: bigweb58nuq
+            x-version-label: easypost-202502212131-cc7bde76a5-master
+            x-backend: easypost
+            x-proxied: ['intlb4nuq 51d74985a2', 'extlb1nuq 99aac35317']
+            strict-transport-security: 'max-age=31536000; includeSubDomains; preload'
+        body: '{"error":{"code":"NOT_FOUND","errors":["No eligible insurance found with provided tracking code."],"message":"The requested resource could not be found."}}'
+        curl_info:
+            url: 'https://api.easypost.com/v2/claims'
+            content_type: 'application/json; charset=utf-8'
+            http_code: 404
+            header_size: 695
+            request_size: 886
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.140263
+            namelookup_time: 0.002094
+            connect_time: 0.03625
+            pretransfer_time: 0.07411
+            size_upload: 581.0
+            size_download: 156.0
+            speed_download: 1112.0
+            speed_upload: 4142.0
+            download_content_length: 156.0
+            upload_content_length: 581.0
+            starttransfer_time: 0.140219
+            redirect_time: 0.0
+            redirect_url: ''
+            primary_ip: 169.62.110.131
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.75
+            local_port: 54059
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: https
+            appconnect_time_us: 74056
+            connect_time_us: 36250
+            namelookup_time_us: 2094
+            pretransfer_time_us: 74110
+            redirect_time_us: 0
+            starttransfer_time_us: 140219
+            total_time_us: 140263
+            effective_method: POST
+    index: 0


### PR DESCRIPTION
# Description

- Fixes error handling
  - Corrects the type of `errors` property on an `ApiException` to allow for the alternative format
  - Fixes a bug where you could not `prettyPrint` an error if it used the alternative format
  - Corrects the `param` references to `property` references on all error models
  - Adds new `AddressVerificationFieldError` for the `errors` property on a `Verification` model
  - Adds missing `suggestion` property to `FieldError`

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- Adds alternative error format test
- Adds address verification error test

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
