### PR TITLE
Breaking changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: set up PHP
-        uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
       - name: install dependencies
@@ -23,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        phpversion: ['8.0', '8.1', '8.2', '8.3']
+        # TODO: Add 8.4 when VCR releases a version compatible with it
+        phpversion: ['8.1', '8.2', '8.3']
     steps:
       - uses: actions/checkout@v4
-      - name: set up PHP
-        uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.phpversion }}
           coverage: xdebug
@@ -53,10 +52,8 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
       - name: Install Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Drops support for PHP 8.0
 - Adds `custom_headers` property to webhook model
 - Corrects wrapping payload for update webhook endpoint
+- Corrects various type hints throughout project
 - Fixes error handling
   - Corrects the type of `errors` property on an `ApiException` to allow for the alternative format
   - Fixes a bug where you could not `prettyPrint` an error if it used the alternative format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 
+- Drops support for PHP 8.0
 - Adds `custom_headers` property to webhook model
 - Corrects wrapping payload for update webhook endpoint
 - Fixes error handling
@@ -11,6 +12,7 @@
   - Adds new `AddressVerificationFieldError` for the `errors` property on a `Verification` model
   - Adds missing `suggestion` property to `FieldError`
 - Removes the deprecated `create_list` tracker endpoint function as it is no longer available via API
+- Bump deps
 
 ## v7.4.2 (2024-08-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
   - Corrects the `param` references to `property` references on all error models
   - Adds new `AddressVerificationFieldError` for the `errors` property on a `Verification` model
   - Adds missing `suggestion` property to `FieldError`
-- Removes the deprecated `create_list` tracker endpoint function as it is no longer available via API
+- Removes deprecated `createList` tracker endpoint function as it is no longer available via API
+- Removes deprecated `user.allApiKeys` and `user.apiKeys`, use `apiKey.all` and `apiKey.retrieveApiKeysForUser` respectively
 - Bump deps
 
 ## v7.4.2 (2024-08-16)

--- a/composer.json
+++ b/composer.json
@@ -19,18 +19,18 @@
   ],
   "require": {
     "ext-json": "*",
-    "php": ">=8.0",
-    "guzzlehttp/guzzle": "^7.5"
+    "php": ">=8.1",
+    "guzzlehttp/guzzle": "^7.9"
   },
   "require-dev": {
-    "allejo/php-vcr-sanitizer": "^1.0.9",
-    "php-coveralls/php-coveralls": "^2.5",
-    "php-vcr/php-vcr": "^1.7",
-    "phpunit/phpunit": "^9",
-    "squizlabs/php_codesniffer": "^3.7",
+    "allejo/php-vcr-sanitizer": "^1.1",
+    "php-coveralls/php-coveralls": "^2.7",
+    "php-vcr/php-vcr": "^1.8",
+    "phpunit/phpunit": "^10",
+    "squizlabs/php_codesniffer": "^3.11",
     "roave/security-advisories": "dev-latest",
     "rregeer/phpunit-coverage-check": "^0.3.1",
-    "phpstan/phpstan": "^1.11"
+    "phpstan/phpstan": "^1.12"
   },
   "scripts": {
     "coverage": "XDEBUG_MODE=coverage ./bin/phpunit --coverage-html clover.html --coverage-clover build/logs/clover.xml && ./bin/coverage-check build/logs/clover.xml 85 --only-percentage",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "squizlabs/php_codesniffer": "^3.11",
     "roave/security-advisories": "dev-latest",
     "rregeer/phpunit-coverage-check": "^0.3.1",
-    "phpstan/phpstan": "^1.12"
+    "phpstan/phpstan": "^2.1"
   },
   "scripts": {
     "coverage": "XDEBUG_MODE=coverage ./bin/phpunit --coverage-html clover.html --coverage-clover build/logs/clover.xml && ./bin/coverage-check build/logs/clover.xml 85 --only-percentage",

--- a/lib/EasyPost/Batch.php
+++ b/lib/EasyPost/Batch.php
@@ -10,7 +10,7 @@ namespace EasyPost;
  * @property string $mode
  * @property string $state
  * @property int $num_shipments
- * @property array $shipments
+ * @property Shipment[] $shipments
  * @property object $status
  * @property string $label_url
  * @property ScanForm $scan_form

--- a/lib/EasyPost/EasyPostObject.php
+++ b/lib/EasyPost/EasyPostObject.php
@@ -241,7 +241,7 @@ class EasyPostObject implements \ArrayAccess, \Iterator
     public function valid(): bool
     {
         $key = key($this->_values);
-        return ($key !== null && $key !== false);
+        return $key !== null;
     }
 
     /**

--- a/lib/EasyPost/Event.php
+++ b/lib/EasyPost/Event.php
@@ -11,8 +11,8 @@ namespace EasyPost;
  * @property object $previous_attributes
  * @property object $result
  * @property string $status
- * @property array $pending_urls
- * @property array $completed_urls
+ * @property array<string> $pending_urls
+ * @property array<string> $completed_urls
  * @property string $created_at
  * @property string $updated_at
  */

--- a/lib/EasyPost/Exception/Api/ApiException.php
+++ b/lib/EasyPost/Exception/Api/ApiException.php
@@ -9,7 +9,7 @@ use Exception;
 /**
  * @package EasyPost
  * @property string|null $code
- * @property array<int, FieldError|array>|null $errors
+ * @property array<FieldError|array<string>>|null $errors
  * @property string $message
  * @property string|null $httpBody
  * @property int|null $httpStatus

--- a/lib/EasyPost/Http/Requestor.php
+++ b/lib/EasyPost/Http/Requestor.php
@@ -264,7 +264,7 @@ class Requestor
      */
     public static function handleApiError(?string $httpBody, int $httpStatus, array $response): void
     {
-        if (!is_array($response) || !isset($response['error'])) {
+        if (!isset($response['error'])) {
             throw new JsonException(
                 "Invalid response object from API: HTTP Status: ({$httpStatus}) {$httpBody})",
                 $httpStatus,

--- a/lib/EasyPost/Insurance.php
+++ b/lib/EasyPost/Insurance.php
@@ -18,7 +18,7 @@ namespace EasyPost;
  * @property Address $to_address
  * @property Address $from_address
  * @property Fee $fee
- * @property array $messages
+ * @property array<string> $messages
  * @property string $created_at
  * @property string $updated_at
  */

--- a/lib/EasyPost/Order.php
+++ b/lib/EasyPost/Order.php
@@ -15,7 +15,7 @@ use EasyPost\Util\InternalUtil;
  * @property Address $return_address
  * @property Address $buyer_address
  * @property Shipment[] $shipments
- * @property Rates[] $rates
+ * @property Rate[] $rates
  * @property Message[] $messages
  * @property bool $is_return
  * @property string $created_at

--- a/lib/EasyPost/ScanForm.php
+++ b/lib/EasyPost/ScanForm.php
@@ -9,7 +9,7 @@ namespace EasyPost;
  * @property string $status
  * @property string $message
  * @property Address $address
- * @property array $tracking_codes
+ * @property array<string> $tracking_codes
  * @property string $form_url
  * @property string $form_file_type
  * @property string $batch_id

--- a/lib/EasyPost/Service/UserService.php
+++ b/lib/EasyPost/Service/UserService.php
@@ -80,49 +80,6 @@ class UserService extends BaseService
     }
 
     /**
-     * Retrieve a list of all API keys.
-     *
-     * @deprecated Use all() under the api_key service instead.
-     *
-     * @return mixed
-     */
-    public function allApiKeys(): mixed
-    {
-        $response = Requestor::request($this->client, 'get', '/api_keys');
-
-        return InternalUtil::convertToEasyPostObject($this->client, $response);
-    }
-
-    /**
-     * Retrieve a list of API keys (works for the authenticated user or a child user).
-     *
-     * @deprecated Use retrieve_api_key_for_user() under the api_key service instead.
-     *
-     * @param string $id
-     * @return mixed
-     */
-    public function apiKeys(string $id): mixed
-    {
-        $apiKeys = self::allApiKeys();
-
-        if ($apiKeys->id == $id) {
-            // This function was called on the authenticated user
-            $myApiKeys = $apiKeys->keys;
-        } else {
-            // This function was called on a child user, authenticated as parent, only return this child user's details
-            $myApiKeys = [];
-            foreach ($apiKeys->children as $childrenKeys) {
-                if ($childrenKeys->id == $id) {
-                    $myApiKeys = $childrenKeys->keys;
-                    break;
-                }
-            }
-        }
-
-        return $myApiKeys;
-    }
-
-    /**
      * Update the User's Brand object.
      *
      * @param string $id

--- a/lib/EasyPost/Shipment.php
+++ b/lib/EasyPost/Shipment.php
@@ -17,7 +17,7 @@ use EasyPost\Util\InternalUtil;
  * @property Parcel $parcel
  * @property CustomsInfo $customs_info
  * @property ScanForm $scan_form
- * @property array $forms
+ * @property array<object> $forms
  * @property Insurance $insurance
  * @property Rate[] $rates
  * @property Rate $selected_rate

--- a/lib/EasyPost/Util/InternalUtil.php
+++ b/lib/EasyPost/Util/InternalUtil.php
@@ -196,9 +196,6 @@ abstract class InternalUtil
         $servicesInclude = [];
         $servicesExclude = [];
 
-        if (!is_array($carriers)) {
-            $carriers = explode(',', $carriers);
-        }
         for ($i = 0; $i < count($carriers); $i++) {
             $carriers[$i] = trim(strtolower($carriers[$i]));
             if (substr($carriers[$i], 0, 1) == '!') {
@@ -208,9 +205,6 @@ abstract class InternalUtil
             }
         }
 
-        if (!is_array($services)) {
-            $services = explode(',', $services);
-        }
         for ($i = 0; $i < count($services); $i++) {
             $services[$i] = trim(strtolower($services[$i]));
             if (substr($services[$i], 0, 1) == '!') {

--- a/lib/EasyPost/Util/Util.php
+++ b/lib/EasyPost/Util/Util.php
@@ -155,9 +155,6 @@ abstract class Util
         $servicesInclude = [];
         $servicesExclude = [];
 
-        if (!is_array($carriers)) {
-            $carriers = explode(',', $carriers);
-        }
         for ($i = 0; $i < count($carriers); $i++) {
             $carriers[$i] = trim(strtolower($carriers[$i]));
             if (substr($carriers[$i], 0, 1) == '!') {
@@ -167,9 +164,6 @@ abstract class Util
             }
         }
 
-        if (!is_array($services)) {
-            $services = explode(',', $services);
-        }
         for ($i = 0; $i < count($services); $i++) {
             $services[$i] = trim(strtolower($services[$i]));
             if (substr($services[$i], 0, 1) == '!') {

--- a/lib/EasyPost/Webhook.php
+++ b/lib/EasyPost/Webhook.php
@@ -9,7 +9,7 @@ namespace EasyPost;
  * @property string $modoe
  * @property string $url
  * @property string $disabled_at
- * @property array $custom_headers
+ * @property array<object> $custom_headers
  */
 class Webhook extends EasyPostObject
 {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,4 @@ parameters:
     paths:
         - lib
         - test
+    treatPhpDocTypesAsCertain: false

--- a/test/EasyPost/AddressTest.php
+++ b/test/EasyPost/AddressTest.php
@@ -178,7 +178,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
             $this->assertNotEquals($firstIdOfFirstPage, $secondIdOfSecondPage);
         } catch (EndOfPaginationException $error) {
             // There's no second page, that's not a failure
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (Exception $error) {
             throw $error;
         }

--- a/test/EasyPost/BillingTest.php
+++ b/test/EasyPost/BillingTest.php
@@ -98,7 +98,7 @@ class BillingTest extends \PHPUnit\Framework\TestCase
         try {
             self::$client->billing->fundWallet('2000', 'primary');
 
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (\Exception $exception) {
             $this->fail('Exception thrown when we expected no error');
         }
@@ -112,7 +112,7 @@ class BillingTest extends \PHPUnit\Framework\TestCase
         try {
             self::$client->billing->fundWallet('2000');
 
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (\Exception $exception) {
             $this->fail('Exception thrown when we expected no error');
         }
@@ -154,7 +154,7 @@ class BillingTest extends \PHPUnit\Framework\TestCase
 
             $this->fail('Exception not thrown when we expected one');
         } catch (\Exception $exception) {
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         }
     }
 
@@ -166,7 +166,7 @@ class BillingTest extends \PHPUnit\Framework\TestCase
         try {
             self::$client->billing->deletePaymentMethod('primary');
 
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (\Exception $exception) {
             $this->fail('Exception thrown when we expected no error');
         }
@@ -185,7 +185,7 @@ class BillingTest extends \PHPUnit\Framework\TestCase
         try {
             self::$client->billing->deletePaymentMethod('primary');
 
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (\Exception $exception) {
             $this->fail('Exception thrown when we expected no error');
         }
@@ -194,7 +194,7 @@ class BillingTest extends \PHPUnit\Framework\TestCase
         try {
             self::$client->billing->deletePaymentMethod('secondary');
 
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (\Exception $exception) {
             $this->fail('Exception thrown when we expected no error');
         }
@@ -205,7 +205,7 @@ class BillingTest extends \PHPUnit\Framework\TestCase
 
             $this->fail('Exception not thrown when we expected one');
         } catch (\Exception $exception) {
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         }
     }
 
@@ -237,7 +237,7 @@ class BillingTest extends \PHPUnit\Framework\TestCase
 
             $this->fail('Exception not thrown when we expected one');
         } catch (\Exception $exception) {
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         }
     }
 
@@ -269,7 +269,7 @@ class BillingTest extends \PHPUnit\Framework\TestCase
 
             $this->fail('Exception not thrown when we expected one');
         } catch (\Exception $exception) {
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         }
     }
 
@@ -308,7 +308,7 @@ class BillingTest extends \PHPUnit\Framework\TestCase
         try {
             $client->billing->deletePaymentMethod('primary');
 
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (\Exception $exception) {
             $this->fail('Exception thrown when we expected no error');
         }

--- a/test/EasyPost/CarrierAccountTest.php
+++ b/test/EasyPost/CarrierAccountTest.php
@@ -221,7 +221,7 @@ class CarrierAccountTest extends \PHPUnit\Framework\TestCase
 
         try {
             self::$client->carrierAccount->delete($carrierAccount->id);
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (\Exception $exception) {
             $this->fail('Exception thrown when we expected no error');
         }

--- a/test/EasyPost/ClaimTest.php
+++ b/test/EasyPost/ClaimTest.php
@@ -28,20 +28,20 @@ class ClaimTest extends \PHPUnit\Framework\TestCase
         TestUtil::teardownVcrTests();
     }
 
-/**
- * Helper method to create and purchase an insured shipment.
- *
- * @param string $amount The amount of insurance for the shipment.
- * @return \EasyPost\Shipment The purchased shipment object.
- */
+    /**
+     * Helper method to create and purchase an insured shipment.
+     *
+     * @param string $amount The amount of insurance for the shipment.
+     * @return \EasyPost\Shipment The purchased shipment object.
+     */
     private static function createAndBuyShipment(string $amount): \EasyPost\Shipment
     {
         $shipment = self::$client->shipment->create(Fixture::fullShipment());
         return self::$client->shipment->buy(
             $shipment->id,
             [
-            'rate' => $shipment->lowestRate(),
-            'insurance' => $amount,
+                'rate' => $shipment->lowestRate(),
+                'insurance' => $amount,
             ]
         );
     }
@@ -125,7 +125,7 @@ class ClaimTest extends \PHPUnit\Framework\TestCase
             $this->assertNotNull($nextPage['_params']);
         } catch (EndOfPaginationException $error) {
             // There's no second page, that's not a failure
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (Exception $error) {
             throw $error;
         }

--- a/test/EasyPost/EventTest.php
+++ b/test/EasyPost/EventTest.php
@@ -69,7 +69,7 @@ class EventTest extends \PHPUnit\Framework\TestCase
             $this->assertNotEquals($firstIdOfFirstPage, $secondIdOfSecondPage);
         } catch (EndOfPaginationException $error) {
             // There's no second page, that's not a failure
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (Exception $error) {
             throw $error;
         }

--- a/test/EasyPost/HookTest.php
+++ b/test/EasyPost/HookTest.php
@@ -101,5 +101,7 @@ class HookTest extends \PHPUnit\Framework\TestCase
         self::$client->unsubscribeFromResponseHook([$this, 'failIfSubscribed']);
 
         self::$client->parcel->create(Fixture::basicParcel());
+
+        $this->expectNotToPerformAssertions();
     }
 }

--- a/test/EasyPost/InsuranceTest.php
+++ b/test/EasyPost/InsuranceTest.php
@@ -104,7 +104,7 @@ class InsuranceTest extends \PHPUnit\Framework\TestCase
             $this->assertNotNull($nextPage['_params']);
         } catch (EndOfPaginationException $error) {
             // There's no second page, that's not a failure
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (Exception $error) {
             throw $error;
         }

--- a/test/EasyPost/PickupTest.php
+++ b/test/EasyPost/PickupTest.php
@@ -104,7 +104,7 @@ class PickupTest extends \PHPUnit\Framework\TestCase
             $this->assertNotEquals($firstIdOfFirstPage, $secondIdOfSecondPage);
         } catch (EndOfPaginationException $error) {
             // There's no second page, that's not a failure
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (Exception $error) {
             throw $error;
         }

--- a/test/EasyPost/ReferralCustomerTest.php
+++ b/test/EasyPost/ReferralCustomerTest.php
@@ -88,7 +88,7 @@ class ReferralCustomerTest extends \PHPUnit\Framework\TestCase
             $this->assertNotEquals($firstIdOfFirstPage, $secondIdOfSecondPage);
         } catch (EndOfPaginationException $error) {
             // There's no second page, that's not a failure
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (Exception $error) {
             throw $error;
         }
@@ -108,7 +108,7 @@ class ReferralCustomerTest extends \PHPUnit\Framework\TestCase
                 $referralUsers['referral_customers'][0]['id'],
                 'email@example.com',
             );
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (\Exception $exception) {
             $this->fail('Exception thrown when we expected no error');
         }

--- a/test/EasyPost/RefundTest.php
+++ b/test/EasyPost/RefundTest.php
@@ -85,7 +85,7 @@ class RefundTest extends \PHPUnit\Framework\TestCase
             $this->assertNotEquals($firstIdOfFirstPage, $secondIdOfSecondPage);
         } catch (EndOfPaginationException $error) {
             // There's no second page, that's not a failure
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (Exception $error) {
             throw $error;
         }

--- a/test/EasyPost/ReportTest.php
+++ b/test/EasyPost/ReportTest.php
@@ -145,7 +145,7 @@ class ReportTest extends \PHPUnit\Framework\TestCase
             $this->assertNotEquals($firstIdOfFirstPage, $secondIdOfSecondPage);
         } catch (EndOfPaginationException $error) {
             // There's no second page, that's not a failure
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (Exception $error) {
             throw $error;
         }

--- a/test/EasyPost/ScanFormTest.php
+++ b/test/EasyPost/ScanFormTest.php
@@ -101,7 +101,7 @@ class ScanFormTest extends \PHPUnit\Framework\TestCase
             $this->assertNotEquals($firstIdOfFirstPage, $secondIdOfSecondPage);
         } catch (EndOfPaginationException $error) {
             // There's no second page, that's not a failure
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (Exception $error) {
             throw $error;
         }

--- a/test/EasyPost/ShipmentTest.php
+++ b/test/EasyPost/ShipmentTest.php
@@ -102,7 +102,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
             $this->assertNotNull($nextPage['_params']);
         } catch (EndOfPaginationException $error) {
             // There's no second page, that's not a failure
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (Exception $error) {
             throw $error;
         }

--- a/test/EasyPost/TrackerTest.php
+++ b/test/EasyPost/TrackerTest.php
@@ -114,7 +114,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
             $this->assertNotEquals($firstIdOfFirstPage, $secondIdOfSecondPage);
         } catch (EndOfPaginationException $error) {
             // There's no second page, that's not a failure
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (Exception $error) {
             throw $error;
         }

--- a/test/EasyPost/UserTest.php
+++ b/test/EasyPost/UserTest.php
@@ -114,7 +114,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
             $this->assertNotEquals($firstIdOfFirstPage, $secondIdOfSecondPage);
         } catch (EndOfPaginationException $error) {
             // There's no second page, that's not a failure
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (Exception $error) {
             /** @noinspection PhpExceptionImmediatelyRethrownInspection */
             throw $error;
@@ -154,7 +154,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
 
         try {
             self::$client->user->delete($user->id);
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (\Exception $exception) {
             $this->fail('Exception thrown when we expected no error');
         }

--- a/test/EasyPost/WebhookTest.php
+++ b/test/EasyPost/WebhookTest.php
@@ -128,7 +128,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
 
         try {
             self::$client->webhook->delete($webhook->id);
-            $this->assertTrue(true);
+            $this->expectNotToPerformAssertions();
         } catch (\Exception $exception) {
             $this->fail('Exception thrown when we expected no error');
         }


### PR DESCRIPTION
# Description

- Drops support for PHP 8.0
- Fixes various type hints and checks after bumping phpstan to v2
- Removes deprecated `user.allApiKeys` and `user.apiKeys`, use `apiKey.all` and `apiKey.retrieveApiKeysForUser` respectively
- Bumps deps

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
