### PR TITLE
feat: add params to requestPin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v8.8.0 (2026-06-25)
+
+- Adds `params` to `requestPin` ensuring users can pass `easypost_details` to the call.
+
 ## v8.7.0 (2026-02-25)
 
 - Adds generic `makeApiCall` function

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "easypost/easypost-php",
   "description": "EasyPost Shipping API Client Library for PHP",
-  "version": "8.7.0",
+  "version": "8.8.0",
   "keywords": [
     "shipping",
     "api",

--- a/lib/EasyPost/Constant/Constants.php
+++ b/lib/EasyPost/Constant/Constants.php
@@ -11,7 +11,7 @@ abstract class Constants
     const BETA_API_VERSION = 'beta';
 
     // Library constants
-    const LIBRARY_VERSION = '8.7.0';
+    const LIBRARY_VERSION = '8.8.0';
     const SUPPORT_EMAIL = 'support@easypost.com';
 
     // Validation

--- a/lib/EasyPost/Service/FedExRegistrationService.php
+++ b/lib/EasyPost/Service/FedExRegistrationService.php
@@ -33,14 +33,14 @@ class FedExRegistrationService extends BaseService
      *
      * @param string $fedexAccountNumber
      * @param string $pinMethodOption
+     * @param mixed $params
      * @return mixed
      */
-    public function requestPin(string $fedexAccountNumber, string $pinMethodOption): mixed
+    public function requestPin(string $fedexAccountNumber, string $pinMethodOption, mixed $params = null): mixed
     {
-        $wrappedParams = [
-            'pin_method' => [
-                'option' => $pinMethodOption,
-            ],
+        $wrappedParams = $this->wrapPinValidation($params);
+        $wrappedParams['pin_method'] = [
+            'option' => $pinMethodOption,
         ];
         $url = "/fedex_registrations/{$fedexAccountNumber}/pin";
 

--- a/test/EasyPost/FedExRegistrationTest.php
+++ b/test/EasyPost/FedExRegistrationTest.php
@@ -112,8 +112,16 @@ class FedExRegistrationTest extends TestCase
     public function testRequestPin(): void
     {
         $fedexAccountNumber = '123456789';
+        $params = [
+            'pin_method' => [
+                'option' => 'SMS',
+            ],
+            'easypost_details' => [
+                'carrier_account_id' => 'ca_123',
+            ],
+        ];
 
-        $response = self::$client->fedexRegistration->requestPin($fedexAccountNumber, 'SMS');
+        $response = self::$client->fedexRegistration->requestPin($fedexAccountNumber, 'SMS', $params);
 
         $this->assertInstanceOf(EasyPostObject::class, $response);
         $this->assertEquals('sent secured Pin', $response->message); // @phpstan-ignore-line

--- a/test/EasyPost/FedExRegistrationTest.php
+++ b/test/EasyPost/FedExRegistrationTest.php
@@ -113,9 +113,6 @@ class FedExRegistrationTest extends TestCase
     {
         $fedexAccountNumber = '123456789';
         $params = [
-            'pin_method' => [
-                'option' => 'SMS',
-            ],
             'easypost_details' => [
                 'carrier_account_id' => 'ca_123',
             ],


### PR DESCRIPTION
# Description

Adds `params` to `requestPin` ensuring users can pass `easypost_details` to the call.

# Testing

Updated test to accept new param.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)