### PR TITLE
Update `.gitattributes` to exclude development files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,15 @@ test/cassettes/**/* linguist-generated
 # Docs
 docs/**/* -diff
 docs/**/* linguist-generated
+
+# Exclude repository development files from `prefer-dist` installs
+/.gitattributes    export-ignore
+/.github           export-ignore
+/.gitignore        export-ignore
+/.gitmodules       export-ignore
+/UPGRADE_GUIDE.md  export-ignore
+/examples          export-ignore
+/justfile          export-ignore
+/phpstan.neon      export-ignore
+/phpunit.xml.dist  export-ignore
+/test              export-ignore


### PR DESCRIPTION
Exclude specific development files from prefer-dist installs.

# Description

Many of the files included in `composer install easypost/easypost-php` are only relevant to the project's own development, not the use of the package.

<img width="297" height="415" alt="Screenshot 2026-05-13 at 10 30 31 PM" src="https://github.com/user-attachments/assets/01429ab8-7f84-45cd-bb55-92a72d01f0cc" />

This PR updates [`.gitattributes`](https://git-scm.com/docs/gitattributes) to exclude unnecessary files. 

Composer's `--prefer-source` option (and equivalent `composer.json` config) can be used to pull in the entire repository as necessary. 

# Testing

Not applicable.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
