### PR TITLE
Replace extractions/setup-just with EasyPost/ep-actions setup/just action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.5'
@@ -26,7 +26,7 @@ jobs:
         phpversion: ['8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.phpversion }}
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.5'


### PR DESCRIPTION
## What

Replaces the unverified third-party action `extractions/setup-just` with the internal composite action [`EasyPost/ep-actions/.github/actions/setup/just@main`](https://github.com/EasyPost/ep-actions/tree/main/.github/actions/setup/just).

## Why

`extractions/setup-just` is a third-party action from an unverified publisher and is **not** on the approved list in `EasyPost/ep-actions/ApprovedThirdPartyActions.yaml`. Using the internal composite action keeps CI on a vetted, EasyPost-owned action.

## Notes

- The ep-actions `setup/just` action installs Just on Linux runners; all affected jobs in this repo run on `ubuntu-latest`.
- The `just-version` input is supported by the ep-actions action where it was previously set.